### PR TITLE
feat(client): GPS capture (watchPosition throttle + Wake Lock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,26 @@ persistence layer (out of scope for this milestone). See
 [`server/lobby/rooms.ts`](./server/lobby/rooms.ts) and the client
 [`Lobby`](./client/src/lobby/Lobby.tsx).
 
+### Client GPS capture (watchPosition + Wake Lock)
+
+Once a match goes `active`, the client starts capturing the device location and
+streaming it to the server. This lives in the client `gps/` hooks and is driven
+by the [`ActiveGame`](./client/src/game/ActiveGame.tsx) screen:
+
+- **`useGpsCapture`** watches the device with `navigator.geolocation.watchPosition`
+  (high accuracy) and **throttles emission to the fixed 5–10s cadence** — the
+  browser can report fixes far faster, so the hook holds the newest fix and
+  flushes one per cadence (the first goes out immediately). A denied permission
+  is a terminal status; a lost signal is transient and the watch recovers.
+- **`useWakeLock`** holds a **Screen Wake Lock** so the phone keeps tracking with
+  the screen on, re-acquiring it whenever the page returns to the foreground.
+  The API is best-effort: **if the request is denied** (no support, a blocking
+  permissions policy, low battery) **tracking carries on without it** and the UI
+  hints to keep the screen on — it never blocks the game.
+- **`useTracking`** ties the two together and emits a
+  [`position_update`](#websocket-message-contract) for each captured fix. The
+  server is authoritative and stamps its own `recordedAt`.
+
 ## Quickstart (Docker)
 
 ```bash

--- a/client/e2e/gps.spec.ts
+++ b/client/e2e/gps.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test';
+import { io, type Socket } from 'socket.io-client';
+
+// Exercises the real client GPS capture end to end: a browser host reaches an
+// active game, `watchPosition` fires (Playwright feeds it a fixed location), and
+// the resulting `position_update` fans out to a second player as `game_state` —
+// the same in-process fallback the other specs use, no DB/Redis required.
+const PORT = process.env.E2E_PORT || 3000;
+const url = `http://127.0.0.1:${PORT}`;
+
+interface Player {
+  id: string;
+  name: string;
+  role: 'hunter' | 'hider';
+  ready: boolean;
+  isHost: boolean;
+}
+interface Game {
+  id: string;
+  roomCode: string;
+  status: 'lobby' | 'active' | 'ended';
+  players: Player[];
+}
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+interface GameState {
+  gameId: string;
+  positions: Record<string, { lat: number; lng: number; recordedAt: string }>;
+}
+
+function waitFor<T>(
+  socket: Socket,
+  event: string,
+  predicate: (payload: T) => boolean = () => true,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!predicate(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+// The browser host's captured location (127.0.0.1 is a secure context, so the
+// Geolocation API works with the granted permission below).
+const HOST_POSITION = { latitude: 52.372, longitude: 4.9041 };
+test.use({ geolocation: HOST_POSITION, permissions: ['geolocation'] });
+
+test('the browser client streams its GPS position to other players', async ({ page }) => {
+  const guest = io(url, { transports: ['websocket'], reconnection: false }); // a hider
+
+  try {
+    await waitFor(guest, 'connect');
+
+    // The host plays through the real UI: create a room, then read its code.
+    await page.goto('/');
+    await expect(page.getByRole('status')).toHaveText(/Connected to server/, { timeout: 15_000 });
+    await page.getByLabel(/your name/i).fill('Host');
+    await page.getByRole('button', { name: /create new game/i }).click();
+
+    const codeChip = page.locator('.room-code__value');
+    await expect(codeChip).toHaveText(/^[A-Z0-9]{4}$/, { timeout: 15_000 });
+    const roomCode = (await codeChip.textContent())?.trim() ?? '';
+
+    // A second player joins over the socket and readies up.
+    const joined = (await guest.emitWithAck('join_game', { roomCode, name: 'Guest' })) as LobbyAck;
+    expect(joined.ok).toBe(true);
+    if (!joined.ok) throw new Error('join failed');
+    const hostId = joined.game.players.find((p) => p.isHost)?.id;
+    expect(hostId).toBeTruthy();
+    await guest.emitWithAck('set_ready', { ready: true });
+
+    // The host readies through the UI, then starts once the button unlocks.
+    await page.getByRole('button', { name: /i'm ready/i }).click();
+    const startButton = page.getByRole('button', { name: /start game/i });
+    await expect(startButton).toBeEnabled({ timeout: 15_000 });
+
+    // Listen for the host's position before starting, then start the match.
+    const hostPosition = waitFor<GameState>(
+      guest,
+      'game_state',
+      (state) => hostId != null && state.positions[hostId] != null,
+    );
+    await startButton.click();
+    await expect(page.getByRole('heading', { name: /game on/i })).toBeVisible();
+
+    const state = await hostPosition;
+    expect(state.positions[hostId as string]).toMatchObject({
+      lat: HOST_POSITION.latitude,
+      lng: HOST_POSITION.longitude,
+    });
+  } finally {
+    guest.close();
+  }
+});

--- a/client/src/game/ActiveGame.css
+++ b/client/src/game/ActiveGame.css
@@ -1,0 +1,35 @@
+.tracking {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.tracking__dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--muted);
+}
+
+.tracking__dot--on {
+  background: var(--teal);
+  box-shadow: 0 0 0 4px rgb(36 227 198 / 15%);
+}
+
+.tracking__dot--warn {
+  background: #e0b341;
+  box-shadow: 0 0 0 4px rgb(224 179 65 / 15%);
+}
+
+.tracking__dot--off {
+  background: var(--red);
+  box-shadow: 0 0 0 4px rgb(255 90 90 / 15%);
+}
+
+.tracking__note {
+  margin: 0;
+}

--- a/client/src/game/ActiveGame.test.tsx
+++ b/client/src/game/ActiveGame.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ActiveGame from './ActiveGame.tsx';
+import type { Game } from '../lobby/types.ts';
+
+// Fake the shared socket so no real connection opens and we can assert emits.
+const { fakeSocket } = vi.hoisted(() => ({
+  fakeSocket: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+vi.mock('../socket.ts', () => ({
+  socket: fakeSocket,
+  createSocket: () => fakeSocket,
+}));
+
+// Drive navigator.geolocation.watchPosition by hand.
+let success: PositionCallback | null = null;
+const watchPosition = vi.fn((ok: PositionCallback) => {
+  success = ok;
+  return 1;
+});
+const clearWatch = vi.fn();
+
+function emitFix(lat: number, lng: number) {
+  act(() => {
+    success?.({
+      coords: {
+        latitude: lat,
+        longitude: lng,
+        accuracy: 5,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      },
+      timestamp: Date.now(),
+    } as GeolocationPosition);
+  });
+}
+
+function game(overrides: Partial<Game> = {}): Game {
+  return {
+    id: 'g1',
+    roomCode: 'AB2C',
+    status: 'active',
+    players: [{ id: 'p1', name: 'Ada', role: 'hunter', ready: true, isHost: true }],
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fakeSocket.emit.mockClear();
+  success = null;
+  watchPosition.mockClear();
+  clearWatch.mockClear();
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: { watchPosition, clearWatch, getCurrentPosition: vi.fn() },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'geolocation');
+});
+
+describe('<ActiveGame />', () => {
+  it('starts GPS capture and streams position_update ticks', () => {
+    render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
+
+    expect(screen.getByRole('heading', { name: /game on/i })).toBeInTheDocument();
+    expect(watchPosition).toHaveBeenCalledTimes(1);
+
+    emitFix(52.1, 4.3);
+
+    expect(fakeSocket.emit).toHaveBeenCalledWith('position_update', {
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.1,
+      lng: 4.3,
+    });
+    expect(screen.getByText(/sharing your location/i)).toBeInTheDocument();
+    expect(screen.getByTestId('tracking-dot')).toHaveClass('tracking__dot--on');
+  });
+
+  it('stops the watch when it leaves the match', () => {
+    const { unmount } = render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
+    unmount();
+    expect(clearWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onLeave from the leave button', async () => {
+    const onLeave = vi.fn();
+    render(<ActiveGame game={game()} playerId="p1" onLeave={onLeave} />);
+    await userEvent.click(screen.getByRole('button', { name: /leave/i }));
+    expect(onLeave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/game/ActiveGame.tsx
+++ b/client/src/game/ActiveGame.tsx
@@ -1,0 +1,72 @@
+import { socket } from '../socket.ts';
+import { useTracking } from '../gps/useTracking.ts';
+import type { GpsStatus } from '../gps/useGpsCapture.ts';
+import type { Game } from '../lobby/types.ts';
+import './ActiveGame.css';
+
+/** Map a GPS status to a user-facing message and an indicator state. */
+function gpsMessage(status: GpsStatus): { text: string; tone: 'on' | 'warn' | 'off' } {
+  switch (status) {
+    case 'tracking':
+      return { text: 'Sharing your location', tone: 'on' };
+    case 'acquiring':
+      return { text: 'Getting your location…', tone: 'warn' };
+    case 'unavailable':
+      return { text: 'Location signal lost — retrying…', tone: 'warn' };
+    case 'denied':
+      return { text: 'Location access denied. Enable it to play.', tone: 'off' };
+    case 'unsupported':
+      return { text: 'This device has no location support.', tone: 'off' };
+    default:
+      return { text: 'Location off', tone: 'off' };
+  }
+}
+
+/**
+ * The in-match screen shown once a game goes `active`. Its job for now is to
+ * drive GPS capture: mounting it starts `watchPosition` (throttled to the fixed
+ * cadence) and holds a screen wake lock, streaming `position_update` ticks to
+ * the server. The live map (backlog #9/#18) will grow out of this screen.
+ */
+export default function ActiveGame({
+  game,
+  playerId,
+  onLeave,
+}: {
+  game: Game;
+  playerId: string | null;
+  onLeave: () => void;
+}) {
+  const tracking = useTracking({
+    enabled: true,
+    gameId: game.id,
+    playerId,
+    socket,
+  });
+
+  const gps = gpsMessage(tracking.gps);
+
+  return (
+    <div className="lobby-card lobby-card--active">
+      <h2 className="active-title">Game on!</h2>
+      <p className="hint">
+        The match has started. The live map is coming next — see the backlog.
+      </p>
+
+      <p className="tracking" role="status">
+        <span className={`tracking__dot tracking__dot--${gps.tone}`} data-testid="tracking-dot" />
+        {gps.text}
+      </p>
+
+      {tracking.wakeLock === 'denied' ? (
+        <p className="hint tracking__note">
+          Keep the screen on so tracking doesn&apos;t pause.
+        </p>
+      ) : null}
+
+      <button type="button" className="lobby-leave" onClick={onLeave}>
+        Leave
+      </button>
+    </div>
+  );
+}

--- a/client/src/gps/useGpsCapture.test.ts
+++ b/client/src/gps/useGpsCapture.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { DEFAULT_CADENCE_MS, MAX_CADENCE_MS, useGpsCapture, type GpsFix } from './useGpsCapture.ts';
+
+/**
+ * A fake `Geolocation`: `emit` feeds a success fix to the active watcher and
+ * `fail` an error. Records whether a watch is active so we can assert teardown.
+ */
+function makeFakeGeolocation() {
+  let success: PositionCallback | null = null;
+  let failure: PositionErrorCallback | null = null;
+  let nextId = 1;
+  const cleared: number[] = [];
+
+  const geolocation = {
+    watchPosition: vi.fn((ok: PositionCallback, err?: PositionErrorCallback | null) => {
+      success = ok;
+      failure = err ?? null;
+      return nextId++;
+    }),
+    clearWatch: vi.fn((id: number) => {
+      cleared.push(id);
+      success = null;
+      failure = null;
+    }),
+    getCurrentPosition: vi.fn(),
+  } as unknown as Geolocation;
+
+  return {
+    geolocation,
+    cleared,
+    emit(coords: { lat: number; lng: number; accuracy?: number; timestamp?: number }) {
+      act(() => {
+        success?.({
+          coords: {
+            latitude: coords.lat,
+            longitude: coords.lng,
+            accuracy: coords.accuracy ?? 5,
+            altitude: null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+          },
+          timestamp: coords.timestamp ?? Date.now(),
+        } as GeolocationPosition);
+      });
+    },
+    fail(code: number, message = 'boom') {
+      act(() => {
+        failure?.({
+          code,
+          message,
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+        } as GeolocationPositionError);
+      });
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useGpsCapture', () => {
+  it('reports unsupported when there is no geolocation source', () => {
+    // A Geolocation-less environment (cast avoids depending on navigator here).
+    const { result } = renderHook(() =>
+      useGpsCapture({ enabled: true, onFix: () => {}, geolocation: undefined }),
+    );
+    // jsdom exposes no navigator.geolocation, so the default source is absent.
+    expect(result.current.status).toBe('unsupported');
+  });
+
+  it('stays idle until enabled', () => {
+    const geo = makeFakeGeolocation();
+    const onFix = vi.fn();
+    const { result } = renderHook(() =>
+      useGpsCapture({ enabled: false, onFix, geolocation: geo.geolocation }),
+    );
+    expect(result.current.status).toBe('idle');
+    expect(geo.geolocation.watchPosition).not.toHaveBeenCalled();
+  });
+
+  it('emits the first fix immediately and throttles the rest to the cadence', () => {
+    const geo = makeFakeGeolocation();
+    const onFix = vi.fn<(fix: GpsFix) => void>();
+    const { result } = renderHook(() =>
+      useGpsCapture({ enabled: true, onFix, geolocation: geo.geolocation }),
+    );
+    expect(result.current.status).toBe('acquiring');
+
+    // First fix goes out at once so downstream state warms up fast.
+    geo.emit({ lat: 52.1, lng: 4.3 });
+    expect(result.current.status).toBe('tracking');
+    expect(onFix).toHaveBeenCalledTimes(1);
+    expect(onFix).toHaveBeenLastCalledWith(expect.objectContaining({ lat: 52.1, lng: 4.3 }));
+
+    // A burst of fresh fixes inside the cadence window is coalesced into one.
+    geo.emit({ lat: 52.2, lng: 4.3 });
+    geo.emit({ lat: 52.3, lng: 4.3 });
+    expect(onFix).toHaveBeenCalledTimes(1);
+
+    // After a full cadence the newest held fix is flushed.
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_CADENCE_MS);
+    });
+    expect(onFix).toHaveBeenCalledTimes(2);
+    expect(onFix).toHaveBeenLastCalledWith(expect.objectContaining({ lat: 52.3 }));
+  });
+
+  it('clamps an out-of-range cadence into the 5–10s band', () => {
+    const geo = makeFakeGeolocation();
+    const onFix = vi.fn();
+    renderHook(() =>
+      useGpsCapture({ enabled: true, onFix, cadenceMs: 60_000, geolocation: geo.geolocation }),
+    );
+    geo.emit({ lat: 1, lng: 1 });
+    expect(onFix).toHaveBeenCalledTimes(1);
+
+    // Just under the max cadence: still throttled.
+    geo.emit({ lat: 2, lng: 2 });
+    act(() => {
+      vi.advanceTimersByTime(MAX_CADENCE_MS - 1);
+    });
+    expect(onFix).toHaveBeenCalledTimes(1);
+
+    // Crossing the clamped (max) cadence releases the next fix.
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onFix).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a denied permission and stops emitting', () => {
+    const geo = makeFakeGeolocation();
+    const onFix = vi.fn();
+    const { result } = renderHook(() =>
+      useGpsCapture({ enabled: true, onFix, geolocation: geo.geolocation }),
+    );
+    geo.fail(1, 'nope'); // PERMISSION_DENIED
+    expect(result.current.status).toBe('denied');
+    expect(result.current.error).toBe('nope');
+    expect(onFix).not.toHaveBeenCalled();
+  });
+
+  it('treats a transient error as recoverable and keeps the watch', () => {
+    const geo = makeFakeGeolocation();
+    const onFix = vi.fn();
+    const { result } = renderHook(() =>
+      useGpsCapture({ enabled: true, onFix, geolocation: geo.geolocation }),
+    );
+    geo.fail(2, 'no signal'); // POSITION_UNAVAILABLE
+    expect(result.current.status).toBe('unavailable');
+
+    // A later fix recovers to tracking.
+    geo.emit({ lat: 10, lng: 10 });
+    expect(result.current.status).toBe('tracking');
+    expect(onFix).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the watch on unmount', () => {
+    const geo = makeFakeGeolocation();
+    const { unmount } = renderHook(() =>
+      useGpsCapture({ enabled: true, onFix: () => {}, geolocation: geo.geolocation }),
+    );
+    unmount();
+    expect(geo.geolocation.clearWatch).toHaveBeenCalledTimes(1);
+    expect(geo.cleared).toEqual([1]);
+  });
+});

--- a/client/src/gps/useGpsCapture.ts
+++ b/client/src/gps/useGpsCapture.ts
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * The fixed position cadence (battery vs. latency trade-off, see the README and
+ * `docs/arc42.md`). `watchPosition` fires as fast as the device produces fixes;
+ * we throttle emission to at most one fix per {@link DEFAULT_CADENCE_MS}, and
+ * clamp any override into the documented 5–10s band.
+ */
+export const MIN_CADENCE_MS = 5_000;
+export const MAX_CADENCE_MS = 10_000;
+export const DEFAULT_CADENCE_MS = 10_000;
+
+/** One captured location fix, normalized from a `GeolocationPosition`. */
+export interface GpsFix {
+  lat: number;
+  lng: number;
+  /** Reported accuracy in metres (`coords.accuracy`). */
+  accuracy: number;
+  /** Fix timestamp in epoch milliseconds (`GeolocationPosition.timestamp`). */
+  at: number;
+}
+
+/**
+ * Status of the capture:
+ *
+ * - `unsupported` — the browser has no Geolocation API.
+ * - `idle` — supported, but capture is off (`enabled` is false).
+ * - `acquiring` — watching, waiting for the first fix.
+ * - `tracking` — receiving fixes.
+ * - `denied` — the user refused location permission (terminal).
+ * - `unavailable` — a position couldn't be obtained (signal/timeout); the watch
+ *   keeps running and recovers to `tracking` on the next fix.
+ */
+export type GpsStatus = 'unsupported' | 'idle' | 'acquiring' | 'tracking' | 'denied' | 'unavailable';
+
+export interface GpsCaptureOptions {
+  /** Capture only while true; flipping it off tears down the watch. */
+  enabled: boolean;
+  /** Called with the latest fix on the throttled cadence. */
+  onFix: (fix: GpsFix) => void;
+  /** Emission cadence in ms, clamped to [{@link MIN_CADENCE_MS}, {@link MAX_CADENCE_MS}]. */
+  cadenceMs?: number;
+  /** Injectable geolocation source (defaults to `navigator.geolocation`); for tests. */
+  geolocation?: Geolocation;
+}
+
+export interface GpsCapture {
+  status: GpsStatus;
+  /** The most recent fix, whether or not it has been emitted yet. */
+  last: GpsFix | null;
+  /** Last error message, if any (cleared on the next successful fix). */
+  error: string | null;
+}
+
+function clampCadence(ms: number): number {
+  if (!Number.isFinite(ms)) return DEFAULT_CADENCE_MS;
+  return Math.min(MAX_CADENCE_MS, Math.max(MIN_CADENCE_MS, ms));
+}
+
+function defaultGeolocation(): Geolocation | null {
+  return typeof navigator !== 'undefined' && 'geolocation' in navigator
+    ? navigator.geolocation
+    : null;
+}
+
+/**
+ * Capture the device location with `watchPosition` and hand the caller one fix
+ * per fixed cadence. `watchPosition` can fire many times a second; the hook
+ * keeps the newest fix and flushes it on a 5–10s heartbeat — the first fix goes
+ * out immediately so downstream state warms up fast, and every fix thereafter is
+ * spaced by the cadence. High accuracy is requested; a denied permission is a
+ * terminal `denied` status while transient errors keep the watch alive.
+ */
+export function useGpsCapture({
+  enabled,
+  onFix,
+  cadenceMs = DEFAULT_CADENCE_MS,
+  geolocation,
+}: GpsCaptureOptions): GpsCapture {
+  const geo = geolocation ?? defaultGeolocation();
+  const cadence = clampCadence(cadenceMs);
+  // Event-driven state, set only from the watch callbacks; the exposed `status`
+  // is derived from it during render so the effect never sets state directly.
+  const [last, setLast] = useState<GpsFix | null>(null);
+  const [failure, setFailure] = useState<'denied' | 'transient' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Hold the latest callback in a ref so a new `onFix` identity doesn't restart
+  // the watch (which would drop GPS state and re-prompt on some browsers).
+  const onFixRef = useRef(onFix);
+  useEffect(() => {
+    onFixRef.current = onFix;
+  }, [onFix]);
+
+  useEffect(() => {
+    if (!enabled || !geo) return;
+
+    let latest: GpsFix | null = null;
+    let hasEmitted = false;
+    let lastEmitAt = 0;
+
+    // Emit the newest fix, but never more often than the cadence. The first fix
+    // is always sent (`hasEmitted` gate); later ones wait out the interval.
+    const flush = (): void => {
+      if (!latest) return;
+      const now = Date.now();
+      if (hasEmitted && now - lastEmitAt < cadence) return;
+      hasEmitted = true;
+      lastEmitAt = now;
+      onFixRef.current(latest);
+    };
+
+    const onSuccess = (pos: GeolocationPosition): void => {
+      latest = {
+        lat: pos.coords.latitude,
+        lng: pos.coords.longitude,
+        accuracy: pos.coords.accuracy,
+        at: pos.timestamp,
+      };
+      setLast(latest);
+      setFailure(null);
+      setError(null);
+      flush();
+    };
+
+    const onError = (err: GeolocationPositionError): void => {
+      // A denied permission is terminal; POSITION_UNAVAILABLE / TIMEOUT are
+      // transient and the watch keeps running (once we have a fix, they no
+      // longer downgrade the derived status below).
+      setFailure((f) => (f === 'denied' ? f : err.code === err.PERMISSION_DENIED ? 'denied' : 'transient'));
+      setError(err.message || 'Location error');
+    };
+
+    const watchId = geo.watchPosition(onSuccess, onError, {
+      enableHighAccuracy: true,
+      maximumAge: 0,
+      timeout: 20_000,
+    });
+    const intervalId = setInterval(flush, cadence);
+
+    return () => {
+      geo.clearWatch(watchId);
+      clearInterval(intervalId);
+    };
+  }, [enabled, geo, cadence]);
+
+  // Derive the status from the inputs and the last observed event.
+  let status: GpsStatus;
+  if (!geo) status = 'unsupported';
+  else if (!enabled) status = 'idle';
+  else if (failure === 'denied') status = 'denied';
+  else if (last) status = 'tracking';
+  else if (failure === 'transient') status = 'unavailable';
+  else status = 'acquiring';
+
+  return { status, last, error };
+}

--- a/client/src/gps/useTracking.test.ts
+++ b/client/src/gps/useTracking.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { useTracking } from './useTracking.ts';
+
+/** Minimal fake geolocation that lets a test push one success fix. */
+function makeFakeGeolocation() {
+  let success: PositionCallback | null = null;
+  const geolocation = {
+    watchPosition: vi.fn((ok: PositionCallback) => {
+      success = ok;
+      return 1;
+    }),
+    clearWatch: vi.fn(),
+    getCurrentPosition: vi.fn(),
+  } as unknown as Geolocation;
+
+  return {
+    geolocation,
+    emit(lat: number, lng: number) {
+      act(() => {
+        success?.({
+          coords: {
+            latitude: lat,
+            longitude: lng,
+            accuracy: 5,
+            altitude: null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+          },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      });
+    },
+  };
+}
+
+function fakeSocket() {
+  return { emit: vi.fn() } as unknown as Socket & { emit: ReturnType<typeof vi.fn> };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useTracking', () => {
+  it('emits a position_update for each captured fix while active', () => {
+    const geo = makeFakeGeolocation();
+    const socket = fakeSocket();
+    renderHook(() =>
+      useTracking({
+        enabled: true,
+        gameId: 'g1',
+        playerId: 'p1',
+        socket,
+        geolocation: geo.geolocation,
+      }),
+    );
+
+    geo.emit(52.1, 4.3);
+
+    expect(socket.emit).toHaveBeenCalledTimes(1);
+    expect(socket.emit).toHaveBeenCalledWith('position_update', {
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.1,
+      lng: 4.3,
+    });
+  });
+
+  it('does not track when disabled', () => {
+    const geo = makeFakeGeolocation();
+    const socket = fakeSocket();
+    renderHook(() =>
+      useTracking({
+        enabled: false,
+        gameId: 'g1',
+        playerId: 'p1',
+        socket,
+        geolocation: geo.geolocation,
+      }),
+    );
+
+    expect(geo.geolocation.watchPosition).not.toHaveBeenCalled();
+    expect(socket.emit).not.toHaveBeenCalled();
+  });
+
+  it('does not track before a player id is known', () => {
+    const geo = makeFakeGeolocation();
+    const socket = fakeSocket();
+    renderHook(() =>
+      useTracking({
+        enabled: true,
+        gameId: 'g1',
+        playerId: null,
+        socket,
+        geolocation: geo.geolocation,
+      }),
+    );
+
+    expect(geo.geolocation.watchPosition).not.toHaveBeenCalled();
+    expect(socket.emit).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/gps/useTracking.ts
+++ b/client/src/gps/useTracking.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import type { Socket } from 'socket.io-client';
+import { useGpsCapture, type GpsFix, type GpsStatus } from './useGpsCapture.ts';
+import { useWakeLock, type WakeLockStatus } from './useWakeLock.ts';
+
+/**
+ * The inbound event that carries one location tick (see the server's
+ * `server/protocol/messages.ts`). Mirrored by hand — the client and server
+ * workspaces don't share a package.
+ */
+const POSITION_UPDATE = 'position_update';
+
+export interface UseTrackingOptions {
+  /** Track only while true (typically: the game is active). */
+  enabled: boolean;
+  /** The active game and the caller's own player id; both required to emit. */
+  gameId: string | null;
+  playerId: string | null;
+  /** The live socket to emit `position_update` on. */
+  socket: Socket;
+  /** Optional cadence override, forwarded to {@link useGpsCapture}. */
+  cadenceMs?: number;
+  /** Injectable geolocation source; for tests. */
+  geolocation?: Geolocation;
+}
+
+export interface Tracking {
+  gps: GpsStatus;
+  wakeLock: WakeLockStatus;
+  /** The most recent captured fix, for display. */
+  last: GpsFix | null;
+  error: string | null;
+}
+
+/**
+ * Capture GPS and stream it to the authoritative server for the length of a
+ * match: on each throttled fix, emit a `position_update`, and hold a screen wake
+ * lock so the phone keeps tracking. The server treats the position as advisory
+ * input and stamps its own `recordedAt`. Tracking runs only when `enabled` and
+ * both ids are known.
+ */
+export function useTracking({
+  enabled,
+  gameId,
+  playerId,
+  socket,
+  cadenceMs,
+  geolocation,
+}: UseTrackingOptions): Tracking {
+  const active = enabled && !!gameId && !!playerId;
+
+  const onFix = useCallback(
+    (fix: GpsFix) => {
+      if (!gameId || !playerId) return;
+      socket.emit(POSITION_UPDATE, { gameId, playerId, lat: fix.lat, lng: fix.lng });
+    },
+    [gameId, playerId, socket],
+  );
+
+  const gps = useGpsCapture({ enabled: active, onFix, cadenceMs, geolocation });
+  const wakeLock = useWakeLock(active);
+
+  return { gps: gps.status, wakeLock, last: gps.last, error: gps.error };
+}

--- a/client/src/gps/useWakeLock.test.ts
+++ b/client/src/gps/useWakeLock.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useWakeLock } from './useWakeLock.ts';
+
+/** A fake `WakeLockSentinel` whose `release` fires the registered listeners. */
+function makeSentinel() {
+  const listeners: Array<() => void> = [];
+  const sentinel = {
+    released: false,
+    addEventListener: vi.fn((_type: string, cb: () => void) => listeners.push(cb)),
+    removeEventListener: vi.fn((_type: string, cb: () => void) => {
+      const i = listeners.indexOf(cb);
+      if (i >= 0) listeners.splice(i, 1);
+    }),
+    release: vi.fn(async () => {
+      sentinel.released = true;
+    }),
+    // Simulate the browser/OS dropping the lock (e.g. page hidden).
+    fireRelease() {
+      listeners.forEach((cb) => cb());
+    },
+  };
+  return sentinel;
+}
+
+type FakeSentinel = ReturnType<typeof makeSentinel>;
+
+let request: ReturnType<typeof vi.fn>;
+
+/** Install `navigator.wakeLock` with a `request` we control. */
+function installWakeLock(impl: () => Promise<unknown>) {
+  request = vi.fn(impl);
+  Object.defineProperty(navigator, 'wakeLock', {
+    configurable: true,
+    value: { request },
+  });
+}
+
+function removeWakeLock() {
+  Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'wakeLock');
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+beforeEach(() => {
+  setVisibility('visible');
+});
+
+afterEach(() => {
+  removeWakeLock();
+});
+
+describe('useWakeLock', () => {
+  it('reports unsupported when the API is missing', () => {
+    removeWakeLock();
+    const { result } = renderHook(() => useWakeLock(true));
+    expect(result.current).toBe('unsupported');
+  });
+
+  it('stays idle until enabled', () => {
+    installWakeLock(async () => makeSentinel());
+    const { result } = renderHook(() => useWakeLock(false));
+    expect(result.current).toBe('idle');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('acquires a screen lock when enabled', async () => {
+    const sentinel = makeSentinel();
+    installWakeLock(async () => sentinel);
+    const { result } = renderHook(() => useWakeLock(true));
+
+    await waitFor(() => expect(result.current).toBe('held'));
+    expect(request).toHaveBeenCalledWith('screen');
+  });
+
+  it('falls back gracefully when the request is denied', async () => {
+    installWakeLock(async () => {
+      throw new DOMException('denied', 'NotAllowedError');
+    });
+    const { result } = renderHook(() => useWakeLock(true));
+
+    await waitFor(() => expect(result.current).toBe('denied'));
+  });
+
+  it('re-acquires the lock after it is released and the page returns to view', async () => {
+    let sentinel: FakeSentinel = makeSentinel();
+    installWakeLock(async () => sentinel);
+    const { result } = renderHook(() => useWakeLock(true));
+    await waitFor(() => expect(result.current).toBe('held'));
+
+    // The OS drops the lock (page hidden): we reflect it as released.
+    act(() => sentinel.fireRelease());
+    expect(result.current).toBe('released');
+
+    // Back to visible → re-acquire a fresh lock.
+    sentinel = makeSentinel();
+    act(() => {
+      setVisibility('visible');
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await waitFor(() => expect(result.current).toBe('held'));
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the lock on unmount', async () => {
+    const sentinel = makeSentinel();
+    installWakeLock(async () => sentinel);
+    const { result, unmount } = renderHook(() => useWakeLock(true));
+    await waitFor(() => expect(result.current).toBe('held'));
+
+    unmount();
+    await waitFor(() => expect(sentinel.release).toHaveBeenCalled());
+  });
+});

--- a/client/src/gps/useWakeLock.ts
+++ b/client/src/gps/useWakeLock.ts
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Lifecycle of a screen wake lock:
+ *
+ * - `unsupported` — the browser has no Screen Wake Lock API.
+ * - `idle` — supported, but not currently requesting a lock (tracking off).
+ * - `held` — a lock is active; the screen stays awake.
+ * - `released` — the lock was dropped (page hidden or reclaimed by the OS). We
+ *   re-acquire automatically when the page becomes visible again.
+ * - `denied` — the request was rejected (permissions policy, a user/OS setting,
+ *   or low battery). Tracking keeps running without keeping the screen awake.
+ */
+export type WakeLockStatus = 'unsupported' | 'idle' | 'held' | 'released' | 'denied';
+
+/** Whether this browser exposes the Screen Wake Lock API. */
+export function wakeLockSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'wakeLock' in navigator;
+}
+
+/**
+ * Hold a screen {@link https://developer.mozilla.org/docs/Web/API/Screen_Wake_Lock_API
+ * Wake Lock} for as long as `enabled` is true, so GPS tracking keeps running
+ * with the screen on. Browsers auto-release the lock whenever the page is
+ * hidden, so we re-acquire it on the next `visibilitychange` back to visible.
+ *
+ * The API is best-effort: if the request is denied — no support, a blocking
+ * permissions policy, or the OS reclaiming it — the hook reports the reason and
+ * the caller carries on without the lock. It never throws.
+ */
+export function useWakeLock(enabled: boolean): WakeLockStatus {
+  const supported = wakeLockSupported();
+  const [status, setStatus] = useState<WakeLockStatus>(supported ? 'idle' : 'unsupported');
+
+  useEffect(() => {
+    // When off/unsupported the resting status is already set by the initial
+    // state (first render) or the previous run's cleanup (a later toggle-off).
+    if (!enabled || !supported) return;
+
+    // `cancelled` guards against an async request that resolves after cleanup.
+    let cancelled = false;
+    let sentinel: WakeLockSentinel | null = null;
+
+    const handleRelease = (): void => {
+      // Fired when the lock drops for any reason (page hidden, OS reclaim, or
+      // our own release). Clear it so the visibility handler can re-acquire.
+      sentinel = null;
+      if (!cancelled) setStatus('released');
+    };
+
+    const acquire = async (): Promise<void> => {
+      // The API only grants a lock to a visible page and rejects otherwise;
+      // skip quietly here and let `visibilitychange` retry when it returns.
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+      try {
+        const next = await navigator.wakeLock.request('screen');
+        if (cancelled) {
+          void next.release();
+          return;
+        }
+        sentinel = next;
+        next.addEventListener('release', handleRelease);
+        setStatus('held');
+      } catch {
+        // Graceful fallback: keep tracking, just without the screen lock.
+        if (!cancelled) setStatus('denied');
+      }
+    };
+
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'visible' && !sentinel) void acquire();
+    };
+
+    void acquire();
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (sentinel) {
+        sentinel.removeEventListener('release', handleRelease);
+        void sentinel.release();
+        sentinel = null;
+      }
+      setStatus(supported ? 'idle' : 'unsupported');
+    };
+  }, [enabled, supported]);
+
+  return status;
+}

--- a/client/src/lobby/Lobby.tsx
+++ b/client/src/lobby/Lobby.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { useLobby } from './useLobby.ts';
+import ActiveGame from '../game/ActiveGame.tsx';
 import type { Game, Player, Role } from './types.ts';
 import './Lobby.css';
 
@@ -207,8 +208,8 @@ function LobbyRoom({
 
 /**
  * The lobby feature: create or join a room, pick a side, ready up, and let the
- * host start. Once the game goes `active` the map screen takes over (tracked in
- * the backlog); for now that's a placeholder.
+ * host start. Once the game goes `active` the {@link ActiveGame} screen takes
+ * over — it drives GPS capture now; the live map is tracked in the backlog.
  */
 export default function Lobby() {
   const lobby = useLobby();
@@ -226,17 +227,7 @@ export default function Lobby() {
   }
 
   if (game.status === 'active') {
-    return (
-      <div className="lobby-card lobby-card--active">
-        <h2 className="active-title">Game on!</h2>
-        <p className="hint">
-          The match has started. The live map is coming next — see the backlog.
-        </p>
-        <button type="button" className="lobby-leave" onClick={lobby.leave}>
-          Leave
-        </button>
-      </div>
-    );
+    return <ActiveGame game={game} playerId={playerId} onLeave={lobby.leave} />;
   }
 
   return (


### PR DESCRIPTION
Closes #8.

Capture the device location once a match goes `active` and stream it to the authoritative server on the fixed cadence.

## What's in it

New client `gps/` module:

- **`useGpsCapture`** — `navigator.geolocation.watchPosition` (high accuracy) with **emission throttled to the fixed 5–10s cadence**. The browser can report fixes far faster, so the hook holds the newest fix and flushes one per cadence (first fix goes out immediately; any override is clamped to `[5000, 10000]`ms). A denied permission is terminal; a lost signal is transient and the watch recovers. Status is derived during render from event-driven state, so the effect only subscribes.
- **`useWakeLock`** — holds a **Screen Wake Lock**, re-acquires it when the page returns to the foreground, and **falls back gracefully on denial** (no support / permissions policy / low battery). It never throws or blocks tracking.
- **`useTracking`** — ties the two together and emits a `position_update` `{ gameId, playerId, lat, lng }` per fix; the server stamps its own authoritative `recordedAt`.

Wiring: the lobby's `active` branch now renders a real `ActiveGame` screen that drives tracking and shows a live status indicator (sharing / acquiring / signal lost / denied), replacing the inline placeholder. The live map (backlog #9/#18) will grow out of this screen.

## Testing

- **Unit** (Vitest): each hook + the `ActiveGame` component — throttle/cadence, clamp, denial fallback, wake-lock re-acquire, teardown, emit wiring.
- **e2e** (Playwright): drives a real browser through create → ready → start with browser geolocation and asserts the captured position fans out to a second player as `game_state`.

All green locally: typecheck, lint (JS/CSS/MD), 30 unit tests, 8 e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an active-game screen with live GPS sharing status and a Leave option.
  - Captures and shares player location during active matches, with updates throttled to a safe cadence.
  - Keeps the screen awake when supported, while allowing gameplay to continue if unavailable or denied.
  - Displays GPS tracking, permission, and availability states.

- **Documentation**
  - Added guidance describing GPS capture, wake-lock behavior, and server-recorded timestamps.

- **Tests**
  - Added automated coverage for GPS streaming, tracking states, wake lock behavior, and end-to-end location sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->