### PR TITLE
feat: Lobby — create/join rooms, roles, ready, start

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ Point the server at Redis with `REDIS_URL` (see [`.env.example`](./.env.example)
 broadcaster, so a single instance (and CI, which has no Redis service) runs
 fully — you only need Redis to share hot state across multiple instances.
 
+### Lobby (rooms, roles, ready, start)
+
+Before a match starts, players gather in a **lobby**. The flow is driven over
+the socket and the server is authoritative — every action is answered with an
+ack and the full roster is broadcast to the room as a `lobby_update`:
+
+- **`create_game` `{ name }`** — hosts a new room and acks with the game
+  (including its short **room code**) and the caller's player id. The creator is
+  the host (a hunter).
+- **`join_game` `{ roomCode, name }`** — joins an existing room by code as a
+  hider. Codes are case-insensitive and drawn from an unambiguous alphabet (no
+  `O`/`0`/`I`/`1`).
+- **`set_role` `{ role }`** and **`set_ready` `{ ready }`** — a player picks
+  their own side (`hunter`/`hider`) and readies up.
+- **`start_game`** — **host only**; moves the room to `active` once at least two
+  players have all readied up.
+
+Lobby state is in-process (like the live-position store); a single instance is
+fully functional. Durable `games`/`players` rows in PostgreSQL are written by the
+persistence layer (out of scope for this milestone). See
+[`server/lobby/rooms.ts`](./server/lobby/rooms.ts) and the client
+[`Lobby`](./client/src/lobby/Lobby.tsx).
+
 ## Quickstart (Docker)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ack and the full roster is broadcast to the room as a `lobby_update`:
 - **`start_game`** — **host only**; moves the room to `active` once at least two
   players have all readied up.
 
-Lobby state is in-process (like the live-position store); a single instance is
+Lobby state is in-process; a single instance is
 fully functional. Durable `games`/`players` rows in PostgreSQL are written by the
 persistence layer (out of scope for this milestone). See
 [`server/lobby/rooms.ts`](./server/lobby/rooms.ts) and the client

--- a/client/README.md
+++ b/client/README.md
@@ -23,7 +23,10 @@ you can also run the workspace's own scripts directly (`npm run dev`,
 
 During development the Vite dev server proxies `/socket.io` and `/health` to the
 game server on `:3000`, so run `npm run dev` (the server) alongside it. Override
-the target with `VITE_SERVER_URL`.
+the proxy target with `DEV_PROXY_TARGET` (a Node-only variable — the browser
+always connects same-origin, so this never leaks into the bundle). Set
+`VITE_SERVER_URL` only to point the browser at a genuinely different, reachable
+origin instead of proxying.
 
 ## Layout
 

--- a/client/e2e/lobby.spec.ts
+++ b/client/e2e/lobby.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+import { io, type Socket } from 'socket.io-client';
+
+// Exercises the lobby against the real production server booted by the
+// Playwright webServer (server/index.ts) — same in-process fallback as the
+// other e2e specs, no DB/Redis required.
+const PORT = process.env.E2E_PORT || 3000;
+const url = `http://127.0.0.1:${PORT}`;
+
+interface Player {
+  id: string;
+  name: string;
+  role: 'hunter' | 'hider';
+  ready: boolean;
+  isHost: boolean;
+}
+interface Game {
+  id: string;
+  roomCode: string;
+  status: 'lobby' | 'active' | 'ended';
+  players: Player[];
+}
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+function waitFor<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+test('runs the full lobby lifecycle over the socket', async () => {
+  const host = io(url, { transports: ['websocket'], reconnection: false });
+  const guest = io(url, { transports: ['websocket'], reconnection: false });
+
+  try {
+    await Promise.all([waitFor(host, 'connect'), waitFor(guest, 'connect')]);
+
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('create failed');
+    const { roomCode } = created.game;
+    expect(roomCode).toMatch(/^[A-Z0-9]{4}$/);
+
+    const joined = (await guest.emitWithAck('join_game', { roomCode, name: 'Guest' })) as LobbyAck;
+    expect(joined.ok).toBe(true);
+    if (!joined.ok) throw new Error('join failed');
+    expect(joined.game.players).toHaveLength(2);
+
+    await host.emitWithAck('set_ready', { ready: true });
+    await guest.emitWithAck('set_ready', { ready: true });
+
+    const guestSawStart = waitFor<{ game: Game }>(guest, 'lobby_update');
+    const started = (await host.emitWithAck('start_game', {})) as LobbyAck;
+    expect(started.ok).toBe(true);
+    if (!started.ok) throw new Error('start failed');
+    expect(started.game.status).toBe('active');
+    expect((await guestSawStart).game.status).toBe('active');
+  } finally {
+    host.close();
+    guest.close();
+  }
+});
+
+test('creates a game from the UI and shows the room code', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('status')).toHaveText(/Connected to server/, { timeout: 15_000 });
+
+  await page.getByLabel(/your name/i).fill('Ada');
+  await page.getByRole('button', { name: /create new game/i }).click();
+
+  // The room-code chip shows a 4-character unambiguous code.
+  const code = page.locator('.room-code__value');
+  await expect(code).toHaveText(/^[A-Z0-9]{4}$/, { timeout: 15_000 });
+  await expect(page.getByRole('button', { name: /start game/i })).toBeVisible();
+});

--- a/client/e2e/lobby.spec.ts
+++ b/client/e2e/lobby.spec.ts
@@ -24,8 +24,22 @@ type LobbyAck =
   | { ok: true; game: Game; playerId: string }
   | { ok: false; error: string; code?: string };
 
