### PR TITLE
feat(infra): Caddy TLS + WebSocket upgrade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Server
 NODE_ENV=production
 PORT=3000
+# Trust the reverse proxy (Caddy) so req.secure/req.protocol/req.ip reflect the
+# real client and HTTPS. Default 1 (single Caddy hop); set false to disable.
+TRUST_PROXY=1
 
 # PostgreSQL
 POSTGRES_USER=manhunt

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,36 @@
+# Caddy reverse proxy — automatic HTTPS (TLS) in front of the app container.
+#
+# Caddy provisions and renews a trusted certificate for {$DOMAIN} automatically:
+#   - a real public domain      -> ACME cert from Let's Encrypt / ZeroSSL
+#   - localhost / 127.0.0.1 / :: -> Caddy's own locally-trusted internal CA
+# so `DOMAIN=localhost` gives you working HTTPS + WSS for local validation with
+# no public DNS. HTTP on :80 is redirected to HTTPS automatically.
+
 {$DOMAIN} {
-	encode gzip
-	# WebSocket upgrades and everything else proxy to the app container.
-	reverse_proxy app:3000
+	# Compress text responses. WebSocket frames pass through untouched.
+	encode zstd gzip
+
+	# Security headers. HSTS is only advertised over the HTTPS Caddy terminates.
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "SAMEORIGIN"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		# Don't leak which server is behind the proxy.
+		-Server
+	}
+
+	# Proxy everything — HTTP and Socket.IO WebSocket (WSS) alike — to the app.
+	# Caddy detects the `Upgrade: websocket` request and switches to a bidirectional
+	# tunnel transparently (no extra config), and sets X-Forwarded-{For,Proto,Host}
+	# which the app trusts via its `trust proxy` setting.
+	reverse_proxy app:3000 {
+		# Flush every write immediately so live/streamed frames aren't buffered.
+		flush_interval -1
+
+		# Active health check: only route to the app once /health answers.
+		health_uri /health
+		health_interval 10s
+		health_timeout 5s
+	}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -2,9 +2,11 @@
 #
 # Caddy provisions and renews a trusted certificate for {$DOMAIN} automatically:
 #   - a real public domain      -> ACME cert from Let's Encrypt / ZeroSSL
-#   - localhost / 127.0.0.1 / :: -> Caddy's own locally-trusted internal CA
+#   - localhost / 127.0.0.1 / :: -> a cert from Caddy's own internal CA (issued
+#     locally; NOT trusted by browsers/other hosts until you import Caddy's root)
 # so `DOMAIN=localhost` gives you working HTTPS + WSS for local validation with
-# no public DNS. HTTP on :80 is redirected to HTTPS automatically.
+# no public DNS (scripts/verify-proxy.sh passes -k to skip that trust check).
+# HTTP on :80 is redirected to HTTPS automatically.
 
 {$DOMAIN} {
 	# Compress text responses. WebSocket frames pass through untouched.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,39 @@ A compiled static design preview still lives in `public/index.html` (with the
 editable source mockup in `docs/mockup/`); the server serves the built client
 from `dist/` when present and falls back to `public/` otherwise.
 
+### HTTPS & WebSockets (Caddy)
+
+The stack fronts the app with **Caddy** ([`Caddyfile`](./Caddyfile)), which
+gives you HTTPS with **no manual certificates**:
+
+- **TLS is automatic.** Caddy provisions and renews a certificate for
+  `$DOMAIN` — an ACME cert from Let's Encrypt/ZeroSSL for a real public domain,
+  or its own locally-trusted internal CA for `localhost`/loopback. HTTP on
+  `:80` is redirected to HTTPS on `:443`.
+- **WebSockets just work.** `reverse_proxy` upgrades `Upgrade: websocket`
+  requests (Socket.IO over WSS) into a transparent bidirectional tunnel, so
+  live position updates flow over the same HTTPS origin.
+- **Correct client info behind the proxy.** Caddy forwards
+  `X-Forwarded-{For,Proto,Host}`; the server trusts them via
+  [`trust proxy`](./server/app.ts) (`TRUST_PROXY`, default the single Caddy
+  hop) so `req.secure`/`req.ip` are accurate.
+
+Point `DOMAIN` at your host in `.env` and make sure its DNS `A`/`AAAA` record
+resolves to the machine (ports `80` and `443` reachable) so ACME can issue the
+certificate.
+
+**Validate a running stack** against issue #5's acceptance — HTTPS reachable
+and WebSocket upgrades succeeding through the proxy:
+
+```bash
+DOMAIN=manhunt.example.com scripts/verify-proxy.sh
+```
+
+To validate locally with no public DNS, set `DOMAIN=localhost` and
+`docker compose up -d`; Caddy serves `localhost` over HTTPS with its internal
+CA, and `DOMAIN=localhost scripts/verify-proxy.sh` checks `/health` over HTTPS
+and asserts the Socket.IO endpoint returns `101 Switching Protocols`.
+
 ## Release
 
 Tag a version and the `release` workflow (`.github/workflows/release.yml`) does two things:

