### PR TITLE
feat(server): Redis integration for hot positions + pub/sub fan-out

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ DATABASE_URL=postgres://manhunt:change-me@db:5432/manhunt
 # Apply DB migrations automatically on server boot (otherwise run `npm run db:migrate`)
 RUN_MIGRATIONS=true
 
-# Redis
+# Redis — hot live positions + cross-instance pub/sub fan-out.
+# Optional in dev: unset, the server uses an in-process fallback (single instance).
 REDIS_URL=redis://redis:6379
 
 # Sessions / auth

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ POSTGRES_PASSWORD=change-me
 POSTGRES_DB=manhunt
 DATABASE_URL=postgres://manhunt:change-me@db:5432/manhunt
 # Apply DB migrations automatically on server boot (otherwise run `npm run db:migrate`)
-RUN_MIGRATIONS=false
+RUN_MIGRATIONS=true
 
 # Redis
 REDIS_URL=redis://redis:6379

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,30 +13,30 @@ Priorities: 🔴 high · 🟡 med · ⚪ low.
 
 ## M2 — Core game loop
 
-1. 🔴 **Lobby** — create/join room by code, role assignment, ready-up, start. *(area: client, server)*
-2. 🔴 **WebSocket contract** — `join`, `position_update`, `claim_catch`, `game_state`, `catch_confirmed`, `lobby_update`. *(area: server)*
-3. 🔴 **Client GPS capture** — `watchPosition`, throttle to 5–10s cadence, Screen Wake Lock. *(area: client)*
-4. 🔴 **Map rendering** — MapLibre GL map with player pins and boundary overlay. *(area: client)*
-5. 🔴 **Authoritative tick engine** — validate inbound positions, write to Redis. *(area: server)*
-6. 🟡 **Boundary enforcement** — geofence checks; warn or eliminate on exit. *(area: server)*
-7. 🔴 **Catch detection + role switch** — server-side distance check, convert caught hider to hunter. *(area: server)*
-8. 🟡 **Ping-reveal scheduler** — periodically force hider positions into the broadcast. *(area: server)*
-9. 🔴 **Per-role state filtering** — hunters never receive hider coordinates except on ping reveal. *(area: server)*
-10. 🟡 **Win conditions + end screen** — last hider / survive-the-timer, produce summary. *(area: server)*
+6. 🔴 **Lobby** — create/join room by code, role assignment, ready-up, start. *(area: client, server)*
+7. 🔴 **WebSocket contract** — `join`, `position_update`, `claim_catch`, `game_state`, `catch_confirmed`, `lobby_update`. *(area: server)*
+8. 🔴 **Client GPS capture** — `watchPosition`, throttle to 5–10s cadence, Screen Wake Lock. *(area: client)*
+9. 🔴 **Map rendering** — MapLibre GL map with player pins and boundary overlay. *(area: client)*
+10. 🔴 **Authoritative tick engine** — validate inbound positions, write to Redis. *(area: server)*
+11. 🟡 **Boundary enforcement** — geofence checks; warn or eliminate on exit. *(area: server)*
+12. 🔴 **Catch detection + role switch** — server-side distance check, convert caught hider to hunter. *(area: server)*
+13. 🟡 **Ping-reveal scheduler** — periodically force hider positions into the broadcast. *(area: server)*
+14. 🔴 **Per-role state filtering** — hunters never receive hider coordinates except on ping reveal. *(area: server)*
+15. 🟡 **Win conditions + end screen** — last hider / survive-the-timer, produce summary. *(area: server)*
 
 ## M2 — Client screens (from the mockup)
 
- 1. 🟡 **Join screen** — enter room code, create/join. *(area: client)*
- 2. 🟡 **Lobby screen** — hunters/hiders list, room code chip, ready. *(area: client)*
- 3. 🔴 **In-game map screen** — hunter + hider views, proximity alerts, timer, reveal countdown. *(area: client)*
- 4. 🟡 **Game over screen** — survival time, catches, replay/rematch actions. *(area: client)*
+16. 🟡 **Join screen** — enter room code, create/join. *(area: client)*
+17. 🟡 **Lobby screen** — hunters/hiders list, room code chip, ready. *(area: client)*
+18. 🔴 **In-game map screen** — hunter + hider views, proximity alerts, timer, reveal countdown. *(area: client)*
+19. 🟡 **Game over screen** — survival time, catches, replay/rematch actions. *(area: client)*
 
 ## M3 — Auth, PWA & polish
 
- 1. 🔴 **Account auth + sessions** — sign-in, sessions, root bootstrap. *(area: server)*
- 2. 🟡 **PWA install** — manifest + service worker, installable, offline shell. *(area: client)*
- 3. 🟡 **Web Push notifications** — event pushes (caught, reveal, time). *(area: client, server)*
- 4. 🟡 **Reconnect handling** — socket auto-reconnect, last-known position on signal loss. *(area: client, server)*
- 5. ⚪ **Replay** — animate movement from position history. *(area: client, server)*
- 6. ⚪ **Anti-cheat** — implausible-speed / teleport detection at the input layer. *(area: server)*
- 7. 🟡 **Configurable game settings** — catch radius, ping interval, boundary, duration. *(area: client, server)*
+20. 🔴 **Account auth + sessions** — sign-in, sessions, root bootstrap. *(area: server)*
+22. 🟡 **PWA install** — manifest + service worker, installable, offline shell. *(area: client)*
+23. 🟡 **Web Push notifications** — event pushes (caught, reveal, time). *(area: client, server)*
+24. 🟡 **Reconnect handling** — socket auto-reconnect, last-known position on signal loss. *(area: client, server)*
+25. ⚪ **Replay** — animate movement from position history. *(area: client, server)*
+26. ⚪ **Anti-cheat** — implausible-speed / teleport detection at the input layer. *(area: server)*
+27. 🟡 **Configurable game settings** — catch radius, ping interval, boundary, duration. *(area: client, server)*

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,30 +13,30 @@ Priorities: 🔴 high · 🟡 med · ⚪ low.
 
 ## M2 — Core game loop
 
-6. 🔴 **Lobby** — create/join room by code, role assignment, ready-up, start. *(area: client, server)*
-7. 🔴 **WebSocket contract** — `join`, `position_update`, `claim_catch`, `game_state`, `catch_confirmed`, `lobby_update`. *(area: server)*
-8. 🔴 **Client GPS capture** — `watchPosition`, throttle to 5–10s cadence, Screen Wake Lock. *(area: client)*
-9. 🔴 **Map rendering** — MapLibre GL map with player pins and boundary overlay. *(area: client)*
-10. 🔴 **Authoritative tick engine** — validate inbound positions, write to Redis. *(area: server)*
-11. 🟡 **Boundary enforcement** — geofence checks; warn or eliminate on exit. *(area: server)*
-12. 🔴 **Catch detection + role switch** — server-side distance check, convert caught hider to hunter. *(area: server)*
-13. 🟡 **Ping-reveal scheduler** — periodically force hider positions into the broadcast. *(area: server)*
-14. 🔴 **Per-role state filtering** — hunters never receive hider coordinates except on ping reveal. *(area: server)*
-15. 🟡 **Win conditions + end screen** — last hider / survive-the-timer, produce summary. *(area: server)*
+1. 🔴 **Lobby** — create/join room by code, role assignment, ready-up, start. *(area: client, server)*
+2. 🔴 **WebSocket contract** — `join`, `position_update`, `claim_catch`, `game_state`, `catch_confirmed`, `lobby_update`. *(area: server)*
+3. 🔴 **Client GPS capture** — `watchPosition`, throttle to 5–10s cadence, Screen Wake Lock. *(area: client)*
+4. 🔴 **Map rendering** — MapLibre GL map with player pins and boundary overlay. *(area: client)*
+5. 🔴 **Authoritative tick engine** — validate inbound positions, write to Redis. *(area: server)*
+6. 🟡 **Boundary enforcement** — geofence checks; warn or eliminate on exit. *(area: server)*
+7. 🔴 **Catch detection + role switch** — server-side distance check, convert caught hider to hunter. *(area: server)*
+8. 🟡 **Ping-reveal scheduler** — periodically force hider positions into the broadcast. *(area: server)*
+9. 🔴 **Per-role state filtering** — hunters never receive hider coordinates except on ping reveal. *(area: server)*
+10. 🟡 **Win conditions + end screen** — last hider / survive-the-timer, produce summary. *(area: server)*
 
 ## M2 — Client screens (from the mockup)
 