-function waitFor<T>(socket: Socket, event: string): Promise<T> {
-  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+// Resolve on the first `event` payload that satisfies `predicate` (default: any).
+// Keeps listening past non-matching payloads so an earlier, unrelated broadcast
+// (e.g. a ready-update arriving late) can't be mistaken for the one we await.
+function waitFor<T>(
+  socket: Socket,
+  event: string,
+  predicate: (payload: T) => boolean = () => true,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!predicate(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
 }
 
 test('runs the full lobby lifecycle over the socket', async () => {
@@ -49,7 +63,11 @@ test('runs the full lobby lifecycle over the socket', async () => {
     await host.emitWithAck('set_ready', { ready: true });
     await guest.emitWithAck('set_ready', { ready: true });
 
-    const guestSawStart = waitFor<{ game: Game }>(guest, 'lobby_update');
+    const guestSawStart = waitFor<{ game: Game }>(
+      guest,
+      'lobby_update',
+      ({ game }) => game.status === 'active',
+    );
     const started = (await host.emitWithAck('start_game', {})) as LobbyAck;
     expect(started.ok).toBe(true);
     if (!started.ok) throw new Error('start failed');

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -42,10 +42,11 @@ beforeEach(() => {
 });
 
 describe('<App />', () => {
-  it('renders the Manhunt landing screen', () => {
+  it('renders the Manhunt landing screen with the lobby entry', () => {
     render(<App />);
     expect(screen.getByRole('heading', { name: 'MANHUNT' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /create or join/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /create new game/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/room code/i)).toBeInTheDocument();
   });
 
   it('connects on mount and reflects the connected status', () => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { socket } from './socket.ts';
+import Lobby from './lobby/Lobby.tsx';
 import './App.css';
 
 /**
- * Landing shell for the Manhunt PWA. This is the scaffold entry point — the
- * real lobby / map / game-over screens are tracked in the backlog. It wires up
- * the Socket.IO connection and surfaces its live status so the plumbing is
- * verifiable end to end.
+ * Landing shell for the Manhunt PWA. It wires up the Socket.IO connection,
+ * surfaces its live status, and hosts the {@link Lobby} (create/join a room,
+ * pick a side, ready up, start). The in-game map screen is tracked in the
+ * backlog.
  */
 export default function App() {
   const [connected, setConnected] = useState(socket.connected);
@@ -37,10 +38,7 @@ export default function App() {
       <h1 className="title">MANHUNT</h1>
       <p className="tagline">Real-world GPS hide&nbsp;&amp;&nbsp;seek</p>
 
-      <button className="cta" type="button" disabled>
-        Create or join a game
-      </button>
-      <p className="hint">Lobby coming soon — see the backlog.</p>
+      <Lobby />
 
       <p className="status" role="status">
         <span

--- a/client/src/lobby/Lobby.css
+++ b/client/src/lobby/Lobby.css
@@ -1,0 +1,232 @@
+.lobby-card {
+  width: 100%;
+  max-width: 22rem;
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  text-align: left;
+  background: rgb(255 255 255 / 3%);
+  border: 1px solid rgb(255 255 255 / 8%);
+  border-radius: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.field__label {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.field__input {
+  padding: 0.7rem 0.85rem;
+  font-size: 1rem;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 10px;
+}
+
+.field__input:focus {
+  outline: none;
+  border-color: var(--teal);
+}
+
+.field__input--code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+}
+
+.lobby-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.btn {
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  color: var(--bg);
+  background: var(--red);
+}
+
+.btn--ghost {
+  color: var(--fg);
+  background: transparent;
+  border-color: rgb(255 255 255 / 18%);
+}
+
+.btn--start {
+  color: var(--bg);
+  background: var(--teal);
+}
+
+.lobby-error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--red);
+}
+
+.room-code {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--bg);
+  border-radius: 12px;
+}
+
+.room-code__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--muted);
+}
+
+.room-code__value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 2rem;
+  letter-spacing: 0.3em;
+  text-indent: 0.3em;
+  color: var(--teal);
+}
+
+.roster {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.roster__row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.65rem;
+  background: rgb(255 255 255 / 4%);
+  border-radius: 10px;
+}
+
+.roster__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roster__you {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.roster__host {
+  color: #f5c451;
+}
+
+.role-chip {
+  padding: 0.15rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+
+.role-chip--hunter {
+  color: var(--red);
+  background: rgb(255 66 66 / 15%);
+}
+
+.role-chip--hider {
+  color: var(--teal);
+  background: rgb(36 227 198 / 15%);
+}
+
+.ready-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.ready-dot--on {
+  background: var(--teal);
+  box-shadow: 0 0 8px var(--teal);
+}
+
+.ready-dot--off {
+  background: rgb(255 255 255 / 18%);
+}
+
+.my-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.side-toggle {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.side-toggle__btn {
+  flex: 1;
+  padding: 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.side-toggle__btn--active {
+  color: var(--fg);
+  border-color: var(--teal);
+  background: rgb(36 227 198 / 12%);
+}
+
+.active-title {
+  margin: 0;
+  text-align: center;
+  font-size: 1.5rem;
+}
+
+.lobby-card--active {
+  align-items: center;
+  text-align: center;
+}
+
+.lobby-leave {
+  align-self: center;
+  padding: 0.4rem 0.5rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/client/src/lobby/Lobby.test.tsx
+++ b/client/src/lobby/Lobby.test.tsx
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Socket } from 'socket.io-client';
+import Lobby from './Lobby.tsx';
+import type { Game, LobbyAck } from './types.ts';
+
+/**
+ * A fake Socket.IO client: `emitWithAck` is answered by a per-event responder
+ * the test installs, and `push` lets a test drive an inbound `lobby_update`.
+ */
+function makeFakeSocket() {
+  const handlers: Record<string, Array<(payload: unknown) => void>> = {};
+  let responder: (event: string, payload: unknown) => LobbyAck | Promise<LobbyAck> = () => ({
+    ok: false,
+    error: 'no responder',
+  });
+
+  const emitWithAck = vi.fn((event: string, payload: unknown) =>
+    Promise.resolve(responder(event, payload)),
+  );
+
+  const socket = {
+    on(event: string, cb: (payload: unknown) => void) {
+      (handlers[event] ||= []).push(cb);
+    },
+    off(event: string, cb: (payload: unknown) => void) {
+      handlers[event] = (handlers[event] || []).filter((f) => f !== cb);
+    },
+    emitWithAck,
+  } as unknown as Socket;
+
+  return {
+    socket,
+    emitWithAck,
+    setResponder(fn: typeof responder) {
+      responder = fn;
+    },
+    push(event: string, payload: unknown) {
+      act(() => {
+        (handlers[event] || []).forEach((f) => f(payload));
+      });
+    },
+  };
+}
+
+let fake: ReturnType<typeof makeFakeSocket>;
+
+// Point the lobby hook at our fake socket instead of the real singleton.
+vi.mock('../socket.ts', () => ({
+  get socket() {
+    return fake.socket;
+  },
+  createSocket: () => fake.socket,
+}));
+
+function game(overrides: Partial<Game> = {}): Game {
+  return {
+    id: 'g1',
+    roomCode: 'AB2C',
+    status: 'lobby',
+    players: [{ id: 'p1', name: 'Ada', role: 'hunter', ready: false, isHost: true }],
+    createdAt: '2026-07-21T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fake = makeFakeSocket();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('<Lobby /> — join screen', () => {
+  it('creates a game and shows the room code', async () => {
+    const user = userEvent.setup();
+    fake.setResponder(() => ({ ok: true, game: game(), playerId: 'p1' }));
+    render(<Lobby />);
+
+    await user.type(screen.getByLabelText(/your name/i), 'Ada');
+    await user.click(screen.getByRole('button', { name: /create new game/i }));
+
+    expect(fake.emitWithAck).toHaveBeenCalledWith('create_game', { name: 'Ada' });
+    expect(await screen.findByText('AB2C')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument();
+  });
+
+  it('joins by code and surfaces a bad-code error', async () => {
+    const user = userEvent.setup();
+    fake.setResponder((event) =>
+      event === 'join_game'
+        ? { ok: false, error: 'No room with that code', code: 'game_not_found' }
+        : { ok: false, error: 'x' },
+    );
+    render(<Lobby />);
+
+    await user.type(screen.getByLabelText(/your name/i), 'Bo');
+    await user.type(screen.getByLabelText(/room code/i), 'zzzz');
+    await user.click(screen.getByRole('button', { name: /join game/i }));
+
+    // Code is upper-cased before it leaves the client.
+    expect(fake.emitWithAck).toHaveBeenCalledWith('join_game', { roomCode: 'ZZZZ', name: 'Bo' });
+    expect(await screen.findByRole('alert')).toHaveTextContent(/no room with that code/i);
+  });
+
+  it('disables the create button until a name is entered', async () => {
+    const user = userEvent.setup();
+    render(<Lobby />);
+    const create = screen.getByRole('button', { name: /create new game/i });
+    expect(create).toBeDisabled();
+    await user.type(screen.getByLabelText(/your name/i), 'Ada');
+    expect(create).toBeEnabled();
+  });
+});
+
+describe('<Lobby /> — in the room', () => {
+  async function enterRoom(initial: Game) {
+    const user = userEvent.setup();
+    fake.setResponder(() => ({ ok: true, game: initial, playerId: 'p1' }));
+    render(<Lobby />);
+    await user.type(screen.getByLabelText(/your name/i), 'Ada');
+    await user.click(screen.getByRole('button', { name: /create new game/i }));
+    await screen.findByText(initial.roomCode);
+    return user;
+  }
+
+  it('toggles ready and switches sides via the socket', async () => {
+    const user = await enterRoom(game());
+
+    await user.click(screen.getByRole('button', { name: /i'm ready/i }));
+    expect(fake.emitWithAck).toHaveBeenCalledWith('set_ready', { ready: true });
+
+    await user.click(screen.getByRole('button', { name: 'hider' }));
+    expect(fake.emitWithAck).toHaveBeenCalledWith('set_role', { role: 'hider' });
+  });
+
+  it('keeps the host start button disabled until everyone is ready', async () => {
+    const user = await enterRoom(game());
+    const start = screen.getByRole('button', { name: /start game/i });
+    expect(start).toBeDisabled(); // only one player, not ready
+
+    // A second player joins and both ready up via a broadcast.
+    fake.push('lobby_update', {
+      game: game({
+        players: [
+          { id: 'p1', name: 'Ada', role: 'hunter', ready: true, isHost: true },
+          { id: 'p2', name: 'Bo', role: 'hider', ready: true, isHost: false },
+        ],
+      }),
+    });
+
+    await waitFor(() => expect(start).toBeEnabled());
+
+    await user.click(start);
+    expect(fake.emitWithAck).toHaveBeenCalledWith('start_game', {});
+  });
+
+  it('renders the roster from lobby_update broadcasts', async () => {
+    await enterRoom(game());
+    fake.push('lobby_update', {
+      game: game({
+        players: [
+          { id: 'p1', name: 'Ada', role: 'hunter', ready: false, isHost: true },
+          { id: 'p2', name: 'Bo', role: 'hider', ready: true, isHost: false },
+        ],
+      }),
+    });
+
+    const roster = await screen.findByRole('list', { name: /players/i });
+    expect(within(roster).getByText('Bo')).toBeInTheDocument();
+    expect(within(roster).getByText(/ada/i)).toBeInTheDocument();
+  });
+
+  it('shows a waiting message to non-hosts and the game-on screen when active', async () => {
+    // Enter as a non-host guest.
+    const guest = game({
+      players: [
+        { id: 'p0', name: 'Host', role: 'hunter', ready: true, isHost: true },
+        { id: 'p1', name: 'Ada', role: 'hider', ready: true, isHost: false },
+      ],
+    });
+    await enterRoom(guest);
+    expect(screen.getByText(/waiting for the host/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /start game/i })).not.toBeInTheDocument();
+
+    fake.push('lobby_update', { game: { ...guest, status: 'active' } });
+    expect(await screen.findByText(/game on/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/lobby/Lobby.tsx
+++ b/client/src/lobby/Lobby.tsx
@@ -1,0 +1,253 @@
+import { useState, type FormEvent } from 'react';
+import { useLobby } from './useLobby.ts';
+import type { Game, Player, Role } from './types.ts';
+import './Lobby.css';
+
+const MIN_PLAYERS_TO_START = 2;
+
+/** Mirror of the server's `canStart`: enough players, all readied up. */
+function canStart(game: Game): boolean {
+  return (
+    game.status === 'lobby' &&
+    game.players.length >= MIN_PLAYERS_TO_START &&
+    game.players.every((p) => p.ready)
+  );
+}
+
+/** The create-or-join entry screen. */
+function JoinScreen({
+  onCreate,
+  onJoin,
+  pending,
+  error,
+}: {
+  onCreate: (name: string) => void;
+  onJoin: (roomCode: string, name: string) => void;
+  pending: boolean;
+  error: string | null;
+}) {
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+
+  const trimmedName = name.trim();
+
+  const handleCreate = (e: FormEvent) => {
+    e.preventDefault();
+    if (trimmedName) onCreate(trimmedName);
+  };
+
+  const handleJoin = (e: FormEvent) => {
+    e.preventDefault();
+    if (trimmedName && code.trim()) onJoin(code.trim(), trimmedName);
+  };
+
+  return (
+    <form className="lobby-card" onSubmit={handleJoin}>
+      <label className="field">
+        <span className="field__label">Your name</span>
+        <input
+          className="field__input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Ada"
+          maxLength={24}
+          autoComplete="off"
+          aria-label="Your name"
+        />
+      </label>
+
+      <label className="field">
+        <span className="field__label">Room code</span>
+        <input
+          className="field__input field__input--code"
+          value={code}
+          onChange={(e) => setCode(e.target.value.toUpperCase())}
+          placeholder="ABCD"
+          maxLength={5}
+          autoComplete="off"
+          autoCapitalize="characters"
+          aria-label="Room code"
+        />
+      </label>
+
+      {error ? (
+        <p className="lobby-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="lobby-actions">
+        <button
+          className="btn btn--primary"
+          type="submit"
+          disabled={pending || !trimmedName || !code.trim()}
+        >
+          Join game
+        </button>
+        <button
+          className="btn btn--ghost"
+          type="button"
+          onClick={handleCreate}
+          disabled={pending || !trimmedName}
+        >
+          Create new game
+        </button>
+      </div>
+    </form>
+  );
+}
+
+/** A single row in the lobby roster. */
+function Roster({ players, playerId }: { players: Player[]; playerId: string | null }) {
+  return (
+    <ul className="roster" aria-label="Players">
+      {players.map((p) => (
+        <li key={p.id} className="roster__row">
+          <span className={`role-chip role-chip--${p.role}`}>{p.role}</span>
+          <span className="roster__name">
+            {p.name}
+            {p.id === playerId ? <span className="roster__you"> (you)</span> : null}
+            {p.isHost ? <span className="roster__host" title="Host"> ★</span> : null}
+          </span>
+          <span
+            className={`ready-dot ${p.ready ? 'ready-dot--on' : 'ready-dot--off'}`}
+            aria-label={p.ready ? 'ready' : 'not ready'}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** The in-lobby screen: roster, side picker, ready toggle, host start. */
+function LobbyRoom({
+  game,
+  playerId,
+  error,
+  onSetRole,
+  onSetReady,
+  onStart,
+  onLeave,
+}: {
+  game: Game;
+  playerId: string | null;
+  error: string | null;
+  onSetRole: (role: Role) => void;
+  onSetReady: (ready: boolean) => void;
+  onStart: () => void;
+  onLeave: () => void;
+}) {
+  const me = game.players.find((p) => p.id === playerId);
+  const startable = canStart(game);
+
+  return (
+    <div className="lobby-card">
+      <div className="room-code">
+        <span className="room-code__label">Room code</span>
+        <span className="room-code__value">{game.roomCode}</span>
+      </div>
+
+      <Roster players={game.players} playerId={playerId} />
+
+      {me ? (
+        <div className="my-controls">
+          <div className="side-toggle" role="group" aria-label="Your side">
+            {(['hunter', 'hider'] as const).map((role) => (
+              <button
+                key={role}
+                type="button"
+                className={`side-toggle__btn ${me.role === role ? 'side-toggle__btn--active' : ''}`}
+                aria-pressed={me.role === role}
+                onClick={() => onSetRole(role)}
+              >
+                {role}
+              </button>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            className={`btn ${me.ready ? 'btn--ghost' : 'btn--primary'}`}
+            onClick={() => onSetReady(!me.ready)}
+          >
+            {me.ready ? "I'm not ready" : "I'm ready"}
+          </button>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p className="lobby-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {me?.isHost ? (
+        <button
+          type="button"
+          className="btn btn--start"
+          onClick={onStart}
+          disabled={!startable}
+        >
+          Start game
+        </button>
+      ) : (
+        <p className="hint">Waiting for the host to start…</p>
+      )}
+
+      {me?.isHost && !startable ? (
+        <p className="hint">Everyone must ready up (at least {MIN_PLAYERS_TO_START} players).</p>
+      ) : null}
+
+      <button type="button" className="lobby-leave" onClick={onLeave}>
+        Leave
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The lobby feature: create or join a room, pick a side, ready up, and let the
+ * host start. Once the game goes `active` the map screen takes over (tracked in
+ * the backlog); for now that's a placeholder.
+ */
+export default function Lobby() {
+  const lobby = useLobby();
+  const { game, playerId, error, pending } = lobby;
+
+  if (!game) {
+    return (
+      <JoinScreen
+        onCreate={lobby.createGame}
+        onJoin={lobby.joinGame}
+        pending={pending}
+        error={error}
+      />
+    );
+  }
+
+  if (game.status === 'active') {
+    return (
+      <div className="lobby-card lobby-card--active">
+        <h2 className="active-title">Game on!</h2>
+        <p className="hint">
+          The match has started. The live map is coming next — see the backlog.
+        </p>
+        <button type="button" className="lobby-leave" onClick={lobby.leave}>
+          Leave
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <LobbyRoom
+      game={game}
+      playerId={playerId}
+      error={error}
+      onSetRole={lobby.setRole}
+      onSetReady={lobby.setReady}
+      onStart={lobby.startGame}
+      onLeave={lobby.leave}
+    />
+  );
+}

--- a/client/src/lobby/types.ts
+++ b/client/src/lobby/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Lobby wire types, mirroring the server's `server/lobby/rooms.ts`. The two
+ * workspaces don't share a package, so these are kept in sync by hand — the
+ * shapes are small and change rarely.
+ */
+
+export type Role = 'hunter' | 'hider';
+export type GameStatus = 'lobby' | 'active' | 'ended';
+
+export interface Player {
+  id: string;
+  name: string;
+  role: Role;
+  ready: boolean;
+  isHost: boolean;
+}
+
+export interface Game {
+  id: string;
+  roomCode: string;
+  status: GameStatus;
+  players: Player[];
+  createdAt: string;
+  startedAt?: string;
+}
+
+/** Ack returned by every lobby action. */
+export type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Payload of the server's `lobby_update` broadcast. */
+export interface LobbyUpdate {
+  game: Game;
+}

--- a/client/src/lobby/useLobby.ts
+++ b/client/src/lobby/useLobby.ts
@@ -97,10 +97,13 @@ export function useLobby(socket: Socket = defaultSocket): Lobby {
   const startGame = useCallback(() => act('start_game', {}), [act]);
 
   const leave = useCallback(() => {
+    // Tell the server so it removes us from the room (the socket stays open);
+    // otherwise we'd linger in the roster until the socket actually disconnects.
+    socket.emit('leave_game');
     setGame(null);
     setPlayerId(null);
     setError(null);
-  }, []);
+  }, [socket]);
 
   return { game, playerId, error, pending, createGame, joinGame, setRole, setReady, startGame, leave };
 }

--- a/client/src/lobby/useLobby.ts
+++ b/client/src/lobby/useLobby.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+import { socket as defaultSocket } from '../socket.ts';
+import type { Game, LobbyAck, LobbyUpdate, Role } from './types.ts';
+
+/** The lobby state and actions exposed to the UI. */
+export interface Lobby {
+  /** The room the player is in, or `null` before they create/join one. */
+  game: Game | null;
+  /** The caller's own player id within {@link game}. */
+  playerId: string | null;
+  /** Last action error (e.g. a bad code), cleared on the next action. */
+  error: string | null;
+  /** True while a create/join/start round-trip is in flight. */
+  pending: boolean;
+  createGame(name: string): Promise<void>;
+  joinGame(roomCode: string, name: string): Promise<void>;
+  setRole(role: Role): void;
+  setReady(ready: boolean): void;
+  startGame(): void;
+  /** Leave the current room locally (back to the join screen). */
+  leave(): void;
+}
+
+/**
+ * Drive the lobby over the socket: emit create/join/role/ready/start actions and
+ * keep the local room in sync with the server's `lobby_update` broadcasts. The
+ * server is authoritative — every action's ack, and every broadcast, replaces
+ * the local game wholesale.
+ */
+export function useLobby(socket: Socket = defaultSocket): Lobby {
+  const [game, setGame] = useState<Game | null>(null);
+  const [playerId, setPlayerId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  // Follow the room after we've joined it: the server pushes the full roster on
+  // every change, so we only accept updates for the game we're actually in.
+  useEffect(() => {
+    const onUpdate = ({ game: next }: LobbyUpdate): void => {
+      setGame((current) => (current && current.id === next.id ? next : current));
+    };
+    socket.on('lobby_update', onUpdate);
+    return () => {
+      socket.off('lobby_update', onUpdate);
+    };
+  }, [socket]);
+
+  const enter = useCallback(
+    async (event: 'create_game' | 'join_game', payload: unknown): Promise<void> => {
+      setPending(true);
+      setError(null);
+      try {
+        const ack = (await socket.emitWithAck(event, payload)) as LobbyAck;
+        if (ack.ok) {
+          setGame(ack.game);
+          setPlayerId(ack.playerId);
+        } else {
+          setError(ack.error);
+        }
+      } catch {
+        setError('Could not reach the server. Check your connection.');
+      } finally {
+        setPending(false);
+      }
+    },
+    [socket],
+  );
+
+  const createGame = useCallback(
+    (name: string) => enter('create_game', { name }),
+    [enter],
+  );
+
+  const joinGame = useCallback(
+    (roomCode: string, name: string) => enter('join_game', { roomCode, name }),
+    [enter],
+  );
+
+  // Fire-and-forget actions: the resulting lobby_update refreshes our state, so
+  // we only surface an ack error if one comes back.
+  const act = useCallback(
+    (event: string, payload: unknown): void => {
+      setError(null);
+      void socket
+        .emitWithAck(event, payload)
+        .then((ack: LobbyAck) => {
+          if (!ack.ok) setError(ack.error);
+        })
+        .catch(() => setError('Could not reach the server. Check your connection.'));
+    },
+    [socket],
+  );
+
+  const setRole = useCallback((role: Role) => act('set_role', { role }), [act]);
+  const setReady = useCallback((ready: boolean) => act('set_ready', { ready }), [act]);
+  const startGame = useCallback(() => act('start_game', {}), [act]);
+
+  const leave = useCallback(() => {
+    setGame(null);
+    setPlayerId(null);
+    setError(null);
+  }, []);
+
+  return { game, playerId, error, pending, createGame, joinGame, setRole, setReady, startGame, leave };
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,11 +4,16 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig(({ mode }) => {
-  // Load .env* files so VITE_SERVER_URL set there configures the dev proxy.
+  // Load .env* files so DEV_PROXY_TARGET set there configures the dev proxy.
   const env = loadEnv(mode, process.cwd(), '');
-  // The API/socket server the client talks to during development. An explicit
+  // Where the Vite dev server forwards /socket.io + /health during development.
+  // This is a Node-only value (deliberately NOT VITE_-prefixed) so it is never
+  // inlined into the browser bundle: the browser always talks to the dev server
+  // same-origin and Vite proxies from there. In the Docker dev stack this points
+  // at the `server` service; on a bare host it defaults to localhost. An explicit
   // environment variable (e.g. from Docker Compose) wins over .env files.
-  const SERVER = process.env.VITE_SERVER_URL || env.VITE_SERVER_URL || 'http://localhost:3000';
+  const PROXY_TARGET =
+    process.env.DEV_PROXY_TARGET || env.DEV_PROXY_TARGET || 'http://localhost:3000';
 
   return {
     plugins: [
@@ -48,8 +53,8 @@ export default defineConfig(({ mode }) => {
       // Proxy the Socket.IO endpoint and the health check to the game server so
       // the dev client can reach them same-origin (no CORS, sockets upgrade).
       proxy: {
-        '/socket.io': { target: SERVER, ws: true, changeOrigin: true },
-        '/health': { target: SERVER, changeOrigin: true },
+        '/socket.io': { target: PROXY_TARGET, ws: true, changeOrigin: true },
+        '/health': { target: PROXY_TARGET, changeOrigin: true },
       },
     },
     test: {

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -79,8 +79,11 @@ services:
     # it reachable from the host) reaches Vite instead of the wrapper npm script.
     command: sh -c "npm ci && npm run dev --workspace client -- --host 0.0.0.0"
     environment:
-      # Where Vite proxies /socket.io + /health (the server service on this network).
-      - VITE_SERVER_URL=http://server:3000
+      # Where Vite proxies /socket.io + /health (the server service on this
+      # network). Deliberately NOT VITE_-prefixed so it stays server-side only:
+      # the browser keeps connecting same-origin (to the Vite dev server), which
+      # avoids CORS to an unreachable Docker-internal hostname.
+      - DEV_PROXY_TARGET=http://server:3000
     ports:
       - "5173:5173"
     volumes:

--- a/server/app.lobby.test.ts
+++ b/server/app.lobby.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { once } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import { createServer, type ServerHandle } from './app.ts';
+import {
+  createLocalBroadcaster,
+  createMemoryPositionStore,
+} from './live/index.ts';
+import { createMemoryLobby, type Game } from './lobby/rooms.ts';
+
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Boot the real server on an ephemeral port with in-memory hot state. */
+async function bootServer(): Promise<{ handle: ServerHandle; url: string }> {
+  const handle = createServer({
+    staticDir: path.join(os.tmpdir(), 'nope'),
+    liveState: {
+      store: createMemoryPositionStore(),
+      broadcaster: createLocalBroadcaster(),
+      close: () => Promise.resolve(),
+    },
+    lobby: createMemoryLobby(),
+  });
+  handle.httpServer.listen(0);
+  await once(handle.httpServer, 'listening');
+  const { port } = handle.httpServer.address() as AddressInfo;
+  return { handle, url: `http://127.0.0.1:${port}` };
+}
+
+function connect(url: string): Socket {
+  return ioClient(url, { transports: ['websocket'], reconnection: false });
+}
+
+function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+/** Resolve on the first matching event, ignoring earlier in-flight broadcasts. */
+function waitUntil<T = unknown>(
+  socket: Socket,
+  event: string,
+  match: (payload: T) => boolean,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!match(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+describe('lobby over the socket', () => {
+  let handle: ServerHandle;
+  const clients: Socket[] = [];
+
+  async function open(url: string): Promise<Socket> {
+    const c = connect(url);
+    clients.push(c);
+    await waitFor(c, 'connect');
+    return c;
+  }
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    handle.io.close();
+    handle.httpServer.close();
+    await once(handle.httpServer, 'close');
+    await handle.liveState.close();
+  });
+
+  it('creates a room and returns a join code', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url);
+
+    const ack = (await host.emitWithAck('create_game', { name: 'Ada' })) as LobbyAck;
+    expect(ack.ok).toBe(true);
+    if (!ack.ok) throw new Error('expected create_game to succeed');
+    expect(ack.game.roomCode).toMatch(/^[A-Z0-9]{4}$/);
+    expect(ack.game.players[0]).toMatchObject({ name: 'Ada', isHost: true });
+    // The manager holds the room under the returned id.
+    expect(handle.lobby.get(ack.game.id)?.roomCode).toBe(ack.game.roomCode);
+  });
+
+  it('rejects creating a room without a name', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url);
+
+    const ack = (await host.emitWithAck('create_game', {})) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected failure');
+    expect(ack.code).toBe('name_required');
+  });
+
+  it('runs the full flow: join, assign role, ready, host starts', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url);
+    const guest = await open(booted.url);
+
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    const { roomCode } = created.game;
+
+    // The host is already subscribed, so joining broadcasts a lobby_update to it.
+    const hostSawJoin = waitFor<{ game: Game }>(host, 'lobby_update');
+    const joined = (await guest.emitWithAck('join_game', { roomCode, name: 'Guest' })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+    expect(joined.game.players.map((p) => p.name)).toEqual(['Host', 'Guest']);
+    expect((await hostSawJoin).game.players).toHaveLength(2);
+
+    // Guest switches to hunter; the host sees the update.
+    const hostSawRole = waitFor<{ game: Game }>(host, 'lobby_update');
+    const roled = (await guest.emitWithAck('set_role', { role: 'hunter' })) as LobbyAck;
+    if (!roled.ok) throw new Error('set_role failed');
+    const guestRow = (await hostSawRole).game.players.find((p) => p.name === 'Guest');
+    expect(guestRow?.role).toBe('hunter');
+
+    // Both ready up.
+    await host.emitWithAck('set_ready', { ready: true });
+    await guest.emitWithAck('set_ready', { ready: true });
+
+    // Host starts; everyone in the room is told the game is active.
+    const guestSawStart = waitFor<{ game: Game }>(guest, 'lobby_update');
+    const started = (await host.emitWithAck('start_game', {})) as LobbyAck;
+    expect(started.ok).toBe(true);
+    if (!started.ok) throw new Error('start failed');
+    expect(started.game.status).toBe('active');
+    expect((await guestSawStart).game.status).toBe('active');
+  });
+
+  it('lets only the host start the game', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url);
+    const guest = await open(booted.url);
+
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    await guest.emitWithAck('join_game', { roomCode: created.game.roomCode, name: 'Guest' });
+    await host.emitWithAck('set_ready', { ready: true });
+    await guest.emitWithAck('set_ready', { ready: true });
+
+    const ack = (await guest.emitWithAck('start_game', {})) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected non-host start to fail');
+    expect(ack.code).toBe('not_host');
+    expect(handle.lobby.get(created.game.id)?.status).toBe('lobby');
+  });
+
+  it('drops a player and broadcasts when they disconnect', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url);
+    const guest = await open(booted.url);
+
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    await guest.emitWithAck('join_game', { roomCode: created.game.roomCode, name: 'Guest' });
+
+    // Wait until the host has observed the guest present, so the leave broadcast
+    // (not the earlier join broadcast) is what we assert on.
+    const hostSawLeave = waitUntil<{ game: Game }>(
+      host,
+      'lobby_update',
+      (p) => p.game.players.length === 1,
+    );
+    guest.close();
+    const after = await hostSawLeave;
+    expect(after.game.players.map((p) => p.name)).toEqual(['Host']);
+  });
+});

--- a/server/app.lobby.test.ts
+++ b/server/app.lobby.test.ts
@@ -117,19 +117,28 @@ describe('lobby over the socket', () => {
     expect(joined.game.players.map((p) => p.name)).toEqual(['Host', 'Guest']);
     expect((await hostSawJoin).game.players).toHaveLength(2);
 
-    // Guest switches to hunter; the host sees the update.
-    const hostSawRole = waitFor<{ game: Game }>(host, 'lobby_update');
+    // Guest switches to hunter; the host sees the update. Then back to hider so
+    // both sides are represented — canStart requires a hunter and a hider.
+    const hostSawRole = waitUntil<{ game: Game }>(
+      host,
+      'lobby_update',
+      (p) => p.game.players.find((x) => x.name === 'Guest')?.role === 'hunter',
+    );
     const roled = (await guest.emitWithAck('set_role', { role: 'hunter' })) as LobbyAck;
     if (!roled.ok) throw new Error('set_role failed');
-    const guestRow = (await hostSawRole).game.players.find((p) => p.name === 'Guest');
-    expect(guestRow?.role).toBe('hunter');
+    expect((await hostSawRole).game.players.find((p) => p.name === 'Guest')?.role).toBe('hunter');
+    await guest.emitWithAck('set_role', { role: 'hider' });
 
     // Both ready up.
     await host.emitWithAck('set_ready', { ready: true });
     await guest.emitWithAck('set_ready', { ready: true });
 
     // Host starts; everyone in the room is told the game is active.
-    const guestSawStart = waitFor<{ game: Game }>(guest, 'lobby_update');
+    const guestSawStart = waitUntil<{ game: Game }>(
+      guest,
+      'lobby_update',
+      (p) => p.game.status === 'active',
+    );
     const started = (await host.emitWithAck('start_game', {})) as LobbyAck;
     expect(started.ok).toBe(true);
     if (!started.ok) throw new Error('start failed');
@@ -176,5 +185,49 @@ describe('lobby over the socket', () => {
     guest.close();
     const after = await hostSawLeave;
     expect(after.game.players.map((p) => p.name)).toEqual(['Host']);
+  });
+
+  it('lets a player leave the room without disconnecting the socket', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url);
+    const guest = await open(booted.url);
+
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    await guest.emitWithAck('join_game', { roomCode: created.game.roomCode, name: 'Guest' });
+
+    const hostSawLeave = waitUntil<{ game: Game }>(
+      host,
+      'lobby_update',
+      (p) => p.game.players.length === 1,
+    );
+    const ack = (await guest.emitWithAck('leave_game', {})) as { ok: boolean };
+    expect(ack.ok).toBe(true);
+    expect((await hostSawLeave).game.players.map((p) => p.name)).toEqual(['Host']);
+    // The socket stays open — only the lobby membership was dropped.
+    expect(guest.connected).toBe(true);
+  });
+
+  it('never strands a ghost when one socket moves to another room', async () => {
+    const booted = await bootServer();
+    handle = booted.handle;
+    const host = await open(booted.url); // owns room A
+    const mover = await open(booted.url); // owns room B, then joins A
+
+    const a = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    const b = (await mover.emitWithAck('create_game', { name: 'Mover' })) as LobbyAck;
+    if (!a.ok || !b.ok) throw new Error('create failed');
+
+    const joined = (await mover.emitWithAck('join_game', {
+      roomCode: a.game.roomCode,
+      name: 'Mover',
+    })) as LobbyAck;
+    expect(joined.ok).toBe(true);
+    if (!joined.ok) throw new Error('join failed');
+    expect(joined.game.players.map((p) => p.name)).toEqual(['Host', 'Mover']);
+    // Room B held only the mover, so dropping the stale membership emptied and
+    // removed it — no ghost player left behind.
+    expect(handle.lobby.get(b.game.id)).toBeUndefined();
   });
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -8,7 +8,7 @@ import express, {
   type Response,
   type NextFunction,
 } from 'express';
-import { Server, type DefaultEventsMap } from 'socket.io';
+import { Server, type DefaultEventsMap, type Socket } from 'socket.io';
 import {
   createLiveState,
   type LiveState,
@@ -17,6 +17,13 @@ import {
   type PositionsByPlayer,
   type GameStateMessage,
 } from './live/index.ts';
+import {
+  createMemoryLobby,
+  LobbyError,
+  type Game,
+  type LobbyManager,
+  type Role,
+} from './lobby/rooms.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -42,6 +49,11 @@ export interface CreateServerOptions {
    * inject an explicit in-memory layer for determinism.
    */
   liveState?: LiveState;
+  /**
+   * The lobby (room lifecycle) manager. Defaults to an in-process manager; tests
+   * inject one so they can assert on room state directly.
+   */
+  lobby?: LobbyManager;
 }
 
 export interface ServerHandle {
@@ -49,6 +61,7 @@ export interface ServerHandle {
   httpServer: http.Server;
   io: Server;
   liveState: LiveState;
+  lobby: LobbyManager;
 }
 
 /** Socket.IO room a game's broadcasts are emitted to. */
@@ -151,6 +164,40 @@ export function resolveTrustProxy(
   return value;
 }
 
+/** What we remember about a socket that has created or joined a lobby. */
+interface LobbyMembership {
+  gameId: string;
+  playerId: string;
+}
+
+/** Ack shape for lobby actions: the current game on success, an error code otherwise. */
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Read the membership a `create_game`/`join_game` recorded on the socket. */
+function membershipOf(socket: Socket): LobbyMembership | undefined {
+  return (socket.data as { lobby?: LobbyMembership }).lobby;
+}
+
+/** Run a lobby action, translating a {@link LobbyError} into an ack error. */
+function withLobbyErrors(
+  ack: ((res: LobbyAck) => void) | undefined,
+  run: () => void,
+): void {
+  try {
+    run();
+  } catch (err) {
+    if (err instanceof LobbyError) {
+      ack?.({ ok: false, error: err.message, code: err.code });
+      return;
+    }
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error('lobby action failed:', reason);
+    ack?.({ ok: false, error: 'Something went wrong' });
+  }
+}
+
 /**
  * Build the Express app + HTTP server + Socket.IO instance without starting to
  * listen. Kept separate from `index.ts` so tests can drive it on an ephemeral
@@ -159,6 +206,7 @@ export function resolveTrustProxy(
 export function createServer({
   staticDir = resolveStaticDir(),
   liveState = createLiveState(),
+  lobby = createMemoryLobby(),
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -207,6 +255,11 @@ export function createServer({
     });
   });
 
+  // Push the current roster/status to everyone in a room after any change.
+  const emitLobby = (game: Game): void => {
+    io.to(gameRoom(game.id)).emit('lobby_update', { game });
+  };
+
   // Authoritative game loop. Only the live-state wiring (join room +
   // position_update tick) is implemented here; claim_catch and the rules
   // engine are tracked in the backlog.
@@ -222,6 +275,79 @@ export function createServer({
         socket.join(gameRoom(identity.gameId));
       }
       if (typeof ack === 'function') ack({ ok: Boolean(identity) });
+    });
+
+    // --- Lobby: create/join a room, pick a side, ready up, host starts. ---
+    // Each socket owns at most one lobby membership, remembered in socket.data
+    // so later actions (role/ready/start) don't need the client to echo ids.
+
+    // Host a new room. Acks with the join code (via game.roomCode) and the
+    // caller's player id, then subscribes the socket to the room.
+    socket.on('create_game', (payload: unknown, ack?: (res: LobbyAck) => void) => {
+      withLobbyErrors(ack, () => {
+        const { name } = (payload ?? {}) as { name?: unknown };
+        const { game, player } = lobby.createGame(name);
+        (socket.data as { lobby?: LobbyMembership }).lobby = {
+          gameId: game.id,
+          playerId: player.id,
+        };
+        socket.join(gameRoom(game.id));
+        ack?.({ ok: true, game, playerId: player.id });
+        emitLobby(game);
+      });
+    });
+
+    // Join an existing room by its code as a hider.
+    socket.on('join_game', (payload: unknown, ack?: (res: LobbyAck) => void) => {
+      withLobbyErrors(ack, () => {
+        const { roomCode, name } = (payload ?? {}) as { roomCode?: unknown; name?: unknown };
+        const { game, player } = lobby.joinGame(roomCode, name);
+        (socket.data as { lobby?: LobbyMembership }).lobby = {
+          gameId: game.id,
+          playerId: player.id,
+        };
+        socket.join(gameRoom(game.id));
+        ack?.({ ok: true, game, playerId: player.id });
+        emitLobby(game);
+      });
+    });
+
+    // Switch the caller's own side (hunter/hider).
+    socket.on('set_role', (payload: unknown, ack?: (res: LobbyAck) => void) => {
+      withLobbyErrors(ack, () => {
+        const membership = membershipOf(socket);
+        if (!membership) throw new LobbyError('player_not_found', 'Not in a game');
+        const { role } = (payload ?? {}) as { role?: unknown };
+        if (role !== 'hunter' && role !== 'hider') {
+          throw new LobbyError('player_not_found', 'Unknown role');
+        }
+        const game = lobby.setRole(membership.gameId, membership.playerId, role as Role);
+        ack?.({ ok: true, game, playerId: membership.playerId });
+        emitLobby(game);
+      });
+    });
+
+    // Toggle the caller's ready flag.
+    socket.on('set_ready', (payload: unknown, ack?: (res: LobbyAck) => void) => {
+      withLobbyErrors(ack, () => {
+        const membership = membershipOf(socket);
+        if (!membership) throw new LobbyError('player_not_found', 'Not in a game');
+        const { ready } = (payload ?? {}) as { ready?: unknown };
+        const game = lobby.setReady(membership.gameId, membership.playerId, Boolean(ready));
+        ack?.({ ok: true, game, playerId: membership.playerId });
+        emitLobby(game);
+      });
+    });
+
+    // Host-only: start the match once everyone is ready.
+    socket.on('start_game', (_payload: unknown, ack?: (res: LobbyAck) => void) => {
+      withLobbyErrors(ack, () => {
+        const membership = membershipOf(socket);
+        if (!membership) throw new LobbyError('player_not_found', 'Not in a game');
+        const game = lobby.startGame(membership.gameId, membership.playerId);
+        ack?.({ ok: true, game, playerId: membership.playerId });
+        emitLobby(game);
+      });
     });
 
     // One tick: a client reports its coordinates. The server trusts the socket's
@@ -248,8 +374,15 @@ export function createServer({
       }
     });
 
-    socket.on('disconnect', () => console.log(`socket disconnected: ${socket.id}`));
+    socket.on('disconnect', () => {
+      console.log(`socket disconnected: ${socket.id}`);
+      // Drop the player from their lobby; if the room survives, tell the rest.
+      const membership = membershipOf(socket);
+      if (!membership) return;
+      const game = lobby.removePlayer(membership.gameId, membership.playerId);
+      if (game) emitLobby(game);
+    });
   });
 
-  return { app, httpServer, io, liveState };
+  return { app, httpServer, io, liveState, lobby };
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -260,6 +260,20 @@ export function createServer({
     io.to(gameRoom(game.id)).emit('lobby_update', { game });
   };
 
+  // Remove a socket from whatever lobby it currently holds: drop the player
+  // server-side, leave the socket room, clear the membership, and broadcast the
+  // updated roster if the room survives. A no-op when the socket isn't in a room.
+  // Shared by leave_game, disconnect, and the create/join guard so a socket can
+  // never linger in two rooms (which would leave a ghost player behind).
+  const leaveCurrentLobby = (socket: Socket): void => {
+    const membership = membershipOf(socket);
+    if (!membership) return;
+    const game = lobby.removePlayer(membership.gameId, membership.playerId);
+    socket.leave(gameRoom(membership.gameId));
+    delete (socket.data as { lobby?: LobbyMembership }).lobby;
+    if (game) emitLobby(game);
+  };
+
   // Authoritative game loop. Only the live-state wiring (join room +
   // position_update tick) is implemented here; claim_catch and the rules
   // engine are tracked in the backlog.
@@ -285,6 +299,10 @@ export function createServer({
     // caller's player id, then subscribes the socket to the room.
     socket.on('create_game', (payload: unknown, ack?: (res: LobbyAck) => void) => {
       withLobbyErrors(ack, () => {
+        // Never let one socket hold two rooms — drop any prior membership first
+        // (double-submit, reconnect race, a client that didn't leave) so it can't
+        // strand a ghost player in the old room.
+        leaveCurrentLobby(socket);
         const { name } = (payload ?? {}) as { name?: unknown };
         const { game, player } = lobby.createGame(name);
         (socket.data as { lobby?: LobbyMembership }).lobby = {
@@ -300,6 +318,9 @@ export function createServer({
     // Join an existing room by its code as a hider.
     socket.on('join_game', (payload: unknown, ack?: (res: LobbyAck) => void) => {
       withLobbyErrors(ack, () => {
+        // Drop any prior membership first (see create_game) so joining a room
+        // never leaves a ghost behind in the one this socket was already in.
+        leaveCurrentLobby(socket);
         const { roomCode, name } = (payload ?? {}) as { roomCode?: unknown; name?: unknown };
         const { game, player } = lobby.joinGame(roomCode, name);
         (socket.data as { lobby?: LobbyMembership }).lobby = {
@@ -350,6 +371,13 @@ export function createServer({
       });
     });
 
+    // Leave the current room without disconnecting the socket. The server drops
+    // the player and tells the rest of the room, mirroring disconnect cleanup.
+    socket.on('leave_game', (_payload: unknown, ack?: (res: { ok: boolean }) => void) => {
+      leaveCurrentLobby(socket);
+      ack?.({ ok: true });
+    });
+
     // One tick: a client reports its coordinates. The server trusts the socket's
     // bound identity (not the payload) for who/which game, throttles to the tick
     // cadence, writes to the hot store, and publishes for cross-instance fan-out.
@@ -377,10 +405,7 @@ export function createServer({
     socket.on('disconnect', () => {
       console.log(`socket disconnected: ${socket.id}`);
       // Drop the player from their lobby; if the room survives, tell the rest.
-      const membership = membershipOf(socket);
-      if (!membership) return;
-      const game = lobby.removePlayer(membership.gameId, membership.playerId);
-      if (game) emitLobby(game);
+      leaveCurrentLobby(socket);
     });
   });
 

--- a/server/lobby/rooms.test.ts
+++ b/server/lobby/rooms.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canStart,
+  createMemoryLobby,
+  LobbyError,
+  MAX_NAME_LENGTH,
+  normalizeRoomCode,
+  ROOM_CODE_ALPHABET,
+  ROOM_CODE_LENGTH,
+} from './rooms.ts';
+
+describe('createMemoryLobby', () => {
+  it('creates a room with an unambiguous code and a host', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Ada');
+
+    expect(game.status).toBe('lobby');
+    expect(game.roomCode).toHaveLength(ROOM_CODE_LENGTH);
+    expect([...game.roomCode]).toEqual(
+      [...game.roomCode].filter((c) => ROOM_CODE_ALPHABET.includes(c)),
+    );
+    expect(game.players).toHaveLength(1);
+    expect(player).toMatchObject({ name: 'Ada', role: 'hunter', ready: false, isHost: true });
+    expect(lobby.getByCode(game.roomCode)?.id).toBe(game.id);
+  });
+
+  it('mints distinct codes for distinct rooms', () => {
+    const lobby = createMemoryLobby();
+    const codes = new Set<string>();
+    for (let i = 0; i < 50; i += 1) codes.add(lobby.createGame(`p${i}`).game.roomCode);
+    expect(codes.size).toBe(50);
+  });
+
+  it('rejects a blank host name', () => {
+    const lobby = createMemoryLobby();
+    expect(() => lobby.createGame('   ')).toThrow(LobbyError);
+    expect(() => lobby.createGame(undefined)).toThrow(/name is required/i);
+  });
+
+  it('trims and caps long names', () => {
+    const lobby = createMemoryLobby();
+    const { player } = lobby.createGame(`  ${'x'.repeat(100)}  `);
+    expect(player.name).toHaveLength(MAX_NAME_LENGTH);
+  });
+
+  it('joins by code (case-insensitively) as a hider', () => {
+    const lobby = createMemoryLobby();
+    const { game } = lobby.createGame('Host');
+
+    const joined = lobby.joinGame(` ${game.roomCode.toLowerCase()} `, 'Bo');
+    expect(joined.player).toMatchObject({ name: 'Bo', role: 'hider', isHost: false });
+    expect(joined.game.id).toBe(game.id);
+    expect(joined.game.players).toHaveLength(2);
+  });
+
+  it('rejects joining an unknown code', () => {
+    const lobby = createMemoryLobby();
+    expect(() => lobby.joinGame('ZZZZ', 'Bo')).toThrow(/no room/i);
+  });
+
+  it('rejects joining a game that already started', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    const other = lobby.joinGame(game.roomCode, 'Bo');
+    lobby.setReady(game.id, player.id, true);
+    lobby.setReady(game.id, other.player.id, true);
+    lobby.startGame(game.id, player.id);
+
+    expect(() => lobby.joinGame(game.roomCode, 'Late')).toThrow(/already started/i);
+  });
+
+  it('lets a player switch sides', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    lobby.setRole(game.id, player.id, 'hider');
+    expect(lobby.get(game.id)?.players[0]?.role).toBe('hider');
+  });
+
+  it('tracks ready state', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    lobby.setReady(game.id, player.id, true);
+    expect(lobby.get(game.id)?.players[0]?.ready).toBe(true);
+    lobby.setReady(game.id, player.id, false);
+    expect(lobby.get(game.id)?.players[0]?.ready).toBe(false);
+  });
+
+  it('throws for actions on a missing game or player', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    expect(() => lobby.setReady('nope', player.id, true)).toThrow(/not found/i);
+    expect(() => lobby.setRole(game.id, 'ghost', 'hunter')).toThrow(/not found/i);
+  });
+});
+
+describe('starting a game', () => {
+  function readyRoom() {
+    const lobby = createMemoryLobby();
+    const { game, player: host } = lobby.createGame('Host');
+    const { player: guest } = lobby.joinGame(game.roomCode, 'Guest');
+    lobby.setReady(game.id, host.id, true);
+    lobby.setReady(game.id, guest.id, true);
+    return { lobby, game, host, guest };
+  }
+
+  it('lets the host start once everyone is ready', () => {
+    const { lobby, game, host } = readyRoom();
+    const started = lobby.startGame(game.id, host.id);
+    expect(started.status).toBe('active');
+    expect(started.startedAt).toBeTypeOf('string');
+  });
+
+  it('refuses a non-host', () => {
+    const { lobby, game, guest } = readyRoom();
+    expect(() => lobby.startGame(game.id, guest.id)).toThrow(/only the host/i);
+  });
+
+  it('refuses to start with a lone or unready player', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    lobby.setReady(game.id, player.id, true);
+    expect(() => lobby.startGame(game.id, player.id)).toThrow(LobbyError); // only one player
+
+    const { player: guest } = lobby.joinGame(game.roomCode, 'Guest'); // guest not ready
+    expect(() => lobby.startGame(game.id, player.id)).toThrow(/readied up/i);
+    expect(guest.ready).toBe(false);
+  });
+
+  it('cannot start twice', () => {
+    const { lobby, game, host } = readyRoom();
+    lobby.startGame(game.id, host.id);
+    expect(() => lobby.startGame(game.id, host.id)).toThrow(/already started/i);
+  });
+
+  it('reports startability with canStart', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    expect(canStart(game)).toBe(false); // one player
+    const { player: guest } = lobby.joinGame(game.roomCode, 'Guest');
+    expect(canStart(game)).toBe(false); // nobody ready
+    lobby.setReady(game.id, player.id, true);
+    lobby.setReady(game.id, guest.id, true);
+    expect(canStart(game)).toBe(true);
+  });
+});
+
+describe('removePlayer', () => {
+  it('deletes the room and frees the code when the last player leaves', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Solo');
+    expect(lobby.removePlayer(game.id, player.id)).toBeUndefined();
+    expect(lobby.get(game.id)).toBeUndefined();
+    expect(lobby.getByCode(game.roomCode)).toBeUndefined();
+  });
+
+  it('promotes a new host when the host leaves', () => {
+    const lobby = createMemoryLobby();
+    const { game, player: host } = lobby.createGame('Host');
+    const { player: guest } = lobby.joinGame(game.roomCode, 'Guest');
+
+    const after = lobby.removePlayer(game.id, host.id);
+    expect(after?.players).toHaveLength(1);
+    expect(after?.players[0]?.id).toBe(guest.id);
+    expect(after?.players[0]?.isHost).toBe(true);
+  });
+
+  it('is a no-op for an unknown game', () => {
+    const lobby = createMemoryLobby();
+    expect(lobby.removePlayer('nope', 'nobody')).toBeUndefined();
+  });
+});
+
+describe('normalizeRoomCode', () => {
+  it('upper-cases and trims strings, and tolerates non-strings', () => {
+    expect(normalizeRoomCode(' ab2c ')).toBe('AB2C');
+    expect(normalizeRoomCode(42)).toBe('');
+    expect(normalizeRoomCode(undefined)).toBe('');
+  });
+});

--- a/server/lobby/rooms.test.ts
+++ b/server/lobby/rooms.test.ts
@@ -142,6 +142,14 @@ describe('starting a game', () => {
     lobby.setReady(game.id, guest.id, true);
     expect(canStart(game)).toBe(true);
   });
+
+  it('refuses a one-sided room (all hunters or all hiders)', () => {
+    const { lobby, game, host, guest } = readyRoom();
+    // Both readied up, but the guest flips to hunter — no hider, not playable.
+    lobby.setRole(game.id, guest.id, 'hunter');
+    expect(canStart(game)).toBe(false);
+    expect(() => lobby.startGame(game.id, host.id)).toThrow(/hunter and a hider/i);
+  });
 });
 
 describe('removePlayer', () => {

--- a/server/lobby/rooms.ts
+++ b/server/lobby/rooms.ts
@@ -1,0 +1,271 @@
+/**
+ * The lobby manager: room lifecycle for the pre-game screen — create a room
+ * (returning a short join code), join by code, assign hunter/hider roles,
+ * ready-up, and let the host start the match.
+ *
+ * This is ephemeral hot state, like the live-position store (see
+ * `server/live/positions.ts`): a lobby only matters while players are gathering.
+ * It is kept in-process here; durable game/player rows in PostgreSQL (see
+ * docs/arc42.md §5) are written by the persistence layer, which is out of scope
+ * for this milestone.
+ */
+import { randomInt, randomUUID } from 'node:crypto';
+
+/** Which side a player is on. */
+export type Role = 'hunter' | 'hider';
+
+/** Lifecycle of a game, mirroring the `games.status` column. */
+export type GameStatus = 'lobby' | 'active' | 'ended';
+
+/** A participant in a lobby. */
+export interface Player {
+  id: string;
+  name: string;
+  role: Role;
+  /** Whether the player has readied up. */
+  ready: boolean;
+  /** The host created the room and is the only one who may start it. */
+  isHost: boolean;
+}
+
+/** A room and everyone in it. */
+export interface Game {
+  id: string;
+  /** Short human-typed join code (see {@link ROOM_CODE_ALPHABET}). */
+  roomCode: string;
+  status: GameStatus;
+  players: Player[];
+  createdAt: string;
+  startedAt?: string;
+}
+
+/** Error codes surfaced to the client so it can show a specific message. */
+export type LobbyErrorCode =
+  | 'name_required'
+  | 'game_not_found'
+  | 'player_not_found'
+  | 'not_host'
+  | 'already_started'
+  | 'not_ready';
+
+/** A recoverable lobby-operation failure, translated to a socket ack error. */
+export class LobbyError extends Error {
+  readonly code: LobbyErrorCode;
+
+  constructor(code: LobbyErrorCode, message: string) {
+    super(message);
+    this.name = 'LobbyError';
+    this.code = code;
+  }
+}
+
+/**
+ * Unambiguous room-code alphabet: uppercase letters and digits with the
+ * lookalike characters removed (`I`, `O`, `0`, `1`), so a code read aloud or
+ * typed on a phone is hard to get wrong.
+ */
+export const ROOM_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+export const ROOM_CODE_LENGTH = 4;
+
+/** Longest accepted display name, to keep the roster tidy and bound payloads. */
+export const MAX_NAME_LENGTH = 24;
+
+/** Minimum players before a match can start (at least a hunter and a hider). */
+export const MIN_PLAYERS_TO_START = 2;
+
+function randomCode(length: number): string {
+  let code = '';
+  for (let i = 0; i < length; i += 1) {
+    code += ROOM_CODE_ALPHABET[randomInt(ROOM_CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+/** Trim and validate a display name, throwing {@link LobbyError} if empty. */
+function cleanName(raw: unknown): string {
+  const name = typeof raw === 'string' ? raw.trim() : '';
+  if (!name) throw new LobbyError('name_required', 'A name is required');
+  return name.slice(0, MAX_NAME_LENGTH);
+}
+
+/** Normalize a typed join code (case- and whitespace-insensitive). */
+export function normalizeRoomCode(raw: unknown): string {
+  return typeof raw === 'string' ? raw.trim().toUpperCase() : '';
+}
+
+/**
+ * A match can start once at least {@link MIN_PLAYERS_TO_START} players have all
+ * readied up. Exposed so the client can enable the host's start button with the
+ * same rule the server enforces.
+ */
+export function canStart(game: Game): boolean {
+  return (
+    game.status === 'lobby' &&
+    game.players.length >= MIN_PLAYERS_TO_START &&
+    game.players.every((p) => p.ready)
+  );
+}
+
+/** Reads and mutates in-progress lobbies. All lookups are by opaque id. */
+export interface LobbyManager {
+  /** Create a room; the creator becomes the host (a hunter, not yet ready). */
+  createGame(hostName: unknown): { game: Game; player: Player };
+  /** Join an existing room by code as a hider. */
+  joinGame(roomCode: unknown, name: unknown): { game: Game; player: Player };
+  /** Switch a player's own side. */
+  setRole(gameId: string, playerId: string, role: Role): Game;
+  /** Toggle a player's ready flag. */
+  setReady(gameId: string, playerId: string, ready: boolean): Game;
+  /** Host-only: move the room from `lobby` to `active`. */
+  startGame(gameId: string, playerId: string): Game;
+  /**
+   * Remove a player (e.g. on disconnect). Reassigns the host and deletes the
+   * room once empty. Returns the updated game, or `undefined` if it's now gone.
+   */
+  removePlayer(gameId: string, playerId: string): Game | undefined;
+  get(gameId: string): Game | undefined;
+  getByCode(roomCode: unknown): Game | undefined;
+}
+
+/**
+ * In-process lobby manager. A single instance is fully functional; a
+ * multi-instance deployment would back this with Redis, mirroring the split in
+ * `server/live/` — that isn't needed until the game is horizontally scaled.
+ */
+export function createMemoryLobby(): LobbyManager {
+  const games = new Map<string, Game>();
+  const codes = new Map<string, string>(); // roomCode -> gameId
+
+  function uniqueCode(): string {
+    // Collisions are vanishingly rare at this scale; retry a bounded number of
+    // times, then widen the code so we never loop forever.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const code = randomCode(ROOM_CODE_LENGTH);
+      if (!codes.has(code)) return code;
+    }
+    let code: string;
+    do {
+      code = randomCode(ROOM_CODE_LENGTH + 1);
+    } while (codes.has(code));
+    return code;
+  }
+
+  function getGameOrThrow(gameId: string): Game {
+    const game = games.get(gameId);
+    if (!game) throw new LobbyError('game_not_found', 'Game not found');
+    return game;
+  }
+
+  function requirePlayer(game: Game, playerId: string): Player {
+    const player = game.players.find((p) => p.id === playerId);
+    if (!player) throw new LobbyError('player_not_found', 'Player not found');
+    return player;
+  }
+
+  return {
+    createGame(hostName) {
+      const name = cleanName(hostName);
+      const game: Game = {
+        id: randomUUID(),
+        roomCode: uniqueCode(),
+        status: 'lobby',
+        players: [],
+        createdAt: new Date().toISOString(),
+      };
+      const player: Player = {
+        id: randomUUID(),
+        name,
+        role: 'hunter',
+        ready: false,
+        isHost: true,
+      };
+      game.players.push(player);
+      games.set(game.id, game);
+      codes.set(game.roomCode, game.id);
+      return { game, player };
+    },
+
+    joinGame(roomCode, name) {
+      const gameId = codes.get(normalizeRoomCode(roomCode));
+      const game = gameId ? games.get(gameId) : undefined;
+      if (!game) throw new LobbyError('game_not_found', 'No room with that code');
+      if (game.status !== 'lobby') {
+        throw new LobbyError('already_started', 'That game has already started');
+      }
+      const player: Player = {
+        id: randomUUID(),
+        name: cleanName(name),
+        role: 'hider',
+        ready: false,
+        isHost: false,
+      };
+      game.players.push(player);
+      return { game, player };
+    },
+
+    setRole(gameId, playerId, role) {
+      const game = getGameOrThrow(gameId);
+      if (game.status !== 'lobby') {
+        throw new LobbyError('already_started', 'The game has already started');
+      }
+      const player = requirePlayer(game, playerId);
+      player.role = role;
+      return game;
+    },
+
+    setReady(gameId, playerId, ready) {
+      const game = getGameOrThrow(gameId);
+      if (game.status !== 'lobby') {
+        throw new LobbyError('already_started', 'The game has already started');
+      }
+      requirePlayer(game, playerId).ready = ready;
+      return game;
+    },
+
+    startGame(gameId, playerId) {
+      const game = getGameOrThrow(gameId);
+      const player = requirePlayer(game, playerId);
+      if (!player.isHost) {
+        throw new LobbyError('not_host', 'Only the host can start the game');
+      }
+      if (game.status !== 'lobby') {
+        throw new LobbyError('already_started', 'The game has already started');
+      }
+      if (!canStart(game)) {
+        throw new LobbyError(
+          'not_ready',
+          `Need at least ${MIN_PLAYERS_TO_START} players, all readied up`,
+        );
+      }
+      game.status = 'active';
+      game.startedAt = new Date().toISOString();
+      return game;
+    },
+
+    removePlayer(gameId, playerId) {
+      const game = games.get(gameId);
+      if (!game) return undefined;
+      const wasHost = game.players.find((p) => p.id === playerId)?.isHost;
+      game.players = game.players.filter((p) => p.id !== playerId);
+      if (game.players.length === 0) {
+        games.delete(game.id);
+        codes.delete(game.roomCode);
+        return undefined;
+      }
+      // Hand the room to the next-longest-present player so it always has a host.
+      if (wasHost && !game.players.some((p) => p.isHost)) {
+        game.players[0]!.isHost = true;
+      }
+      return game;
+    },
+
+    get(gameId) {
+      return games.get(gameId);
+    },
+
+    getByCode(roomCode) {
+      const gameId = codes.get(normalizeRoomCode(roomCode));
+      return gameId ? games.get(gameId) : undefined;
+    },
+  };
+}

--- a/server/lobby/rooms.ts
+++ b/server/lobby/rooms.ts
@@ -95,14 +95,17 @@ export function normalizeRoomCode(raw: unknown): string {
 
 /**
  * A match can start once at least {@link MIN_PLAYERS_TO_START} players have all
- * readied up. Exposed so the client can enable the host's start button with the
- * same rule the server enforces.
+ * readied up AND both sides are represented (at least one hunter and one hider)
+ * — an all-hunter or all-hider room is not a playable game. Exposed so the client
+ * can enable the host's start button with the same rule the server enforces.
  */
 export function canStart(game: Game): boolean {
   return (
     game.status === 'lobby' &&
     game.players.length >= MIN_PLAYERS_TO_START &&
-    game.players.every((p) => p.ready)
+    game.players.every((p) => p.ready) &&
+    game.players.some((p) => p.role === 'hunter') &&
+    game.players.some((p) => p.role === 'hider')
   );
 }
 
@@ -234,7 +237,7 @@ export function createMemoryLobby(): LobbyManager {
       if (!canStart(game)) {
         throw new LobbyError(
           'not_ready',
-          `Need at least ${MIN_PLAYERS_TO_START} players, all readied up`,
+          `Need at least ${MIN_PLAYERS_TO_START} players — a hunter and a hider — all readied up`,
         );
       }
       game.status = 'active';


### PR DESCRIPTION
Closes #6.

Implements the pre-game **lobby**: create a room with a join code, join by code, assign hunter/hider, ready up, and let the host start. Branched from the issue #5 branch (PR #33) per the repo's stacked-PR convention, so this diff shows only the lobby work.

> **Base note:** targeted at `claude/session-vv6ukn` (PR #33, issue #5). Retarget to `master` once the #1→…→#5 stack merges.

## Acceptance criteria

- [x] **Create game returns a room code** — `create_game` mints a room with a short, unambiguous 4-character join code (alphabet excludes `O`/`0`/`I`/`1`) and acks it back with the caller's player id.
- [x] **Join by code** — `join_game` looks up a room by code (case- and whitespace-insensitive) and rejects unknown or already-started rooms.
- [x] **Assign hunter/hider** — `set_role` lets a player switch their own side; the host defaults to hunter, joiners to hider.
- [x] **Ready-up** — `set_ready` toggles per-player readiness.
- [x] **Host starts** — `start_game` is **host-only** and gated on at least two players having all readied up; the room moves to `active`.

## What changed

**`server/lobby/rooms.ts` — in-process lobby manager.** Room lifecycle as ephemeral hot state, mirroring the live-position store (`server/live/`): create/join, role and ready mutations, and a `canStart`-gated host start. Recoverable failures are typed `LobbyError`s (`name_required`, `game_not_found`, `not_host`, `already_started`, …). When a player leaves, the host is reassigned and empty rooms are freed. Durable `games`/`players` rows in PostgreSQL are left to the persistence layer (out of scope for this milestone).

**`server/app.ts` — socket wiring.** `create_game`, `join_game`, `set_role`, `set_ready`, and `start_game`, each answered with an ack (the current game on success; `{ ok: false, error, code }` on failure). Every change broadcasts the full roster as `lobby_update` to the game's room. Each socket owns one membership (remembered in `socket.data`), so role/ready/start don't need the client to echo ids; disconnects drop the player and re-broadcast. `ServerHandle` now exposes the `lobby` manager for tests.

**Client — `client/src/lobby/`.** A `useLobby` hook drives the flow over the socket and keeps the room in sync with `lobby_update` broadcasts (the server is authoritative — every ack/broadcast replaces the local game wholesale). The `Lobby` component renders a create/join screen, a roster with role chips and ready state, a side picker, a ready toggle, and a host start button that mirrors the server's start rule. Wired into `App`, replacing the placeholder CTA.

**Docs.** README gains a **Lobby (rooms, roles, ready, start)** section documenting the socket contract.

## Testing

- **Server unit** (`server/lobby/rooms.test.ts`) — code generation/uniqueness, join by code, role/ready, start permissions and gating, host reassignment, room cleanup.
- **Server integration** (`server/app.lobby.test.ts`) — the full flow over real Socket.IO clients: create → join → role → ready → start, host-only start, and disconnect drop/broadcast.
- **Client** (`Lobby.test.tsx`) — create/join, bad-code error, ready/role emits, start-button gating, and roster from broadcasts.
- **E2E** (`client/e2e/lobby.spec.ts`) — the socket lifecycle end to end against the real production server, plus a UI create-game flow.

`npm run typecheck`, `npm run lint` (js/css/md), `npm test`, and `npm run test:e2e` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeuxJx6BHCQoCakBv7TstZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete multiplayer lobby flow: create/join rooms, choose roles, toggle readiness, view the roster, and host-only game start with readiness gating and active/leave transitions.
* **Documentation**
  * Updated the README with the end-to-end lobby behavior, room code rules, and detailed action/ack expectations, plus refreshed client development notes.
* **Tests**
  * Added/expanded automated coverage for server and UI lobby behavior, including full end-to-end socket lifecycles and disconnect/leave handling.
* **Chores**
  * Updated local development proxy settings to use a dedicated proxy target configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->