--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ gives you HTTPS with **no manual certificates**:
 
 - **TLS is automatic.** Caddy provisions and renews a certificate for
   `$DOMAIN` — an ACME cert from Let's Encrypt/ZeroSSL for a real public domain,
-  or its own locally-trusted internal CA for `localhost`/loopback. HTTP on
-  `:80` is redirected to HTTPS on `:443`.
+  or a cert from its own internal CA for `localhost`/loopback (issued locally;
+  import Caddy's root CA to trust it in a browser). HTTP on `:80` is redirected
+  to HTTPS on `:443`.
 - **WebSockets just work.** `reverse_proxy` upgrades `Upgrade: websocket`
   requests (Socket.IO over WSS) into a transparent bidirectional tunnel, so
   live position updates flow over the same HTTPS origin.
@@ -186,8 +187,11 @@ DOMAIN=manhunt.example.com scripts/verify-proxy.sh
 
 To validate locally with no public DNS, set `DOMAIN=localhost` and
 `docker compose up -d`; Caddy serves `localhost` over HTTPS with its internal
-CA, and `DOMAIN=localhost scripts/verify-proxy.sh` checks `/health` over HTTPS
-and asserts the Socket.IO endpoint returns `101 Switching Protocols`.
+CA. That CA isn't in the system trust store by default, so
+`DOMAIN=localhost scripts/verify-proxy.sh` passes `curl -k` to skip browser
+trust — it checks `/health` over HTTPS and asserts the Socket.IO endpoint
+returns `101 Switching Protocols`. To make browsers trust it, import Caddy's
+root CA (`docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt .`).
 
 ## Release
 

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,9 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
-    depends_on: [app]
+    depends_on:
+      app:
+        condition: service_healthy
 
   app:
     image: ghcr.io/sschorer/manhunt:latest
@@ -21,7 +23,13 @@ services:
       - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=${REDIS_URL}
       - SESSION_SECRET=${SESSION_SECRET}
-    depends_on: [db, redis]
+      # Trust the single Caddy hop so req.secure/req.ip are correct behind TLS.
+      - TRUST_PROXY=${TRUST_PROXY:-1}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   db:
     image: postgres:16-alpine
@@ -32,10 +40,20 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   pgdata:

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,14 @@ services:
       - SESSION_SECRET=${SESSION_SECRET}
       # Trust the single Caddy hop so req.secure/req.ip are correct behind TLS.
       - TRUST_PROXY=${TRUST_PROXY:-1}
+    healthcheck:
+      # Explicit probe so Caddy's `service_healthy` gate is satisfied even if the
+      # image ships without a baked-in HEALTHCHECK. node is always on PATH here.
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     depends_on:
       db:
         condition: service_healthy

--- a/scripts/verify-proxy.sh
+++ b/scripts/verify-proxy.sh
@@ -35,6 +35,9 @@ echo "2/2 WebSocket upgrade through the proxy"
 # Ask the Socket.IO endpoint for a raw WebSocket upgrade and assert Caddy/app
 # answer 101 Switching Protocols (i.e. the upgrade tunnel was established).
 WS_URL="${BASE}/socket.io/?EIO=4&transport=websocket"
+# A successful upgrade keeps the tunnel open, so curl runs until --max-time and
+# exits non-zero (timeout) *after* emitting the 101 status. Ignore that exit code
+# (|| true) and judge the check by the captured status instead of curl's rc.
 # shellcheck disable=SC2086
 status="$(curl $INSECURE -sS --max-time 10 -o /dev/null -w '%{http_code}' \
   --http1.1 \
@@ -42,7 +45,7 @@ status="$(curl $INSECURE -sS --max-time 10 -o /dev/null -w '%{http_code}' \
   -H 'Upgrade: websocket' \
   -H 'Sec-WebSocket-Version: 13' \
   -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
-  "$WS_URL")" || fail "request to $WS_URL failed"
+  "$WS_URL" 2>/dev/null || true)"
 [ "$status" = "101" ] || fail "expected 101 Switching Protocols, got HTTP $status"
 echo "     ok — HTTP 101 Switching Protocols"
 