-16. 🟡 **Join screen** — enter room code, create/join. *(area: client)*
-17. 🟡 **Lobby screen** — hunters/hiders list, room code chip, ready. *(area: client)*
-18. 🔴 **In-game map screen** — hunter + hider views, proximity alerts, timer, reveal countdown. *(area: client)*
-19. 🟡 **Game over screen** — survival time, catches, replay/rematch actions. *(area: client)*
+ 1. 🟡 **Join screen** — enter room code, create/join. *(area: client)*
+ 2. 🟡 **Lobby screen** — hunters/hiders list, room code chip, ready. *(area: client)*
+ 3. 🔴 **In-game map screen** — hunter + hider views, proximity alerts, timer, reveal countdown. *(area: client)*
+ 4. 🟡 **Game over screen** — survival time, catches, replay/rematch actions. *(area: client)*
 
 ## M3 — Auth, PWA & polish
 
-20. 🔴 **Account auth + sessions** — sign-in, sessions, root bootstrap. *(area: server)*
-22. 🟡 **PWA install** — manifest + service worker, installable, offline shell. *(area: client)*
-23. 🟡 **Web Push notifications** — event pushes (caught, reveal, time). *(area: client, server)*
-24. 🟡 **Reconnect handling** — socket auto-reconnect, last-known position on signal loss. *(area: client, server)*
-25. ⚪ **Replay** — animate movement from position history. *(area: client, server)*
-26. ⚪ **Anti-cheat** — implausible-speed / teleport detection at the input layer. *(area: server)*
-27. 🟡 **Configurable game settings** — catch radius, ping interval, boundary, duration. *(area: client, server)*
+ 1. 🔴 **Account auth + sessions** — sign-in, sessions, root bootstrap. *(area: server)*
+ 2. 🟡 **PWA install** — manifest + service worker, installable, offline shell. *(area: client)*
+ 3. 🟡 **Web Push notifications** — event pushes (caught, reveal, time). *(area: client, server)*
+ 4. 🟡 **Reconnect handling** — socket auto-reconnect, last-known position on signal loss. *(area: client, server)*
+ 5. ⚪ **Replay** — animate movement from position history. *(area: client, server)*
+ 6. ⚪ **Anti-cheat** — implausible-speed / teleport detection at the input layer. *(area: server)*
+ 7. 🟡 **Configurable game settings** — catch radius, ping interval, boundary, duration. *(area: client, server)*

--- a/README.md
+++ b/README.md
@@ -129,9 +129,15 @@ once merged) and updating the snapshot to match.
 
 Hot, ephemeral state — every player's latest position — lives in **Redis**, and
 the **broadcaster** fans out `game_state` between server instances over Redis
-pub/sub (see [`docs/arc42.md`](./docs/arc42.md) §5.2, ADR-004). On each tick the
-server writes the reported position to a per-game Redis hash and publishes the
-game's positions to every instance, which emit it to their connected sockets.
+pub/sub (see [`docs/arc42.md`](./docs/arc42.md) §5.2, ADR-004). A socket first
+`join`s with its identity (`gameId`, `playerId`, `role`); that identity is bound
+server-side, so a `position_update` carries only coordinates and can only write
+its own player — a client can't spoof another. On each tick the server writes
+the reported position to a per-game Redis hash and publishes the game's positions
+to every instance, which emit `game_state` to their connected sockets **filtered
+per recipient's role** — hunters never receive hider coordinates (the scheduled
+reveal is part of the rules engine, [BACKLOG.md](./BACKLOG.md) #14). Updates
+arriving faster than the tick cadence are dropped.
 
 Point the server at Redis with `REDIS_URL` (see [`.env.example`](./.env.example);
 `docker compose up` provides one). Redis is **optional in development**: with no

--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ no build step. Type-check the server and client with `npm run typecheck`.
 Evolve the schema by adding a new `NNNN_name.sql` migration (files are immutable
 once merged) and updating the snapshot to match.
 
+### Live state (Redis)
+
+Hot, ephemeral state — every player's latest position — lives in **Redis**, and
+the **broadcaster** fans out `game_state` between server instances over Redis
+pub/sub (see [`docs/arc42.md`](./docs/arc42.md) §5.2, ADR-004). On each tick the
+server writes the reported position to a per-game Redis hash and publishes the
+game's positions to every instance, which emit it to their connected sockets.
+
+Point the server at Redis with `REDIS_URL` (see [`.env.example`](./.env.example);
+`docker compose up` provides one). Redis is **optional in development**: with no
+`REDIS_URL` the server falls back to an in-process store and loopback
+broadcaster, so a single instance (and CI, which has no Redis service) runs
+fully — you only need Redis to share hot state across multiple instances.
+
 ## Quickstart (Docker)
 
 ```bash

--- a/client/e2e/live.spec.ts
+++ b/client/e2e/live.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { io, type Socket } from 'socket.io-client';
+
+// The Playwright webServer boots the real production server (server/index.ts).
+// Without REDIS_URL it runs the in-process live-state fallback, so this
+// exercises the full position tick → game_state fan-out against the real
+// server the same way a client would, no Redis service required.
+const PORT = process.env.E2E_PORT || 3000;
+const url = `http://127.0.0.1:${PORT}`;
+
+interface GameState {
+  gameId: string;
+  positions: Record<string, { lat: number; lng: number; recordedAt: string }>;
+}
+
+function waitFor<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+test('fans out a position update to other players in the game over the socket', async () => {
+  const hunter = io(url, { transports: ['websocket'], reconnection: false });
+  const hider = io(url, { transports: ['websocket'], reconnection: false });
+
+  try {
+    await Promise.all([waitFor(hunter, 'connect'), waitFor(hider, 'connect')]);
+
+    const ack = (await hunter.emitWithAck('join', { gameId: 'e2e-game' })) as { ok: boolean };
+    expect(ack.ok).toBe(true);
+
+    const received = waitFor<GameState>(hunter, 'game_state');
+    hider.emit('position_update', {
+      gameId: 'e2e-game',
+      playerId: 'runner',
+      lat: 52.1,
+      lng: 4.3,
+    });
+
+    const state = await received;
+    expect(state.gameId).toBe('e2e-game');
+    expect(state.positions.runner).toMatchObject({ lat: 52.1, lng: 4.3 });
+  } finally {
+    hunter.close();
+    hider.close();
+  }
+});

--- a/client/e2e/live.spec.ts
+++ b/client/e2e/live.spec.ts
@@ -18,28 +18,30 @@ function waitFor<T>(socket: Socket, event: string): Promise<T> {
 }
 
 test('fans out a position update to other players in the game over the socket', async () => {
-  const hunter = io(url, { transports: ['websocket'], reconnection: false });
-  const hider = io(url, { transports: ['websocket'], reconnection: false });
+  const watcher = io(url, { transports: ['websocket'], reconnection: false });
+  const runner = io(url, { transports: ['websocket'], reconnection: false });
 
   try {
-    await Promise.all([waitFor(hunter, 'connect'), waitFor(hider, 'connect')]);
+    await Promise.all([waitFor(watcher, 'connect'), waitFor(runner, 'connect')]);
 
-    const ack = (await hunter.emitWithAck('join', { gameId: 'e2e-game' })) as { ok: boolean };
-    expect(ack.ok).toBe(true);
-
-    const received = waitFor<GameState>(hunter, 'game_state');
-    hider.emit('position_update', {
+    // Both players join with their identity; position updates then trust the
+    // socket's bound identity, not the payload.
+    const ack = (await watcher.emitWithAck('join', {
       gameId: 'e2e-game',
-      playerId: 'runner',
-      lat: 52.1,
-      lng: 4.3,
-    });
+      playerId: 'watcher',
+      role: 'hider',
+    })) as { ok: boolean };
+    expect(ack.ok).toBe(true);
+    await runner.emitWithAck('join', { gameId: 'e2e-game', playerId: 'runner', role: 'hider' });
+
+    const received = waitFor<GameState>(watcher, 'game_state');
+    runner.emit('position_update', { lat: 52.1, lng: 4.3 });
 
     const state = await received;
     expect(state.gameId).toBe('e2e-game');
     expect(state.positions.runner).toMatchObject({ lat: 52.1, lng: 4.3 });
   } finally {
-    hunter.close();
-    hider.close();
+    watcher.close();
+    runner.close();
   }
 });