--- a/scripts/verify-proxy.sh
+++ b/scripts/verify-proxy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+# Verify issue #5 acceptance against a running stack (`docker compose up -d`):
+#   1. the app is reachable over HTTPS at $DOMAIN
+#   2. a WebSocket (Socket.IO / WSS) upgrade succeeds through the Caddy proxy
+#
+# Usage:
+#   DOMAIN=manhunt.example.com scripts/verify-proxy.sh
+#   DOMAIN=localhost scripts/verify-proxy.sh      # local: -k trusts Caddy's CA
+#
+# Exits non-zero on the first failed check.
+set -eu
+
+DOMAIN="${DOMAIN:-localhost}"
+BASE="https://${DOMAIN}"
+
+# Caddy's internal CA (localhost/loopback) isn't in the system trust store, so
+# skip verification for local hostnames; verify certs for real domains.
+INSECURE=""
+case "$DOMAIN" in
+  localhost|127.0.0.1|::1|*.localhost) INSECURE="-k" ;;
+esac
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+echo "1/2 HTTPS at ${BASE}/health"
+# shellcheck disable=SC2086
+body="$(curl $INSECURE -fsS --max-time 10 "${BASE}/health")" \
+  || fail "GET ${BASE}/health did not return success over HTTPS"
+case "$body" in
+  *'"ok":true'*) echo "     ok — $body" ;;
+  *) fail "unexpected /health body: $body" ;;
+esac
+
+echo "2/2 WebSocket upgrade through the proxy"
+# Ask the Socket.IO endpoint for a raw WebSocket upgrade and assert Caddy/app
+# answer 101 Switching Protocols (i.e. the upgrade tunnel was established).
+WS_URL="${BASE}/socket.io/?EIO=4&transport=websocket"
+# shellcheck disable=SC2086
+status="$(curl $INSECURE -sS --max-time 10 -o /dev/null -w '%{http_code}' \
+  --http1.1 \
+  -H 'Connection: Upgrade' \
+  -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' \
+  -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  "$WS_URL")" || fail "request to $WS_URL failed"
+[ "$status" = "101" ] || fail "expected 101 Switching Protocols, got HTTP $status"
+echo "     ok — HTTP 101 Switching Protocols"
+
+echo "PASS: HTTPS reachable and WebSocket upgrades succeed through Caddy."

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -9,7 +9,7 @@ import type { Express } from 'express';
 import type { Server } from 'socket.io';
 import request from 'supertest';
 import { io as ioClient } from 'socket.io-client';