--- a/server/app.live.test.ts
+++ b/server/app.live.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { once } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import { createServer, type ServerHandle } from './app.ts';
+import {
+  createLocalBroadcaster,
+  createMemoryPositionStore,
+  type GameStateMessage,
+} from './live/index.ts';
+
+/** Boot the real server on an ephemeral port with an in-memory live state. */
+async function bootServer(): Promise<{ handle: ServerHandle; url: string }> {
+  const handle = createServer({
+    staticDir: path.join(os.tmpdir(), 'nope'),
+    liveState: {
+      store: createMemoryPositionStore(),
+      broadcaster: createLocalBroadcaster(),
+      close: () => Promise.resolve(),
+    },
+  });
+  handle.httpServer.listen(0);
+  await once(handle.httpServer, 'listening'); // node EventEmitter — safe
+  const { port } = handle.httpServer.address() as AddressInfo;
+  return { handle, url: `http://127.0.0.1:${port}` };
+}
+
+function connect(url: string): Socket {
+  return ioClient(url, { transports: ['websocket'], reconnection: false });
+}
+
+/** Await a socket.io-client event (its Emitter isn't a node EventEmitter). */
+function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+describe('live position tick over the socket', () => {
+  let handle: ServerHandle;
+  const clients: Socket[] = [];
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    handle.io.close();
+    handle.httpServer.close();
+    await once(handle.httpServer, 'close');
+    await handle.liveState.close();
+  });
+
+  it('writes a position and fans out game_state to everyone in the game', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+
+    const hunter = connect(booted.url);
+    const hider = connect(booted.url);
+    clients.push(hunter, hider);
+    await Promise.all([waitFor(hunter, 'connect'), waitFor(hider, 'connect')]);
+
+    // The hunter joins the game room and awaits the ack.
+    const ack = (await hunter.emitWithAck('join', { gameId: 'g1' })) as { ok: boolean };
+    expect(ack).toEqual({ ok: true });
+
+    // The hider reports a position; the hunter should receive the fan-out.
+    const received = waitFor<GameStateMessage>(hunter, 'game_state');
+    hider.emit('position_update', { gameId: 'g1', playerId: 'hider-1', lat: 52.37, lng: 4.9 });
+
+    const state = await received;
+    expect(state.gameId).toBe('g1');
+    expect(state.positions['hider-1']).toMatchObject({ lat: 52.37, lng: 4.9 });
+    expect(typeof state.positions['hider-1']?.recordedAt).toBe('string');
+  });
+
+  it('ignores malformed position updates', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+
+    const client = connect(booted.url);
+    clients.push(client);
+    await waitFor(client, 'connect');
+    await client.emitWithAck('join', { gameId: 'g2' });
+
+    let got = false;
+    client.on('game_state', () => {
+      got = true;
+    });
+    // Missing playerId / non-numeric coords — dropped, no broadcast.
+    client.emit('position_update', { gameId: 'g2', lat: 'nope' });
+    client.emit('position_update', { playerId: 'x', lat: 1, lng: 2 });
+
+    // Give the server a moment; nothing should have been emitted.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(got).toBe(false);
+  });
+});

--- a/server/app.live.test.ts
+++ b/server/app.live.test.ts
@@ -48,7 +48,38 @@ describe('live position tick over the socket', () => {
     await handle.liveState.close();
   });
 
-  it('writes a position and fans out game_state to everyone in the game', async () => {
+  it('writes a position and fans out game_state to others in the game', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+
+    const runner = connect(booted.url);
+    const watcher = connect(booted.url);
+    clients.push(runner, watcher);
+    await Promise.all([waitFor(runner, 'connect'), waitFor(watcher, 'connect')]);
+
+    // Both join with their identity (game, player, role) and await the ack.
+    const ack = (await runner.emitWithAck('join', {
+      gameId: 'g1',
+      playerId: 'hider-1',
+      role: 'hider',
+    })) as { ok: boolean };
+    expect(ack).toEqual({ ok: true });
+    await watcher.emitWithAck('join', { gameId: 'g1', playerId: 'hider-2', role: 'hider' });
+
+    // The runner reports only coordinates; identity comes from its join, so the
+    // stored position is keyed by the bound playerId, not anything in the payload.
+    const received = waitFor<GameStateMessage>(watcher, 'game_state');
+    runner.emit('position_update', { lat: 52.37, lng: 4.9 });
+
+    const state = await received;
+    expect(state.gameId).toBe('g1');
+    expect(state.positions['hider-1']).toMatchObject({ lat: 52.37, lng: 4.9 });
+    expect(typeof state.positions['hider-1']?.recordedAt).toBe('string');
+    // The server-only role marker is never leaked to clients.
+    expect('role' in (state.positions['hider-1'] ?? {})).toBe(false);
+  });
+
+  it('does not send hider coordinates to a hunter', async () => {
     const booted = await bootServer();
     handle = booted.handle;
 
@@ -56,19 +87,39 @@ describe('live position tick over the socket', () => {
     const hider = connect(booted.url);
     clients.push(hunter, hider);
     await Promise.all([waitFor(hunter, 'connect'), waitFor(hider, 'connect')]);
+    await hunter.emitWithAck('join', { gameId: 'g3', playerId: 'seeker', role: 'hunter' });
+    await hider.emitWithAck('join', { gameId: 'g3', playerId: 'runner', role: 'hider' });
 
-    // The hunter joins the game room and awaits the ack.
-    const ack = (await hunter.emitWithAck('join', { gameId: 'g1' })) as { ok: boolean };
-    expect(ack).toEqual({ ok: true });
-
-    // The hider reports a position; the hunter should receive the fan-out.
+    // The hunter is in the room, so it receives the fan-out — but the hider's
+    // position must be filtered out of what it sees.
     const received = waitFor<GameStateMessage>(hunter, 'game_state');
-    hider.emit('position_update', { gameId: 'g1', playerId: 'hider-1', lat: 52.37, lng: 4.9 });
+    hider.emit('position_update', { lat: 52.1, lng: 4.3 });
 
     const state = await received;
-    expect(state.gameId).toBe('g1');
-    expect(state.positions['hider-1']).toMatchObject({ lat: 52.37, lng: 4.9 });
-    expect(typeof state.positions['hider-1']?.recordedAt).toBe('string');
+    expect(state.positions['runner']).toBeUndefined();
+    expect(Object.keys(state.positions)).toHaveLength(0);
+  });
+
+  it('rejects a position update from a socket that has not joined', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+
+    const other = connect(booted.url);
+    const rogue = connect(booted.url);
+    clients.push(other, rogue);
+    await Promise.all([waitFor(other, 'connect'), waitFor(rogue, 'connect')]);
+    await other.emitWithAck('join', { gameId: 'g4', playerId: 'p1', role: 'hider' });
+
+    let got = false;
+    other.on('game_state', () => {
+      got = true;
+    });
+    // rogue never joined — it has no identity, so its update is ignored and
+    // can't inject a position into g4.
+    rogue.emit('position_update', { lat: 1, lng: 2 });
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(got).toBe(false);
   });
 
   it('ignores malformed position updates', async () => {
@@ -78,18 +129,39 @@ describe('live position tick over the socket', () => {
     const client = connect(booted.url);
     clients.push(client);
     await waitFor(client, 'connect');
-    await client.emitWithAck('join', { gameId: 'g2' });
+    await client.emitWithAck('join', { gameId: 'g2', playerId: 'p1', role: 'hider' });
 
     let got = false;
     client.on('game_state', () => {
       got = true;
     });
-    // Missing playerId / non-numeric coords — dropped, no broadcast.
-    client.emit('position_update', { gameId: 'g2', lat: 'nope' });
-    client.emit('position_update', { playerId: 'x', lat: 1, lng: 2 });
+    // Non-numeric / missing coords — dropped, no broadcast.
+    client.emit('position_update', { lat: 'nope' });
+    client.emit('position_update', { lng: 2 });
 
-    // Give the server a moment; nothing should have been emitted.
     await new Promise((r) => setTimeout(r, 100));
     expect(got).toBe(false);
+  });
+
+  it('throttles position updates faster than the tick cadence', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+
+    const runner = connect(booted.url);
+    clients.push(runner);
+    await waitFor(runner, 'connect');
+    await runner.emitWithAck('join', { gameId: 'g5', playerId: 'p1', role: 'hider' });
+
+    let count = 0;
+    runner.on('game_state', () => {
+      count += 1;
+    });
+    // Two updates back-to-back: the first is accepted, the second arrives well
+    // inside the minimum interval and is dropped.
+    runner.emit('position_update', { lat: 1, lng: 2 });
+    runner.emit('position_update', { lat: 3, lng: 4 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(count).toBe(1);
   });
 });

--- a/server/app.live.test.ts
+++ b/server/app.live.test.ts
@@ -135,9 +135,12 @@ describe('live position tick over the socket', () => {
     client.on('game_state', () => {
       got = true;
     });
-    // Non-numeric / missing coords — dropped, no broadcast.
+    // Non-numeric / missing coords, and coordinates outside the valid
+    // geographic range — all dropped, no broadcast.
     client.emit('position_update', { lat: 'nope' });
     client.emit('position_update', { lng: 2 });
+    client.emit('position_update', { lat: 91, lng: 0 });
+    client.emit('position_update', { lat: 0, lng: 200 });
 
     await new Promise((r) => setTimeout(r, 100));
     expect(got).toBe(false);

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,6 +9,7 @@ import express, {
   type NextFunction,
 } from 'express';
 import { Server } from 'socket.io';
+import { createLiveState, type LiveState, type Position } from './live/index.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -28,12 +29,57 @@ function resolveStaticDir(): string {
 
 export interface CreateServerOptions {
   staticDir?: string;
+  /**
+   * The live (hot) state layer. Defaults to {@link createLiveState}, which uses
+   * Redis when `REDIS_URL` is set and an in-process fallback otherwise. Tests
+   * inject an explicit in-memory layer for determinism.
+   */
+  liveState?: LiveState;
 }
 
 export interface ServerHandle {
   app: Express;
   httpServer: http.Server;
   io: Server;
+  liveState: LiveState;
+}
+
+/** Socket.IO room a game's broadcasts are emitted to. */
+function gameRoom(gameId: string): string {
+  return `game:${gameId}`;
+}
+
+interface PositionUpdate {
+  gameId: string;
+  playerId: string;
+  position: Position;
+}
+
+/** Extract a non-empty `gameId` from an untrusted socket payload. */
+function readGameId(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const { gameId } = payload as { gameId?: unknown };
+  return typeof gameId === 'string' && gameId ? gameId : undefined;
+}
+
+/**
+ * Validate an untrusted `position_update` payload. Returns the normalized
+ * update, or `undefined` if any field is missing or malformed. Positions are
+ * advisory input — authoritative rules (boundary, catch, role filtering) are
+ * layered on later (see BACKLOG.md).
+ */
+function readPositionUpdate(payload: unknown): PositionUpdate | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const { gameId, playerId, lat, lng } = payload as Record<string, unknown>;
+  if (typeof gameId !== 'string' || !gameId) return undefined;
+  if (typeof playerId !== 'string' || !playerId) return undefined;
+  if (typeof lat !== 'number' || !Number.isFinite(lat)) return undefined;
+  if (typeof lng !== 'number' || !Number.isFinite(lng)) return undefined;
+  return {
+    gameId,
+    playerId,
+    position: { lat, lng, recordedAt: new Date().toISOString() },
+  };
 }
 
 /**
@@ -43,6 +89,7 @@ export interface ServerHandle {
  */
 export function createServer({
   staticDir = resolveStaticDir(),
+  liveState = createLiveState(),
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -66,13 +113,48 @@ export function createServer({
 
   const httpServer = http.createServer(app);
   const io = new Server(httpServer);
+  const { store, broadcaster } = liveState;
 
-  // Authoritative game loop lives here. This is a stub — the real handlers
-  // (join, position_update, claim_catch, game_state) are tracked in the backlog.
+  // Single fan-out path: a game-state message — published locally or received
+  // from another instance over Redis pub/sub — is emitted to every socket in
+  // that game's room. Per-role visibility filtering is layered on later (see
+  // BACKLOG.md #14).
+  broadcaster.subscribe(({ gameId, positions }) => {
+    io.to(gameRoom(gameId)).emit('game_state', { gameId, positions });
+  });
+
+  // Authoritative game loop. Only the live-state wiring (join room +
+  // position_update tick) is implemented here; claim_catch and the rules
+  // engine are tracked in the backlog.
   io.on('connection', (socket) => {
     console.log(`socket connected: ${socket.id}`);
+
+    // Subscribe a socket to a game's broadcasts. Acks so callers can await it.
+    socket.on('join', (payload: unknown, ack?: (res: { ok: boolean }) => void) => {
+      const gameId = readGameId(payload);
+      if (gameId) socket.join(gameRoom(gameId));
+      if (typeof ack === 'function') ack({ ok: Boolean(gameId) });
+    });
+
+    // One tick: a client reports its position. The server writes it to the hot
+    // store and publishes the game's live positions for cross-instance fan-out.
+    socket.on('position_update', async (payload: unknown) => {
+      const update = readPositionUpdate(payload);
+      if (!update) return;
+      const { gameId, playerId, position } = update;
+      socket.join(gameRoom(gameId));
+      try {
+        await store.writePosition(gameId, playerId, position);
+        const positions = await store.readPositions(gameId);
+        await broadcaster.publish({ gameId, positions });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error('position_update failed:', reason);
+      }
+    });
+
     socket.on('disconnect', () => console.log(`socket disconnected: ${socket.id}`));
   });
 
-  return { app, httpServer, io };
+  return { app, httpServer, io, liveState };
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -102,14 +102,18 @@ function readPosition(payload: unknown): Position | undefined {
   const { lat, lng } = payload as Record<string, unknown>;
   if (typeof lat !== 'number' || !Number.isFinite(lat)) return undefined;
   if (typeof lng !== 'number' || !Number.isFinite(lng)) return undefined;
+  // Reject coordinates outside the valid geographic range. Per-game *playable*
+  // boundary enforcement (geofence) is a separate concern — see BACKLOG.md #11.
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return undefined;
   return { lat, lng, recordedAt: new Date().toISOString() };
 }
 
 /**
- * Filter a game's positions for a single recipient. Hunters never receive hider
- * coordinates (the scheduled-reveal exception is part of the rules engine — see
- * BACKLOG.md #14); everyone else sees the full map. The stored `role` marker is
- * stripped so the roster isn't leaked to clients.
+ * Filter a game's positions for a single recipient. Fails closed: a hunter only
+ * ever sees positions explicitly marked `hunter`, so anything unlabelled (a
+ * hider, or a record missing its role) is withheld rather than leaked. The
+ * scheduled-reveal exception is part of the rules engine (see BACKLOG.md #14).
+ * The stored `role` marker is stripped so the roster isn't leaked to clients.
  */
 function visibleTo(
   role: PlayerRole | undefined,
@@ -117,7 +121,7 @@ function visibleTo(
 ): PositionsByPlayer {
   const out: PositionsByPlayer = {};
   for (const [playerId, pos] of Object.entries(positions)) {
-    if (role === 'hunter' && pos.role === 'hider') continue;
+    if (role === 'hunter' && pos.role !== 'hunter') continue;
     out[playerId] = { lat: pos.lat, lng: pos.lng, recordedAt: pos.recordedAt };
   }
   return out;

--- a/server/app.ts
+++ b/server/app.ts
@@ -8,8 +8,15 @@ import express, {
   type Response,
   type NextFunction,
 } from 'express';
-import { Server } from 'socket.io';
-import { createLiveState, type LiveState, type Position } from './live/index.ts';
+import { Server, type DefaultEventsMap } from 'socket.io';
+import {
+  createLiveState,
+  type LiveState,
+  type Position,
+  type PlayerRole,
+  type PositionsByPlayer,
+  type GameStateMessage,
+} from './live/index.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -49,37 +56,71 @@ function gameRoom(gameId: string): string {
   return `game:${gameId}`;
 }
 
-interface PositionUpdate {
+/**
+ * The server-side identity bound to a socket at `join`. Position updates trust
+ * this — never the client-supplied payload — so a socket can only write its own
+ * player's position and can't spoof another.
+ */
+interface SocketIdentity {
   gameId: string;
   playerId: string;
-  position: Position;
+  role: PlayerRole;
 }
 
-/** Extract a non-empty `gameId` from an untrusted socket payload. */
-function readGameId(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== 'object') return undefined;
-  const { gameId } = payload as { gameId?: unknown };
-  return typeof gameId === 'string' && gameId ? gameId : undefined;
+/** Per-socket state the live handlers keep on `socket.data`. */
+interface SocketState {
+  identity?: SocketIdentity;
+  /** Epoch ms of the last accepted `position_update`, for rate limiting. */
+  lastPositionAt?: number;
 }
 
 /**
- * Validate an untrusted `position_update` payload. Returns the normalized
- * update, or `undefined` if any field is missing or malformed. Positions are
- * advisory input — authoritative rules (boundary, catch, role filtering) are
- * layered on later (see BACKLOG.md).
+ * Minimum spacing between accepted position updates. Clients tick every 5–10s
+ * (see docs); this is a generous anti-flood floor well below that, so a buggy
+ * or malicious client can't hammer writes/broadcasts faster than the server is
+ * willing to fan out.
  */
-function readPositionUpdate(payload: unknown): PositionUpdate | undefined {
+const MIN_POSITION_INTERVAL_MS = 1000;
+
+/** Validate an untrusted `join` payload into a server-side identity. */
+function readJoin(payload: unknown): SocketIdentity | undefined {
   if (!payload || typeof payload !== 'object') return undefined;
-  const { gameId, playerId, lat, lng } = payload as Record<string, unknown>;
+  const { gameId, playerId, role } = payload as Record<string, unknown>;
   if (typeof gameId !== 'string' || !gameId) return undefined;
   if (typeof playerId !== 'string' || !playerId) return undefined;
+  if (role !== 'hunter' && role !== 'hider') return undefined;
+  return { gameId, playerId, role };
+}
+
+/**
+ * Validate the untrusted half of a `position_update`: only the coordinates are
+ * ever taken from the client. Identity (game, player, role) comes from the
+ * socket's `join`, so it can't be forged in the payload.
+ */
+function readPosition(payload: unknown): Position | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const { lat, lng } = payload as Record<string, unknown>;
   if (typeof lat !== 'number' || !Number.isFinite(lat)) return undefined;
   if (typeof lng !== 'number' || !Number.isFinite(lng)) return undefined;
-  return {
-    gameId,
-    playerId,
-    position: { lat, lng, recordedAt: new Date().toISOString() },
-  };
+  return { lat, lng, recordedAt: new Date().toISOString() };
+}
+
+/**
+ * Filter a game's positions for a single recipient. Hunters never receive hider
+ * coordinates (the scheduled-reveal exception is part of the rules engine — see
+ * BACKLOG.md #14); everyone else sees the full map. The stored `role` marker is
+ * stripped so the roster isn't leaked to clients.
+ */
+function visibleTo(
+  role: PlayerRole | undefined,
+  positions: PositionsByPlayer,
+): PositionsByPlayer {
+  const out: PositionsByPlayer = {};
+  for (const [playerId, pos] of Object.entries(positions)) {
+    if (role === 'hunter' && pos.role === 'hider') continue;
+    out[playerId] = { lat: pos.lat, lng: pos.lng, recordedAt: pos.recordedAt };
+  }
+  return out;
 }
 
 /**
@@ -112,15 +153,26 @@ export function createServer({
   }
 
   const httpServer = http.createServer(app);
-  const io = new Server(httpServer);
+  const io = new Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, SocketState>(
+    httpServer,
+  );
   const { store, broadcaster } = liveState;
 
-  // Single fan-out path: a game-state message — published locally or received
-  // from another instance over Redis pub/sub — is emitted to every socket in
-  // that game's room. Per-role visibility filtering is layered on later (see
-  // BACKLOG.md #14).
-  broadcaster.subscribe(({ gameId, positions }) => {
-    io.to(gameRoom(gameId)).emit('game_state', { gameId, positions });
+  // Fan-out path: a game-state message — published locally or received from
+  // another instance over Redis pub/sub — is emitted to the game's sockets on
+  // THIS instance, filtered per recipient's role so hunters never receive hider
+  // coordinates (see BACKLOG.md #14).
+  async function fanOut({ gameId, positions }: GameStateMessage): Promise<void> {
+    const sockets = await io.in(gameRoom(gameId)).fetchSockets();
+    for (const s of sockets) {
+      s.emit('game_state', { gameId, positions: visibleTo(s.data.identity?.role, positions) });
+    }
+  }
+  broadcaster.subscribe((message) => {
+    void fanOut(message).catch((err: unknown) => {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.error('game_state fan-out failed:', reason);
+    });
   });
 
   // Authoritative game loop. Only the live-state wiring (join room +
@@ -129,22 +181,33 @@ export function createServer({
   io.on('connection', (socket) => {
     console.log(`socket connected: ${socket.id}`);
 
-    // Subscribe a socket to a game's broadcasts. Acks so callers can await it.
+    // Bind the socket's identity and subscribe it to its game's broadcasts.
+    // Acks so callers can await it.
     socket.on('join', (payload: unknown, ack?: (res: { ok: boolean }) => void) => {
-      const gameId = readGameId(payload);
-      if (gameId) socket.join(gameRoom(gameId));
-      if (typeof ack === 'function') ack({ ok: Boolean(gameId) });
+      const identity = readJoin(payload);
+      if (identity) {
+        socket.data.identity = identity;
+        socket.join(gameRoom(identity.gameId));
+      }
+      if (typeof ack === 'function') ack({ ok: Boolean(identity) });
     });
 
-    // One tick: a client reports its position. The server writes it to the hot
-    // store and publishes the game's live positions for cross-instance fan-out.
+    // One tick: a client reports its coordinates. The server trusts the socket's
+    // bound identity (not the payload) for who/which game, throttles to the tick
+    // cadence, writes to the hot store, and publishes for cross-instance fan-out.
     socket.on('position_update', async (payload: unknown) => {
-      const update = readPositionUpdate(payload);
-      if (!update) return;
-      const { gameId, playerId, position } = update;
-      socket.join(gameRoom(gameId));
+      const { identity } = socket.data;
+      if (!identity) return; // must join first — no identity, no write
+      const position = readPosition(payload);
+      if (!position) return;
+
+      const now = Date.now();
+      if (now - (socket.data.lastPositionAt ?? 0) < MIN_POSITION_INTERVAL_MS) return;
+      socket.data.lastPositionAt = now;
+
+      const { gameId, playerId, role } = identity;
       try {
-        await store.writePosition(gameId, playerId, position);
+        await store.writePosition(gameId, playerId, { ...position, role });
         const positions = await store.readPositions(gameId);
         await broadcaster.publish({ gameId, positions });
       } catch (err) {

--- a/server/live/broadcaster.test.ts
+++ b/server/live/broadcaster.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CHANNEL_PATTERN,
+  createLocalBroadcaster,
+  createRedisBroadcaster,
+  stateChannel,
+  type GameStateMessage,
+  type RedisPublisher,
+  type RedisSubscriber,
+} from './broadcaster.ts';
+
+type PMessageListener = (pattern: string, channel: string, message: string) => void;
+
+interface FakePubSub extends RedisPublisher, RedisSubscriber {
+  published: Array<{ channel: string; message: string }>;
+  patterns: string[];
+  /** Simulate a message arriving on the wire. */
+  deliver(channel: string, message: string): void;
+}
+
+/** A fake Redis pair wired so publishing loops back through the subscriber. */
+function fakePubSub(): FakePubSub {
+  const published: Array<{ channel: string; message: string }> = [];
+  const patterns: string[] = [];
+  let listener: PMessageListener | undefined;
+  return {
+    published,
+    patterns,
+    async publish(channel, message) {
+      published.push({ channel, message });
+      return 1;
+    },
+    async psubscribe(pattern) {
+      patterns.push(pattern);
+      return 1;
+    },
+    on(_event, cb) {
+      listener = cb;
+      return this;
+    },
+    deliver(channel, message) {
+      listener?.(CHANNEL_PATTERN, channel, message);
+    },
+  };
+}
+
+const message = (gameId: string): GameStateMessage => ({
+  gameId,
+  positions: { p1: { lat: 1, lng: 2, recordedAt: '2026-07-21T00:00:00.000Z' } },
+});
+
+describe('stateChannel', () => {
+  it('namespaces the channel per game and matches the pattern shape', () => {
+    expect(stateChannel('ABCD')).toBe('game:ABCD:state');
+    expect(CHANNEL_PATTERN).toBe('game:*:state');
+  });
+});
+
+describe('createRedisBroadcaster', () => {
+  it('publishes JSON on the game channel', async () => {
+    const redis = fakePubSub();
+    const broadcaster = createRedisBroadcaster(redis, redis);
+    await broadcaster.publish(message('g1'));
+
+    expect(redis.published).toEqual([
+      { channel: 'game:g1:state', message: JSON.stringify(message('g1')) },
+    ]);
+  });
+
+  it('subscribes to the channel pattern once and dispatches decoded messages', async () => {
+    const redis = fakePubSub();
+    const broadcaster = createRedisBroadcaster(redis, redis);
+
+    const a = vi.fn();
+    const b = vi.fn();
+    broadcaster.subscribe(a);
+    broadcaster.subscribe(b);
+    // Give the fire-and-forget psubscribe a chance to settle.
+    await Promise.resolve();
+
+    // Only one network subscription regardless of handler count.
+    expect(redis.patterns).toEqual([CHANNEL_PATTERN]);
+
+    redis.deliver('game:g1:state', JSON.stringify(message('g1')));
+    expect(a).toHaveBeenCalledWith(message('g1'));
+    expect(b).toHaveBeenCalledWith(message('g1'));
+  });
+
+  it('delivers a published message to subscribers via the subscriber loopback', async () => {
+    const redis = fakePubSub();
+    const broadcaster = createRedisBroadcaster(redis, redis);
+    const handler = vi.fn();
+    broadcaster.subscribe(handler);
+
+    await broadcaster.publish(message('g7'));
+    // Emulate Redis routing the publish back to pattern subscribers.
+    const { channel, message: payload } = redis.published[0]!;
+    redis.deliver(channel, payload);
+
+    expect(handler).toHaveBeenCalledWith(message('g7'));
+  });
+
+  it('stops dispatching after close', async () => {
+    const redis = fakePubSub();
+    const broadcaster = createRedisBroadcaster(redis, redis);
+    const handler = vi.fn();
+    broadcaster.subscribe(handler);
+    await broadcaster.close();
+
+    redis.deliver('game:g1:state', JSON.stringify(message('g1')));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('createLocalBroadcaster', () => {
+  it('delivers published messages to every local subscriber', async () => {
+    const broadcaster = createLocalBroadcaster();
+    const a = vi.fn();
+    const b = vi.fn();
+    broadcaster.subscribe(a);
+    broadcaster.subscribe(b);
+
+    await broadcaster.publish(message('g1'));
+    expect(a).toHaveBeenCalledWith(message('g1'));
+    expect(b).toHaveBeenCalledWith(message('g1'));
+  });
+
+  it('stops delivering after close', async () => {
+    const broadcaster = createLocalBroadcaster();
+    const handler = vi.fn();
+    broadcaster.subscribe(handler);
+    await broadcaster.close();
+
+    await broadcaster.publish(message('g1'));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/server/live/broadcaster.ts
+++ b/server/live/broadcaster.ts
@@ -1,0 +1,108 @@
+/**
+ * Cross-instance fan-out of game state. Any server instance publishes a game's
+ * state; every instance (including the publisher) receives it and emits to its
+ * own connected sockets. This is what lets the game run behind more than one
+ * server process — the Broadcaster in docs/arc42.md §5.2, backed by Redis
+ * pub/sub, with an in-process loopback for a single instance.
+ */
+import { EventEmitter } from 'node:events';
+import type { PositionsByPlayer } from './positions.ts';
+
+/** A room-state message fanned out to every instance for a game. */
+export interface GameStateMessage {
+  gameId: string;
+  positions: PositionsByPlayer;
+}
+
+export type GameStateHandler = (message: GameStateMessage) => void;
+
+/** Publish/subscribe fan-out of {@link GameStateMessage}s across instances. */
+export interface Broadcaster {
+  /** Publish a game's state to every subscribed instance. */
+  publish(message: GameStateMessage): Promise<void>;
+  /** Register a handler run for every message received (local or remote). */
+  subscribe(handler: GameStateHandler): void;
+  /** Tear down subscriptions/handlers. */
+  close(): Promise<void>;
+}
+
+/** The publish half of a Redis client. */
+export interface RedisPublisher {
+  publish(channel: string, message: string): Promise<number>;
+}
+
+/** The subscribe half of a Redis client (a dedicated subscriber connection). */
+export interface RedisSubscriber {
+  psubscribe(pattern: string): Promise<unknown>;
+  on(
+    event: 'pmessage',
+    listener: (pattern: string, channel: string, message: string) => void,
+  ): unknown;
+}
+
+/** Glob pattern matching every game-state channel. */
+export const CHANNEL_PATTERN = 'game:*:state';
+
+/** Redis pub/sub channel carrying a game's state. */
+export function stateChannel(gameId: string): string {
+  return `game:${gameId}:state`;
+}
+
+/**
+ * Fan out game state across instances over Redis pub/sub. `pub` publishes on
+ * the game's channel; `sub` (a dedicated subscriber connection) pattern-matches
+ * every game channel and dispatches decoded messages to registered handlers.
+ */
+export function createRedisBroadcaster(
+  pub: RedisPublisher,
+  sub: RedisSubscriber,
+): Broadcaster {
+  const handlers = new Set<GameStateHandler>();
+  let subscribed = false;
+
+  return {
+    async publish(message) {
+      await pub.publish(stateChannel(message.gameId), JSON.stringify(message));
+    },
+    subscribe(handler) {
+      handlers.add(handler);
+      if (subscribed) return;
+      subscribed = true;
+
+      sub.on('pmessage', (_pattern, _channel, payload) => {
+        const message = JSON.parse(payload) as GameStateMessage;
+        for (const h of handlers) h(message);
+      });
+      // Registration is synchronous; the network subscribe settles in the
+      // background so callers (e.g. server wiring) need not await it.
+      void Promise.resolve(sub.psubscribe(CHANNEL_PATTERN)).catch((err: unknown) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error('redis psubscribe failed:', reason);
+      });
+    },
+    async close() {
+      handlers.clear();
+    },
+  };
+}
+
+/**
+ * In-process fan-out for a single instance (dev, tests, no Redis). Publishing
+ * synchronously delivers to local handlers — the loopback Redis provides across
+ * instances, without the network hop.
+ */
+export function createLocalBroadcaster(): Broadcaster {
+  const emitter = new EventEmitter();
+  const EVENT = 'game_state';
+  return {
+    async publish(message) {
+      emitter.emit(EVENT, message);
+    },
+    subscribe(handler) {
+      emitter.on(EVENT, handler);
+    },
+    async close() {
+      emitter.removeAllListeners(EVENT);
+    },
+  };
+}

--- a/server/live/index.ts
+++ b/server/live/index.ts
@@ -1,0 +1,57 @@
+/**
+ * The live (hot) state layer: a per-game position store plus a cross-instance
+ * broadcaster. Backed by Redis when `REDIS_URL` is set, and by an in-process
+ * fallback otherwise so a bare dev checkout and CI (which have no Redis
+ * service) still run as a single instance.
+ */
+import { closeRedis, getRedis, getSubscriber, isRedisConfigured } from '../redis/client.ts';
+import {
+  createMemoryPositionStore,
+  createRedisPositionStore,
+  type PositionStore,
+} from './positions.ts';
+import {
+  createLocalBroadcaster,
+  createRedisBroadcaster,
+  type Broadcaster,
+} from './broadcaster.ts';
+
+export * from './positions.ts';
+export * from './broadcaster.ts';
+
+/** The hot-state layer wired into the server. */
+export interface LiveState {
+  store: PositionStore;
+  broadcaster: Broadcaster;
+  /** Release the broadcaster and any underlying Redis connections. */
+  close(): Promise<void>;
+}
+
+/**
+ * Build the live-state layer. With `REDIS_URL` set it shares hot positions and
+ * fans out over pub/sub — the shape a multi-instance deployment needs. Without
+ * it, an in-process store and loopback broadcaster keep a single instance fully
+ * functional.
+ */
+export function createLiveState(): LiveState {
+  if (isRedisConfigured()) {
+    const pub = getRedis();
+    const sub = getSubscriber();
+    const broadcaster = createRedisBroadcaster(pub, sub);
+    return {
+      store: createRedisPositionStore(pub),
+      broadcaster,
+      async close() {
+        await broadcaster.close();
+        await closeRedis();
+      },
+    };
+  }
+
+  const broadcaster = createLocalBroadcaster();
+  return {
+    store: createMemoryPositionStore(),
+    broadcaster,
+    close: () => broadcaster.close(),
+  };
+}

--- a/server/live/positions.test.ts
+++ b/server/live/positions.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMemoryPositionStore,
+  createRedisPositionStore,
+  positionsKey,
+  POSITIONS_TTL_S,
+  type Position,
+  type RedisHashClient,
+} from './positions.ts';
+
+interface FakeRedis extends RedisHashClient {
+  hashes: Map<string, Map<string, string>>;
+  expires: Array<{ key: string; seconds: number }>;
+}
+
+/** An in-memory stand-in for the hash/expire commands the store uses. */
+function fakeRedis(): FakeRedis {
+  const hashes = new Map<string, Map<string, string>>();
+  const expires: Array<{ key: string; seconds: number }> = [];
+  return {
+    hashes,
+    expires,
+    async hset(key, field, value) {
+      let hash = hashes.get(key);
+      if (!hash) {
+        hash = new Map();
+        hashes.set(key, hash);
+      }
+      const isNew = hash.has(field) ? 0 : 1;
+      hash.set(field, value);
+      return isNew;
+    },
+    async hgetall(key) {
+      return Object.fromEntries(hashes.get(key) ?? new Map());
+    },
+    async expire(key, seconds) {
+      expires.push({ key, seconds });
+      return hashes.has(key) ? 1 : 0;
+    },
+  };
+}
+
+const pos = (lat: number, lng: number): Position => ({
+  lat,
+  lng,
+  recordedAt: '2026-07-21T00:00:00.000Z',
+});
+
+describe('positionsKey', () => {
+  it('namespaces the hash per game', () => {
+    expect(positionsKey('ABCD')).toBe('game:ABCD:positions');
+  });
+});
+
+describe('createRedisPositionStore', () => {
+  it('writes each player into the game hash and refreshes the TTL', async () => {
+    const redis = fakeRedis();
+    const store = createRedisPositionStore(redis);
+
+    await store.writePosition('g1', 'p1', pos(1, 2));
+    await store.writePosition('g1', 'p2', pos(3, 4));
+
+    const key = positionsKey('g1');
+    expect([...(redis.hashes.get(key)?.keys() ?? [])]).toEqual(['p1', 'p2']);
+    // Every write bumps the key's expiry.
+    expect(redis.expires).toEqual([
+      { key, seconds: POSITIONS_TTL_S },
+      { key, seconds: POSITIONS_TTL_S },
+    ]);
+  });
+
+  it('reads back every player position for a game', async () => {
+    const redis = fakeRedis();
+    const store = createRedisPositionStore(redis);
+    await store.writePosition('g1', 'p1', pos(1, 2));
+    await store.writePosition('g1', 'p2', pos(3, 4));
+
+    const positions = await store.readPositions('g1');
+    expect(positions).toEqual({ p1: pos(1, 2), p2: pos(3, 4) });
+  });
+
+  it('overwrites a player with their latest position', async () => {
+    const redis = fakeRedis();
+    const store = createRedisPositionStore(redis);
+    await store.writePosition('g1', 'p1', pos(1, 1));
+    await store.writePosition('g1', 'p1', pos(9, 9));
+
+    expect(await store.readPositions('g1')).toEqual({ p1: pos(9, 9) });
+  });
+
+  it('honors a custom TTL', async () => {
+    const redis = fakeRedis();
+    const store = createRedisPositionStore(redis, 42);
+    await store.writePosition('g1', 'p1', pos(1, 2));
+    expect(redis.expires).toEqual([{ key: positionsKey('g1'), seconds: 42 }]);
+  });
+
+  it('returns an empty map for an unknown game', async () => {
+    const store = createRedisPositionStore(fakeRedis());
+    expect(await store.readPositions('nope')).toEqual({});
+  });
+});
+
+describe('createMemoryPositionStore', () => {
+  it('stores and reads positions per game, isolated from other games', async () => {
+    const store = createMemoryPositionStore();
+    await store.writePosition('g1', 'p1', pos(1, 2));
+    await store.writePosition('g2', 'p1', pos(5, 6));
+
+    expect(await store.readPositions('g1')).toEqual({ p1: pos(1, 2) });
+    expect(await store.readPositions('g2')).toEqual({ p1: pos(5, 6) });
+    expect(await store.readPositions('g3')).toEqual({});
+  });
+
+  it('overwrites a player with their latest position', async () => {
+    const store = createMemoryPositionStore();
+    await store.writePosition('g1', 'p1', pos(1, 1));
+    await store.writePosition('g1', 'p1', pos(2, 2));
+    expect(await store.readPositions('g1')).toEqual({ p1: pos(2, 2) });
+  });
+});

--- a/server/live/positions.ts
+++ b/server/live/positions.ts
@@ -1,0 +1,94 @@
+/**
+ * Hot, per-game live position state — the latest reported position of every
+ * player in a game. This is the ephemeral half of the split-state model (see
+ * docs/arc42.md §5, ADR-004): live positions live in Redis; durable history is
+ * flushed to PostgreSQL by the persistence layer.
+ */
+
+/** A player's latest reported position. */
+export interface Position {
+  lat: number;
+  lng: number;
+  /** When the client reported it (ISO-8601). */
+  recordedAt: string;
+}
+
+/** Latest position per player id, for one game. */
+export type PositionsByPlayer = Record<string, Position>;
+
+/** Reads and writes the hot live-position state for games. */
+export interface PositionStore {
+  /** Record a player's latest position for a game (called on each tick). */
+  writePosition(gameId: string, playerId: string, pos: Position): Promise<void>;
+  /** Read every player's latest position for a game. */
+  readPositions(gameId: string): Promise<PositionsByPlayer>;
+}
+
+/**
+ * The subset of a Redis client the position store uses. Kept minimal so a fake
+ * client can drive the store in tests without a live Redis.
+ */
+export interface RedisHashClient {
+  hset(key: string, field: string, value: string): Promise<number>;
+  hgetall(key: string): Promise<Record<string, string>>;
+  expire(key: string, seconds: number): Promise<number>;
+}
+
+/** Redis key holding the latest position of every player in a game. */
+export function positionsKey(gameId: string): string {
+  return `game:${gameId}:positions`;
+}
+
+/**
+ * Time-to-live for a game's hot position state. Live state is ephemeral, so the
+ * key self-expires a while after the last write, keeping abandoned games from
+ * lingering in Redis; each write refreshes it.
+ */
+export const POSITIONS_TTL_S = 60 * 60 * 6; // 6 hours
+
+/**
+ * Store live positions in a Redis hash keyed per game: one field per player id
+ * holding the JSON-encoded latest position. Every write refreshes the key TTL.
+ */
+export function createRedisPositionStore(
+  redis: RedisHashClient,
+  ttlSeconds: number = POSITIONS_TTL_S,
+): PositionStore {
+  return {
+    async writePosition(gameId, playerId, pos) {
+      const key = positionsKey(gameId);
+      await redis.hset(key, playerId, JSON.stringify(pos));
+      await redis.expire(key, ttlSeconds);
+    },
+    async readPositions(gameId) {
+      const raw = await redis.hgetall(positionsKey(gameId));
+      const positions: PositionsByPlayer = {};
+      for (const [playerId, value] of Object.entries(raw)) {
+        positions[playerId] = JSON.parse(value) as Position;
+      }
+      return positions;
+    },
+  };
+}
+
+/**
+ * In-process position store used when Redis is not configured (dev, tests, a
+ * single instance). Same contract as the Redis store, minus cross-instance
+ * sharing and TTL.
+ */
+export function createMemoryPositionStore(): PositionStore {
+  const games = new Map<string, Map<string, Position>>();
+  return {
+    async writePosition(gameId, playerId, pos) {
+      let game = games.get(gameId);
+      if (!game) {
+        game = new Map<string, Position>();
+        games.set(gameId, game);
+      }
+      game.set(playerId, pos);
+    },
+    async readPositions(gameId) {
+      return Object.fromEntries(games.get(gameId) ?? new Map<string, Position>());
+    },
+  };
+}

--- a/server/live/positions.ts
+++ b/server/live/positions.ts
@@ -5,12 +5,21 @@
  * flushed to PostgreSQL by the persistence layer.
  */
 
+/** A player's role in a game. */
+export type PlayerRole = 'hunter' | 'hider';
+
 /** A player's latest reported position. */
 export interface Position {
   lat: number;
   lng: number;
   /** When the client reported it (ISO-8601). */
   recordedAt: string;
+  /**
+   * The owner's role, stored alongside the position so any instance can apply
+   * server-side visibility filtering (hunters don't see hiders) without a
+   * separate roster lookup. Omitted for the raw coordinate a client receives.
+   */
+  role?: PlayerRole;
 }
 
 /** Latest position per player id, for one game. */

--- a/server/redis/client.test.ts
+++ b/server/redis/client.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Stub ioredis so the module never opens a real socket. A lightweight class is
+// enough — the connection module only constructs it, attaches an error handler,
+// and calls quit().
+vi.mock('ioredis', () => {
+  class FakeRedis {
+    on(): this {
+      return this;
+    }
+    quit(): Promise<string> {
+      return Promise.resolve('OK');
+    }
+  }
+  return { Redis: FakeRedis };
+});
+
+const REDIS_URL = 'redis://localhost:6379';
+
+describe('redis client', () => {
+  const original = process.env.REDIS_URL;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.REDIS_URL;
+    else process.env.REDIS_URL = original;
+    vi.resetModules();
+  });
+
+  it('isRedisConfigured reflects REDIS_URL', async () => {
+    vi.resetModules();
+    delete process.env.REDIS_URL;
+    const withoutUrl = await import('./client.ts');
+    expect(withoutUrl.isRedisConfigured()).toBe(false);
+
+    vi.resetModules();
+    process.env.REDIS_URL = REDIS_URL;
+    const withUrl = await import('./client.ts');
+    expect(withUrl.isRedisConfigured()).toBe(true);
+  });
+
+  it('getRedis throws a clear error when REDIS_URL is unset', async () => {
+    vi.resetModules();
+    delete process.env.REDIS_URL;
+    const mod = await import('./client.ts');
+    expect(() => mod.getRedis()).toThrow(/REDIS_URL is not set/);
+  });
+
+  it('reuses one command connection and a separate subscriber connection', async () => {
+    vi.resetModules();
+    process.env.REDIS_URL = REDIS_URL;
+    const mod = await import('./client.ts');
+
+    const command = mod.getRedis();
+    expect(mod.getRedis()).toBe(command); // reused, not reconnected
+
+    const sub = mod.getSubscriber();
+    expect(mod.getSubscriber()).toBe(sub); // reused
+    expect(sub).not.toBe(command); // pub/sub needs its own connection
+
+    await expect(mod.closeRedis()).resolves.toBeUndefined();
+  });
+});

--- a/server/redis/client.ts
+++ b/server/redis/client.ts
@@ -1,0 +1,56 @@
+import { Redis } from 'ioredis';
+
+let client: Redis | undefined;
+let subscriber: Redis | undefined;
+
+/** Whether a Redis connection is configured (via `REDIS_URL`). */
+export function isRedisConfigured(): boolean {
+  return Boolean(process.env.REDIS_URL);
+}
+
+/**
+ * Build a lazily-connecting ioredis client from `REDIS_URL`.
+ *
+ * `lazyConnect` mirrors the database pool: constructing the client never opens
+ * a socket, so importing this module (or a bare dev checkout without Redis)
+ * pays nothing until the first command. Connection trouble surfaces as `error`
+ * events, which ioredis retries internally — we attach a listener so Node does
+ * not treat them as unhandled.
+ */
+function connect(): Redis {
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    throw new Error('REDIS_URL is not set — cannot connect to Redis');
+  }
+  const redis = new Redis(url, { lazyConnect: true });
+  redis.on('error', (err: Error) => console.error('redis error:', err.message));
+  return redis;
+}
+
+/**
+ * The shared connection used for commands and publishing. Lazily created on
+ * first use and reused thereafter.
+ */
+export function getRedis(): Redis {
+  if (!client) client = connect();
+  return client;
+}
+
+/**
+ * The dedicated subscriber connection. A Redis connection in subscribe mode can
+ * only issue (p)subscribe/unsubscribe commands, so pub/sub needs its own
+ * connection separate from {@link getRedis}.
+ */
+export function getSubscriber(): Redis {
+  if (!subscriber) subscriber = connect();
+  return subscriber;
+}
+
+/** Close any open Redis connections. Safe to call when none were created. */
+export async function closeRedis(): Promise<void> {
+  const open = [client, subscriber].filter((c): c is Redis => Boolean(c));
+  client = undefined;
+  subscriber = undefined;
+  // quit() rejects on a never-connected lazyConnect client; ignore that.
+  await Promise.all(open.map((c) => c.quit().catch(() => {})));
+}


### PR DESCRIPTION
Closes #3.

Wires **Redis** for hot live state and cross-instance pub/sub — the live-state layer from `docs/arc42.md` §5.2 / ADR-004. Built on top of the issue #2 branch (PR #30), so this diff shows only the Redis work.

> **Base note:** targeted at `claude/manhunt-feature-impl-9soupu` (PR #30, issue #2). Retarget to `master` once #1/#2 merge.

## Acceptance criteria

- [x] **Positions written to Redis on each tick** — the `position_update` handler writes the reported position into a per-game Redis hash (one field per player, TTL-refreshed on each write).
- [x] **Broadcaster fans out via pub/sub** — each tick publishes the game's positions on `game:<id>:state`; every instance pattern-subscribes (`game:*:state`) and emits `game_state` to that game's room.

## What's here

**Connection (`server/redis/client.ts`)** — a lazily-connecting `ioredis` command/publish connection plus a **dedicated subscriber** connection (a connection in subscribe mode can't run other commands), both from `REDIS_URL`. Importing never opens a socket, mirroring `server/db/pool.ts`.

**Position store (`server/live/positions.ts`)** — stores each player's latest position in a Redis hash keyed per game (`game:<id>:positions`), refreshing a TTL on write since live state is ephemeral (durable history lives in PostgreSQL). Ships with an in-process fallback of the same contract.

**Broadcaster (`server/live/broadcaster.ts`)** — cross-instance `game_state` fan-out over Redis pub/sub, plus an in-process loopback for a single instance.

**Factory (`server/live/index.ts`)** — `createLiveState()` uses Redis when `REDIS_URL` is set and the in-process fallback otherwise, so a single instance (and CI, which has no Redis service) runs fully; multi-instance deployments set `REDIS_URL` to share hot state and fan out.

**Wiring (`server/app.ts`)** — `join` (subscribe a socket to a game room, with ack) and `position_update` (validate → write → publish) handlers, and a single subscription that emits `game_state` to each game room. Authoritative rules (boundary, catch, per-role filtering) are intentionally left to their own backlog items (#10, #11, #14).

`ioredis` was already a declared-but-unused dependency; this wires it in.

## Testing

- **Unit (Vitest, DB/Redis-free):** `positions.test.ts` and `broadcaster.test.ts` drive the Redis implementations through in-memory fake clients (à la the migration tests); `redis/client.test.ts` covers lazy/reuse/error behavior with `ioredis` stubbed.
- **Integration:** `server/app.live.test.ts` boots the real server with an in-memory live state and verifies the tick fan-out over two real Socket.IO clients.
- **E2E (Playwright):** `client/e2e/live.spec.ts` drives the position tick against the **real production server** (`server/index.ts`, no `REDIS_URL` → in-process fallback), asserting one player's `position_update` fans out to another.

`npm run typecheck`, `npm run lint`, `npm test`, and `npm run test:e2e` all pass.

## Docs

`README.md` gains a **Live state (Redis)** section; `.env.example` documents that `REDIS_URL` is optional in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy955e3HpZviaY1ZKAEXcd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time GPS position updates now fan out through Socket.IO “live state,” including cross-instance sharing via Redis pub/sub.
  * Role-based visibility filtering (hunters vs hiders) and throttling reduce over-updates.
* **Bug Fixes**
  * Enforces join-before-update identity, validates coordinates strictly (including bounds), and avoids leaking server-only role info.
  * Updates arriving faster than the tick cadence are dropped to keep consistency.
* **Documentation**
  * Expanded Redis “Live state” documentation and clarified development fallback when Redis isn’t configured.
  * Updated environment example to enable migrations.
* **Tests**
  * Added unit and E2E coverage for live fan-out, broadcaster/position storage behavior, validation, and throttling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->