-import { createServer } from './app.ts';
+import { createServer, resolveTrustProxy } from './app.ts';
 
 describe('http server', () => {
   // Serve from a throwaway static dir so the tests don't depend on a built
@@ -42,6 +42,40 @@ describe('http server', () => {
   it('does not swallow unknown /api routes with the SPA fallback', async () => {
     const res = await request(app).get('/api/nope');
     expect(res.status).toBe(404);
+  });
+
+  it('trusts the reverse proxy so forwarded HTTPS is honored', async () => {
+    // With `trust proxy` on, Caddy's X-Forwarded-Proto makes req.secure true.
+    expect(app.get('trust proxy')).toBe(1);
+    const res = await request(app)
+      .get('/api/scheme')
+      .set('X-Forwarded-Proto', 'https');
+    // The route is unhandled (404), but reaching it means the forwarded header
+    // was accepted rather than rejected as an untrusted spoof.
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('resolveTrustProxy', () => {
+  it('defaults to trusting a single hop', () => {
+    expect(resolveTrustProxy(undefined)).toBe(1);
+    expect(resolveTrustProxy('')).toBe(1);
+    expect(resolveTrustProxy('  ')).toBe(1);
+  });
+
+  it('parses booleans', () => {
+    expect(resolveTrustProxy('true')).toBe(true);
+    expect(resolveTrustProxy('false')).toBe(false);
+  });
+
+  it('parses a hop count', () => {
+    expect(resolveTrustProxy('0')).toBe(0);
+    expect(resolveTrustProxy('2')).toBe(2);
+  });
+
+  it('passes through named/subnet values', () => {
+    expect(resolveTrustProxy('loopback')).toBe('loopback');
+    expect(resolveTrustProxy('10.0.0.0/8')).toBe('10.0.0.0/8');
   });
 });
 

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type http from 'node:http';
 import type { AddressInfo } from 'node:net';
-import type { Express } from 'express';
+import type { Express, Request, Response } from 'express';
 import type { Server } from 'socket.io';
 import request from 'supertest';
 import { io as ioClient } from 'socket.io-client';
@@ -16,15 +16,24 @@ describe('http server', () => {
   // client or the checked-in preview.
   let staticDir: string;
   let app: Express;
+  let originalTrustProxy: string | undefined;
 
   beforeAll(() => {
+    // Pin the default (single Caddy hop) regardless of the ambient environment.
+    originalTrustProxy = process.env.TRUST_PROXY;
+    delete process.env.TRUST_PROXY;
     staticDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manhunt-static-'));
     fs.writeFileSync(path.join(staticDir, 'index.html'), '<!doctype html><title>shell</title>');
     ({ app } = createServer({ staticDir }));
+    // Observe the resolved scheme behind the trusted proxy. The SPA fallback
+    // calls next() for /api paths, so this route is reached rather than shadowed.
+    app.get('/api/scheme', (req: Request, res: Response) => res.json({ secure: req.secure }));
   });
 
   afterAll(() => {
     fs.rmSync(staticDir, { recursive: true, force: true });
+    if (originalTrustProxy === undefined) delete process.env.TRUST_PROXY;
+    else process.env.TRUST_PROXY = originalTrustProxy;
   });
 
   it('reports healthy at /health', async () => {
@@ -50,9 +59,8 @@ describe('http server', () => {
     const res = await request(app)
       .get('/api/scheme')
       .set('X-Forwarded-Proto', 'https');
-    // The route is unhandled (404), but reaching it means the forwarded header
-    // was accepted rather than rejected as an untrusted spoof.
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ secure: true });
   });
 });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -128,6 +128,30 @@ function visibleTo(
 }
 
 /**
+ * Resolve Express's `trust proxy` setting from `TRUST_PROXY`.
+ *
+ * In production the app runs behind Caddy (see `Caddyfile`), which terminates
+ * TLS and forwards `X-Forwarded-{For,Proto,Host}`. Trusting the proxy makes
+ * `req.secure`, `req.protocol` and `req.ip` reflect the real client and the
+ * HTTPS scheme — needed for secure cookies and correct client addresses.
+ *
+ * Defaults to `1` (trust the single Caddy hop). `TRUST_PROXY` overrides it:
+ * `false`/`0` disables trust, a number sets the hop count, and any other value
+ * (e.g. `loopback`, a subnet, or a comma list) is passed through to Express.
+ */
+export function resolveTrustProxy(
+  raw: string | undefined = process.env.TRUST_PROXY,
+): boolean | number | string {
+  if (raw === undefined || raw.trim() === '') return 1;
+  const value = raw.trim();
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  const n = Number(value);
+  if (Number.isInteger(n) && n >= 0) return n;
+  return value;
+}
+
+/**
  * Build the Express app + HTTP server + Socket.IO instance without starting to
  * listen. Kept separate from `index.ts` so tests can drive it on an ephemeral
  * port and tear it down cleanly.
@@ -137,6 +161,10 @@ export function createServer({
   liveState = createLiveState(),
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
+
+  // Behind the Caddy reverse proxy: trust its forwarded headers so req.secure
+  // (HTTPS), req.protocol and req.ip are accurate. See resolveTrustProxy.
+  app.set('trust proxy', resolveTrustProxy());
 
   // Liveness/readiness probe (used by the load balancer and Docker healthcheck).
   app.get('/health', (_req: Request, res: Response) => res.json({ ok: true }));


### PR DESCRIPTION
Closes #5.

Serve the app over **HTTPS with automatic TLS** and pass **Socket.IO WebSocket (WSS)** upgrades through Caddy. Branched from the issue #4 branch (PR #32) per the repo's stacked-PR convention, so this diff shows only the reverse-proxy work.

> **Base note:** targeted at `claude/manhunt-issue-4-gan99v` (PR #32, issue #4). Retarget to `master` once the #1→#2→#3→#4 stack merges.

## Acceptance criteria

- [x] **App reachable at `$DOMAIN` over HTTPS** — Caddy provisions and renews a certificate for `$DOMAIN` automatically (ACME/Let's Encrypt for a public domain; its own locally-trusted internal CA for `localhost`/loopback), and redirects `:80` → `:443`. The server also now trusts the Caddy hop so `req.secure`/`req.protocol`/`req.ip` are correct behind TLS termination.
- [x] **WebSocket upgrades succeed through the proxy** — `reverse_proxy` upgrades `Upgrade: websocket` requests (Socket.IO over WSS) into a transparent bidirectional tunnel; `flush_interval -1` streams frames without buffering.

## What changed

**`Caddyfile` — hardened reverse proxy.**
- `encode zstd gzip` for text responses (WS frames pass through untouched).
- Security headers: HSTS, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and hides the upstream `Server` header.
- `reverse_proxy app:3000` with `flush_interval -1` and an active `/health` check so Caddy only routes to a healthy app.

**`server/app.ts` — trust the proxy.** New exported `resolveTrustProxy()` reads `TRUST_PROXY` (default `1` = the single Caddy hop; accepts `true`/`false`, a hop count, or a named/subnet value) and the app sets `trust proxy` accordingly, so forwarded HTTPS/IP headers are honored rather than treated as spoofable.

**`compose.yml` — reliable startup ordering.** `db`/`redis` get healthchecks; the `app` waits for them healthy and Caddy waits for a healthy `app` (`condition: service_healthy`), and `TRUST_PROXY` is passed through.

**`scripts/verify-proxy.sh` — acceptance check.** Against a running stack it asserts (1) `GET /health` succeeds over HTTPS and (2) the Socket.IO endpoint answers **`101 Switching Protocols`** to a raw WebSocket upgrade — i.e. both acceptance criteria. Uses `-k` only for `localhost`/loopback (Caddy's internal CA), verifies real certs otherwise.

**Docs.** README gains an **HTTPS & WebSockets (Caddy)** section (incl. local validation via `DOMAIN=localhost`); `.env.example` documents `TRUST_PROXY`.

## Testing

`npm run typecheck`, `npm run lint`, and `npm run test:server` all pass. New unit tests cover `resolveTrustProxy` across its inputs and assert the app's `trust proxy` setting; the existing Socket.IO test already exercises a raw `transports: ['websocket']` upgrade against the app. End-to-end HTTPS/WSS behavior is validated by `scripts/verify-proxy.sh` against a live `docker compose` stack (Caddy needs real ports/DNS, so it isn't run in unit CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNQpyrMixM7cjHQ4cUcz9d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Caddy HTTPS support with automatic redirects, WebSocket-aware proxying, compression, and security hardening headers.
  * Improved proxy behavior with health-checked upstream routing and immediate flush.
  * Added `TRUST_PROXY` configuration and server trust-proxy resolution.

* **Bug Fixes**
  * Services now start only after dependent services and the app’s `/health` endpoint are healthy.

* **Documentation**
  * Extended Quickstart with “HTTPS & WebSockets (Caddy)” setup and validation steps.

* **Tests**
  * Added proxy verification script and new tests for trust-proxy behavior and forwarded HTTPS scheme handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->