### PR TITLE
feat(client): live match map with player pins + play-area boundary

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,10 +1,11 @@
 # Client
 
 The Manhunt PWA — **React 19 + Vite**, with `vite-plugin-pwa` (installable,
-offline app shell) and a **Socket.IO** connection to the game server. This is
-the scaffold: a landing shell that establishes the socket and shows its live
-status. The lobby / map / game-over screens and GPS capture are tracked in the
-backlog.
+offline app shell) and a **Socket.IO** connection to the game server. It hosts
+the lobby (create/join, roles, ready, start), GPS capture, and the in-match
+**MapLibre GL** map — the player's own pin, permitted others from the server's
+fan-out, and the play-area boundary overlaid. The game-over screen is tracked in
+the backlog.
 
 ## Scripts
 

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "maplibre-gl": "^5.24.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "socket.io-client": "^4.8.3"

--- a/client/src/game/ActiveGame.test.tsx
+++ b/client/src/game/ActiveGame.test.tsx
@@ -13,6 +13,34 @@ vi.mock('../socket.ts', () => ({
   createSocket: () => fakeSocket,
 }));
 
+// MapLibre needs a real WebGL context, which jsdom has no notion of. Stub it
+// with inert Map/Marker classes so ActiveGame can mount the map in tests.
+vi.mock('maplibre-gl', () => {
+  class FakeMap {
+    on(event: string, cb: () => void) {
+      if (event === 'load') cb();
+      return this;
+    }
+    addSource() {}
+    addLayer() {}
+    getSource() {
+      return { setData: () => {} };
+    }
+    easeTo() {}
+    remove() {}
+  }
+  class FakeMarker {
+    setLngLat() {
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+    remove() {}
+  }
+  return { default: { Map: FakeMap, Marker: FakeMarker } };
+});
+
 // Drive navigator.geolocation.watchPosition by hand.
 let success: PositionCallback | null = null;
 const watchPosition = vi.fn((ok: PositionCallback) => {
@@ -70,6 +98,7 @@ describe('<ActiveGame />', () => {
     render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
 
     expect(screen.getByRole('heading', { name: /game on/i })).toBeInTheDocument();
+    expect(screen.getByTestId('game-map')).toBeInTheDocument();
     expect(watchPosition).toHaveBeenCalledTimes(1);
 
     emitFix(52.1, 4.3);

--- a/client/src/game/ActiveGame.test.tsx
+++ b/client/src/game/ActiveGame.test.tsx
@@ -14,31 +14,10 @@ vi.mock('../socket.ts', () => ({
 }));
 
 // MapLibre needs a real WebGL context, which jsdom has no notion of. Stub it
-// with inert Map/Marker classes so ActiveGame can mount the map in tests.
-vi.mock('maplibre-gl', () => {
-  class FakeMap {
-    on(event: string, cb: () => void) {
-      if (event === 'load') cb();
-      return this;
-    }
-    addSource() {}
-    addLayer() {}
-    getSource() {
-      return { setData: () => {} };
-    }
-    easeTo() {}
-    remove() {}
-  }
-  class FakeMarker {
-    setLngLat() {
-      return this;
-    }
-    addTo() {
-      return this;
-    }
-    remove() {}
-  }
-  return { default: { Map: FakeMap, Marker: FakeMarker } };
+// with the shared inert stub so ActiveGame can mount the map in tests.
+vi.mock('maplibre-gl', async () => {
+  const { default: stub } = await import('../test/maplibreStub.ts');
+  return { default: stub };
 });
 
 // Drive navigator.geolocation.watchPosition by hand.

--- a/client/src/game/ActiveGame.tsx
+++ b/client/src/game/ActiveGame.tsx
@@ -1,7 +1,11 @@
+import { useMemo, useState } from 'react';
 import { socket } from '../socket.ts';
 import { useTracking } from '../gps/useTracking.ts';
 import type { GpsStatus } from '../gps/useGpsCapture.ts';
 import type { Game } from '../lobby/types.ts';
+import GameMap from './GameMap.tsx';
+import { useLivePositions } from './useLivePositions.ts';
+import { DEFAULT_BOUNDARY_RADIUS_M, type BoundaryCircle, type LngLat } from './geo.ts';
 import './ActiveGame.css';
 
 /** Map a GPS status to a user-facing message and an indicator state. */
@@ -23,10 +27,11 @@ function gpsMessage(status: GpsStatus): { text: string; tone: 'on' | 'warn' | 'o
 }
 
 /**
- * The in-match screen shown once a game goes `active`. Its job for now is to
- * drive GPS capture: mounting it starts `watchPosition` (throttled to the fixed
- * cadence) and holds a screen wake lock, streaming `position_update` ticks to
- * the server. The live map (backlog #9/#18) will grow out of this screen.
+ * The in-match screen shown once a game goes `active`. It drives GPS capture —
+ * mounting it starts `watchPosition` (throttled to the fixed cadence) and holds
+ * a screen wake lock, streaming `position_update` ticks to the server — and
+ * renders the live map: the player's own pin, every other permitted player from
+ * the server's fan-out, and the play-area boundary overlaid (backlog #9).
  */
 export default function ActiveGame({
   game,
@@ -43,15 +48,31 @@ export default function ActiveGame({
     playerId,
     socket,
   });
+  const others = useLivePositions(game.id, socket);
+
+  const lat = tracking.last?.lat ?? null;
+  const lng = tracking.last?.lng ?? null;
+  const self = useMemo<LngLat | null>(
+    () => (lat !== null && lng !== null ? { lng, lat } : null),
+    [lat, lng],
+  );
+
+  // Anchor a default play area to the first fix and hold it fixed for the match.
+  // Set during render (React's endorsed pattern for latching a value the first
+  // time it's known) rather than in an effect. A server-configured per-game
+  // boundary replaces this later (BACKLOG.md #11).
+  const [boundary, setBoundary] = useState<BoundaryCircle | null>(null);
+  if (!boundary && self) {
+    setBoundary({ center: self, radiusM: DEFAULT_BOUNDARY_RADIUS_M });
+  }
 
   const gps = gpsMessage(tracking.gps);
 
   return (
     <div className="lobby-card lobby-card--active">
       <h2 className="active-title">Game on!</h2>
-      <p className="hint">
-        The match has started. The live map is coming next — see the backlog.
-      </p>
+
+      <GameMap self={self} selfId={playerId} others={others} boundary={boundary} />
 
       <p className="tracking" role="status">
         <span className={`tracking__dot tracking__dot--${gps.tone}`} data-testid="tracking-dot" />

--- a/client/src/game/GameMap.css
+++ b/client/src/game/GameMap.css
@@ -1,0 +1,32 @@
+.game-map {
+  width: 100%;
+  height: 60vh;
+  min-height: 18rem;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #0b0f16;
+}
+
+/* Player pins. The own pin is highlighted; everyone else is a plain marker. */
+.map-pin {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid var(--bg);
+  box-sizing: border-box;
+}
+
+.map-pin--self {
+  background: var(--teal);
+  box-shadow: 0 0 0 4px rgb(36 227 198 / 25%);
+}
+
+.map-pin--other {
+  background: var(--red);
+  box-shadow: 0 0 0 4px rgb(255 66 66 / 25%);
+}
+
+/* Keep the MapLibre attribution legible on the dark shell. */
+.game-map .maplibregl-ctrl-attrib {
+  font-size: 0.65rem;
+}

--- a/client/src/game/GameMap.test.tsx
+++ b/client/src/game/GameMap.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import GameMap from './GameMap.tsx';
+import type { LivePositions } from './useLivePositions.ts';
+import type { BoundaryCircle } from './geo.ts';
+
+// Instrumented MapLibre stub: jsdom has no WebGL, so we record what the
+// component asks the map to do rather than render anything real. The classes
+// live inside the (hoisted) mock factory; tests reach their instances via
+// `state`.
+interface FakeMap {
+  sourceData: Record<string, unknown>;
+  layers: string[];
+}
+interface FakeMarker {
+  removed: boolean;
+  element: HTMLElement;
+}
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    maps: [] as FakeMap[],
+    markers: [] as FakeMarker[],
+  },
+}));
+
+vi.mock('maplibre-gl', () => {
+  class FakeMarkerImpl {
+    lngLat: [number, number] | null = null;
+    removed = false;
+    element: HTMLElement;
+    constructor(opts: { element: HTMLElement }) {
+      this.element = opts.element;
+      state.markers.push(this);
+    }
+    setLngLat(v: [number, number]) {
+      this.lngLat = v;
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+    remove() {
+      this.removed = true;
+    }
+  }
+  class FakeMapImpl {
+    sourceData: Record<string, unknown> = {};
+    layers: string[] = [];
+    constructor() {
+      state.maps.push(this);
+    }
+    on(event: string, cb: () => void) {
+      if (event === 'load') cb();
+      return this;
+    }
+    addSource(id: string, source: { data: unknown }) {
+      this.sourceData[id] = source.data;
+    }
+    addLayer(layer: { id: string }) {
+      this.layers.push(layer.id);
+    }
+    getSource(id: string) {
+      return {
+        setData: (data: unknown) => {
+          this.sourceData[id] = data;
+        },
+      };
+    }
+    easeTo() {}
+    remove() {}
+  }
+  return { default: { Map: FakeMapImpl, Marker: FakeMarkerImpl } };
+});
+
+const boundary: BoundaryCircle = { center: { lng: 4.9, lat: 52.37 }, radiusM: 500 };
+
+beforeEach(() => {
+  state.maps = [];
+  state.markers = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** The single live marker positions, keyed for readable assertions. */
+function liveMarkers() {
+  return state.markers.filter((m) => !m.removed);
+}
+
+describe('<GameMap />', () => {
+  it('creates a map and installs the boundary layers', () => {
+    render(<GameMap self={null} selfId={null} others={{}} boundary={null} />);
+    expect(state.maps).toHaveLength(1);
+    expect(state.maps[0]!.layers).toEqual(
+      expect.arrayContaining(['boundary-fill', 'boundary-line']),
+    );
+  });
+
+  it('overlays the play-area boundary as a polygon', () => {
+    render(<GameMap self={null} selfId={null} others={{}} boundary={boundary} />);
+    const data = state.maps[0]!.sourceData['boundary'] as {
+      geometry?: { type?: string };
+    };
+    expect(data.geometry?.type).toBe('Polygon');
+  });
+
+  it('draws the own pin and every other permitted player', () => {
+    const others: LivePositions = {
+      me: { lat: 52.37, lng: 4.9, recordedAt: '2026-07-21T00:00:00.000Z' },
+      p2: { lat: 52.38, lng: 4.91, recordedAt: '2026-07-21T00:00:00.000Z' },
+    };
+    render(
+      <GameMap self={{ lng: 4.9, lat: 52.37 }} selfId="me" others={others} boundary={boundary} />,
+    );
+
+    const pins = liveMarkers();
+    // Own pin (from the live fix) + p2; the `me` entry in `others` is dropped so
+    // the player isn't drawn twice.
+    expect(pins).toHaveLength(2);
+    expect(pins.filter((p) => p.element.className.includes('map-pin--self'))).toHaveLength(1);
+    expect(pins.filter((p) => p.element.className.includes('map-pin--other'))).toHaveLength(1);
+  });
+
+  it('renders without an own position yet', () => {
+    render(<GameMap self={null} selfId="me" others={{}} boundary={null} />);
+    expect(liveMarkers()).toHaveLength(0);
+    expect(state.maps).toHaveLength(1);
+  });
+});

--- a/client/src/game/GameMap.tsx
+++ b/client/src/game/GameMap.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react';
+import maplibregl, { type StyleSpecification } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { boundaryFeature, type BoundaryCircle, type LngLat } from './geo.ts';
+import type { LivePositions } from './useLivePositions.ts';
+import './GameMap.css';
+
+/**
+ * A self-contained raster style backed by the public OpenStreetMap tiles. It
+ * needs no API key, so the map renders out of the box in dev and CI. Swap the
+ * tile source for a proper provider (or a self-hosted vector style) before any
+ * real deployment — OSM's tiles are not for production traffic.
+ */
+const MAP_STYLE: StyleSpecification = {
+  version: 8,
+  sources: {
+    osm: {
+      type: 'raster',
+      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      attribution: '© OpenStreetMap contributors',
+    },
+  },
+  layers: [{ id: 'osm', type: 'raster', source: 'osm' }],
+};
+
+const BOUNDARY_SOURCE = 'boundary';
+const BOUNDARY_FILL = 'boundary-fill';
+const BOUNDARY_LINE = 'boundary-line';
+
+/** Zoom the map opens at once a position is known — street level for a chase. */
+const PLAY_ZOOM = 15;
+
+/** Empty feature collection used to clear a source. */
+const EMPTY_DATA = { type: 'FeatureCollection' as const, features: [] };
+
+export interface GameMapProps {
+  /** The caller's own live position, drawn as the highlighted pin. */
+  self: LngLat | null;
+  /** The caller's own player id, so it can be excluded from {@link others}. */
+  selfId: string | null;
+  /** Every other permitted player's latest position, keyed by player id. */
+  others: LivePositions;
+  /** The play-area boundary to overlay, or `null` before one is known. */
+  boundary: BoundaryCircle | null;
+}
+
+/** Build the DOM element MapLibre uses for a player pin. */
+function makePin(kind: 'self' | 'other'): HTMLElement {
+  const el = document.createElement('div');
+  el.className = `map-pin map-pin--${kind}`;
+  return el;
+}
+
+/**
+ * The live match map: a MapLibre GL map that overlays the play-area boundary and
+ * a pin for every player this client is permitted to see — the caller's own
+ * position highlighted, everyone else from the server's fan-out. The map is
+ * created once and then imperatively kept in sync as positions and the boundary
+ * change; React only owns the container element.
+ */
+export default function GameMap({ self, selfId, others, boundary }: GameMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const markersRef = useRef<Map<string, maplibregl.Marker>>(new Map());
+  const centeredRef = useRef(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Create the map exactly once. It opens at a neutral world view when no
+  // position is known yet; the recentre effect below snaps to the player as
+  // soon as the first fix arrives.
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+
+    const center = self ?? boundary?.center ?? { lng: 0, lat: 0 };
+    const map = new maplibregl.Map({
+      container: containerRef.current,
+      style: MAP_STYLE,
+      center: [center.lng, center.lat],
+      zoom: self || boundary ? PLAY_ZOOM : 1,
+      attributionControl: { compact: true },
+    });
+    mapRef.current = map;
+
+    map.on('load', () => {
+      map.addSource(BOUNDARY_SOURCE, { type: 'geojson', data: EMPTY_DATA });
+      map.addLayer({
+        id: BOUNDARY_FILL,
+        type: 'fill',
+        source: BOUNDARY_SOURCE,
+        paint: { 'fill-color': '#24e3c6', 'fill-opacity': 0.08 },
+      });
+      map.addLayer({
+        id: BOUNDARY_LINE,
+        type: 'line',
+        source: BOUNDARY_SOURCE,
+        paint: { 'line-color': '#24e3c6', 'line-width': 2, 'line-opacity': 0.7 },
+      });
+      setLoaded(true);
+    });
+
+    const markers = markersRef.current;
+    return () => {
+      for (const marker of markers.values()) marker.remove();
+      markers.clear();
+      map.remove();
+      mapRef.current = null;
+      centeredRef.current = false;
+      setLoaded(false);
+    };
+    // Intentionally run once: initial center is a best-effort seed and later
+    // props are applied by the effects below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Snap to the player the first time we learn where they are.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || centeredRef.current) return;
+    const focus = self ?? boundary?.center;
+    if (!focus) return;
+    centeredRef.current = true;
+    map.easeTo({ center: [focus.lng, focus.lat], zoom: PLAY_ZOOM, duration: 600 });
+  }, [self, boundary]);
+
+  // Keep the boundary overlay in sync with the source of truth.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !loaded) return;
+    const source = map.getSource(BOUNDARY_SOURCE) as maplibregl.GeoJSONSource | undefined;
+    if (!source) return;
+    source.setData(boundary ? boundaryFeature(boundary) : EMPTY_DATA);
+  }, [boundary, loaded]);
+
+  // Reconcile one marker per visible player: the caller's own pin plus every
+  // other permitted position. Markers absent from the latest set are removed.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const markers = markersRef.current;
+
+    const desired = new Map<string, { lngLat: LngLat; kind: 'self' | 'other' }>();
+    if (self) desired.set('self', { lngLat: self, kind: 'self' });
+    for (const [id, pos] of Object.entries(others)) {
+      if (id === selfId) continue; // own pin comes from the live GPS fix, not the fan-out
+      desired.set(id, { lngLat: { lng: pos.lng, lat: pos.lat }, kind: 'other' });
+    }
+
+    for (const [id, marker] of markers) {
+      if (!desired.has(id)) {
+        marker.remove();
+        markers.delete(id);
+      }
+    }
+
+    for (const [id, { lngLat, kind }] of desired) {
+      const existing = markers.get(id);
+      if (existing) {
+        existing.setLngLat([lngLat.lng, lngLat.lat]);
+      } else {
+        const marker = new maplibregl.Marker({ element: makePin(kind) })
+          .setLngLat([lngLat.lng, lngLat.lat])
+          .addTo(map);
+        markers.set(id, marker);
+      }
+    }
+  }, [self, selfId, others]);
+
+  return <div ref={containerRef} className="game-map" data-testid="game-map" />;
+}

--- a/client/src/game/geo.test.ts
+++ b/client/src/game/geo.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  boundaryFeature,
+  circleRing,
+  DEFAULT_BOUNDARY_RADIUS_M,
+  type BoundaryCircle,
+} from './geo.ts';
+
+/** Great-circle-ish distance in metres between two points (haversine). */
+function distanceM(a: [number, number], b: [number, number]): number {
+  const R = 6_371_008.8;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b[1] - a[1]);
+  const dLng = toRad(b[0] - a[0]);
+  const lat1 = toRad(a[1]);
+  const lat2 = toRad(b[1]);
+  const h =
+    Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+describe('circleRing', () => {
+  const center = { lng: 4.9, lat: 52.37 };
+
+  it('returns a closed ring (first point repeated at the end)', () => {
+    const ring = circleRing(center, 500, 32);
+    expect(ring).toHaveLength(33); // 32 points + the closing repeat
+    expect(ring[0]).toEqual(ring[ring.length - 1]);
+  });
+
+  it('places every point at roughly the requested radius from the centre', () => {
+    const radius = 500;
+    const ring = circleRing(center, radius, 64);
+    for (const point of ring) {
+      const d = distanceM([center.lng, center.lat], point);
+      // Equirectangular approximation: within a few metres at play-area scale.
+      expect(Math.abs(d - radius)).toBeLessThan(5);
+    }
+  });
+
+  it('does not divide by zero at the poles', () => {
+    const ring = circleRing({ lng: 0, lat: 90 }, 500, 8);
+    for (const [lng, latVal] of ring) {
+      expect(Number.isFinite(lng)).toBe(true);
+      expect(Number.isFinite(latVal)).toBe(true);
+    }
+  });
+});
+
+describe('boundaryFeature', () => {
+  it('wraps the ring in a GeoJSON Polygon feature', () => {
+    const boundary: BoundaryCircle = {
+      center: { lng: 4.9, lat: 52.37 },
+      radiusM: DEFAULT_BOUNDARY_RADIUS_M,
+    };
+    const feature = boundaryFeature(boundary);
+    expect(feature.type).toBe('Feature');
+    expect(feature.geometry.type).toBe('Polygon');
+    expect(feature.geometry.coordinates).toHaveLength(1);
+    const ring = feature.geometry.coordinates[0]!;
+    expect(ring[0]).toEqual(ring[ring.length - 1]);
+  });
+});

--- a/client/src/game/geo.ts
+++ b/client/src/game/geo.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure geometry helpers for the live map: turning a play-area definition into
+ * the GeoJSON the map overlays. Kept free of any MapLibre or DOM dependency so
+ * the maths is unit-testable on its own and the map component stays a thin
+ * rendering shell over it.
+ */
+
+/** A longitude/latitude pair — MapLibre's `[lng, lat]` order, named. */
+export interface LngLat {
+  lng: number;
+  lat: number;
+}
+
+/**
+ * A circular play area: a centre and a radius in metres. This is a stand-in for
+ * a server-configured play area (BACKLOG.md #11/#27). Until the server sends a
+ * per-game boundary, the client anchors a default circle to the first own fix
+ * so the overlay has something real to draw and the map screen is complete.
+ */
+export interface BoundaryCircle {
+  center: LngLat;
+  radiusM: number;
+}
+
+/** Default play-area radius, in metres, until the server configures one. */
+export const DEFAULT_BOUNDARY_RADIUS_M = 500;
+
+/** Mean Earth radius in metres (WGS84 sphere approximation). */
+const EARTH_RADIUS_M = 6_371_008.8;
+
+/** A GeoJSON `[lng, lat]` coordinate. */
+export type Position = [number, number];
+
+/** A closed GeoJSON Polygon feature — the shape a map source consumes. */
+export interface PolygonFeature {
+  type: 'Feature';
+  properties: Record<string, never>;
+  geometry: {
+    type: 'Polygon';
+    coordinates: Position[][];
+  };
+}
+
+/**
+ * Approximate a geographic circle as a closed ring of `[lng, lat]` points. Uses
+ * an equirectangular offset around the centre — accurate to within metres at
+ * play-area scale (hundreds of metres to a few km), which is all the overlay
+ * needs. The ring is explicitly closed (the first point is repeated at the end)
+ * as GeoJSON linear rings require.
+ */
+export function circleRing(center: LngLat, radiusM: number, steps = 64): Position[] {
+  const ring: Position[] = [];
+  const latRad = (center.lat * Math.PI) / 180;
+  // Metres per degree of latitude, and of longitude at this latitude.
+  const mPerDegLat = (Math.PI / 180) * EARTH_RADIUS_M;
+  const mPerDegLng = mPerDegLat * Math.cos(latRad);
+  for (let i = 0; i < steps; i++) {
+    const theta = (i / steps) * 2 * Math.PI;
+    const dLng = mPerDegLng === 0 ? 0 : (radiusM * Math.cos(theta)) / mPerDegLng;
+    const dLat = (radiusM * Math.sin(theta)) / mPerDegLat;
+    ring.push([center.lng + dLng, center.lat + dLat]);
+  }
+  const first = ring[0];
+  if (first) ring.push(first);
+  return ring;
+}
+
+/** A GeoJSON Polygon feature for a boundary circle, ready for a map source. */
+export function boundaryFeature(boundary: BoundaryCircle): PolygonFeature {
+  return {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [circleRing(boundary.center, boundary.radiusM)],
+    },
+  };
+}

--- a/client/src/game/useLivePositions.test.ts
+++ b/client/src/game/useLivePositions.test.ts
@@ -20,6 +20,9 @@ function fakeSocket() {
     emitState(payload: unknown) {
       act(() => handlers.get('game_state')?.(payload));
     },
+    fire(event: string, payload?: unknown) {
+      act(() => handlers.get(event)?.(payload));
+    },
     has(event: string) {
       return handlers.has(event);
     },
@@ -47,6 +50,16 @@ describe('useLivePositions', () => {
     fake.emitState({ gameId: 'g1', positions });
 
     expect(result.current).toEqual(positions);
+  });
+
+  it('re-joins the room when the socket reconnects', () => {
+    const fake = fakeSocket();
+    renderHook(() => useLivePositions('g1', fake.socket));
+    expect(fake.socket.emit).toHaveBeenCalledTimes(1); // join on mount
+
+    fake.fire('connect');
+    expect(fake.socket.emit).toHaveBeenCalledTimes(2);
+    expect(fake.socket.emit).toHaveBeenLastCalledWith('join', { gameId: 'g1' });
   });
 
   it('ignores game_state for a different game', () => {

--- a/client/src/game/useLivePositions.test.ts
+++ b/client/src/game/useLivePositions.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { useLivePositions, type LivePositions } from './useLivePositions.ts';
+
+/** A fake socket that records handlers so a test can drive `game_state`. */
+function fakeSocket() {
+  const handlers = new Map<string, (payload: unknown) => void>();
+  const socket = {
+    emit: vi.fn(),
+    on: vi.fn((event: string, cb: (payload: unknown) => void) => {
+      handlers.set(event, cb);
+    }),
+    off: vi.fn((event: string) => {
+      handlers.delete(event);
+    }),
+  };
+  return {
+    socket: socket as unknown as Socket & { emit: ReturnType<typeof vi.fn> },
+    emitState(payload: unknown) {
+      act(() => handlers.get('game_state')?.(payload));
+    },
+    has(event: string) {
+      return handlers.has(event);
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useLivePositions', () => {
+  it('subscribes to the game on mount', () => {
+    const fake = fakeSocket();
+    renderHook(() => useLivePositions('g1', fake.socket));
+    expect(fake.socket.emit).toHaveBeenCalledWith('join', { gameId: 'g1' });
+  });
+
+  it('tracks positions from game_state for the current game', () => {
+    const fake = fakeSocket();
+    const { result } = renderHook(() => useLivePositions('g1', fake.socket));
+
+    const positions: LivePositions = {
+      p2: { lat: 52.1, lng: 4.3, recordedAt: '2026-07-21T00:00:00.000Z' },
+    };
+    fake.emitState({ gameId: 'g1', positions });
+
+    expect(result.current).toEqual(positions);
+  });
+
+  it('ignores game_state for a different game', () => {
+    const fake = fakeSocket();
+    const { result } = renderHook(() => useLivePositions('g1', fake.socket));
+
+    fake.emitState({
+      gameId: 'other',
+      positions: { p9: { lat: 1, lng: 2, recordedAt: '2026-07-21T00:00:00.000Z' } },
+    });
+
+    expect(result.current).toEqual({});
+  });
+
+  it('does not subscribe without a game id', () => {
+    const fake = fakeSocket();
+    renderHook(() => useLivePositions(null, fake.socket));
+    expect(fake.socket.emit).not.toHaveBeenCalled();
+    expect(fake.has('game_state')).toBe(false);
+  });
+
+  it('unsubscribes and clears positions on unmount', () => {
+    const fake = fakeSocket();
+    const { result, unmount } = renderHook(() => useLivePositions('g1', fake.socket));
+
+    fake.emitState({
+      gameId: 'g1',
+      positions: { p2: { lat: 52.1, lng: 4.3, recordedAt: '2026-07-21T00:00:00.000Z' } },
+    });
+    expect(result.current).not.toEqual({});
+
+    unmount();
+    expect(fake.socket.off).toHaveBeenCalledWith('game_state', expect.any(Function));
+  });
+});

--- a/client/src/game/useLivePositions.ts
+++ b/client/src/game/useLivePositions.ts
@@ -35,8 +35,9 @@ interface GameStateEvent {
  * arrives here is exactly what this player is permitted to see (BACKLOG.md #14).
  *
  * The socket is normally already in the room via its lobby membership; emitting
- * `join` again is idempotent and covers a socket that reconnected straight into
- * an active match.
+ * `join` again is idempotent. It is also re-emitted on every `connect`, because
+ * a reconnect gets a fresh socket that the server has dropped from the room —
+ * without re-joining, `game_state` would stop for the rest of the match.
  */
 export function useLivePositions(gameId: string | null, socket: Socket): LivePositions {
   const [positions, setPositions] = useState<LivePositions>({});
@@ -44,15 +45,20 @@ export function useLivePositions(gameId: string | null, socket: Socket): LivePos
   useEffect(() => {
     if (!gameId) return;
 
-    socket.emit(JOIN, { gameId });
+    const join = (): void => {
+      socket.emit(JOIN, { gameId });
+    };
+    join();
 
     const onState = (event: GameStateEvent): void => {
       if (event.gameId !== gameId) return;
       setPositions(event.positions ?? {});
     };
+    socket.on('connect', join);
     socket.on(GAME_STATE, onState);
 
     return () => {
+      socket.off('connect', join);
       socket.off(GAME_STATE, onState);
       // Drop stale positions so a later game starts from a clean slate.
       setPositions({});

--- a/client/src/game/useLivePositions.ts
+++ b/client/src/game/useLivePositions.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+
+/**
+ * The socket events this hook speaks, mirrored by hand from the server's
+ * `server/protocol/messages.ts` (the client and server workspaces don't share a
+ * package). `join` subscribes this socket to a game's broadcasts; `game_state`
+ * carries the latest per-player positions the server fans out to the room.
+ */
+const JOIN = 'join';
+const GAME_STATE = 'game_state';
+
+/** One player's latest position, as broadcast in `game_state`. */
+export interface LivePosition {
+  lat: number;
+  lng: number;
+  /** When the server recorded it (ISO-8601). */
+  recordedAt: string;
+}
+
+/** Latest position per player id, for the current game. */
+export type LivePositions = Record<string, LivePosition>;
+
+/** Payload of the server's `game_state` broadcast. */
+interface GameStateEvent {
+  gameId: string;
+  positions: LivePositions;
+}
+
+/**
+ * Follow a game's live positions over the socket. On mount it (re-)subscribes
+ * the socket to the game's broadcasts and then keeps the latest per-player
+ * positions from every `game_state` message for that game. The server is
+ * authoritative and already applies per-role visibility filtering, so whatever
+ * arrives here is exactly what this player is permitted to see (BACKLOG.md #14).
+ *
+ * The socket is normally already in the room via its lobby membership; emitting
+ * `join` again is idempotent and covers a socket that reconnected straight into
+ * an active match.
+ */
+export function useLivePositions(gameId: string | null, socket: Socket): LivePositions {
+  const [positions, setPositions] = useState<LivePositions>({});
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    socket.emit(JOIN, { gameId });
+
+    const onState = (event: GameStateEvent): void => {
+      if (event.gameId !== gameId) return;
+      setPositions(event.positions ?? {});
+    };
+    socket.on(GAME_STATE, onState);
+
+    return () => {
+      socket.off(GAME_STATE, onState);
+      // Drop stale positions so a later game starts from a clean slate.
+      setPositions({});
+    };
+  }, [gameId, socket]);
+
+  return positions;
+}

--- a/client/src/lobby/Lobby.test.tsx
+++ b/client/src/lobby/Lobby.test.tsx
@@ -27,6 +27,7 @@ function makeFakeSocket() {
     off(event: string, cb: (payload: unknown) => void) {
       handlers[event] = (handlers[event] || []).filter((f) => f !== cb);
     },
+    emit: vi.fn(),
     emitWithAck,
   } as unknown as Socket;
 
@@ -53,6 +54,34 @@ vi.mock('../socket.ts', () => ({
   },
   createSocket: () => fake.socket,
 }));
+
+// The active-game screen mounts the MapLibre map, which needs a WebGL context
+// jsdom lacks. Stub it with inert Map/Marker classes.
+vi.mock('maplibre-gl', () => {
+  class FakeMap {
+    on(event: string, cb: () => void) {
+      if (event === 'load') cb();
+      return this;
+    }
+    addSource() {}
+    addLayer() {}
+    getSource() {
+      return { setData: () => {} };
+    }
+    easeTo() {}
+    remove() {}
+  }
+  class FakeMarker {
+    setLngLat() {
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+    remove() {}
+  }
+  return { default: { Map: FakeMap, Marker: FakeMarker } };
+});
 
 function game(overrides: Partial<Game> = {}): Game {
   return {

--- a/client/src/lobby/Lobby.test.tsx
+++ b/client/src/lobby/Lobby.test.tsx
@@ -56,31 +56,10 @@ vi.mock('../socket.ts', () => ({
 }));
 
 // The active-game screen mounts the MapLibre map, which needs a WebGL context
-// jsdom lacks. Stub it with inert Map/Marker classes.
-vi.mock('maplibre-gl', () => {
-  class FakeMap {
-    on(event: string, cb: () => void) {
-      if (event === 'load') cb();
-      return this;
-    }
-    addSource() {}
-    addLayer() {}
-    getSource() {
-      return { setData: () => {} };
-    }
-    easeTo() {}
-    remove() {}
-  }
-  class FakeMarker {
-    setLngLat() {
-      return this;
-    }
-    addTo() {
-      return this;
-    }
-    remove() {}
-  }
-  return { default: { Map: FakeMap, Marker: FakeMarker } };
+// jsdom lacks. Stub it with the shared inert stub.
+vi.mock('maplibre-gl', async () => {
+  const { default: stub } = await import('../test/maplibreStub.ts');
+  return { default: stub };
 });
 
 function game(overrides: Partial<Game> = {}): Game {

--- a/client/src/test/maplibreStub.ts
+++ b/client/src/test/maplibreStub.ts
@@ -14,14 +14,19 @@
  * `GameMap.test.tsx`) instrument their own stub instead of using this one.
  */
 class FakeMap {
+  private sources = new Map<string, { setData: () => void }>();
+
   on(event: string, cb: () => void) {
     if (event === 'load') cb();
     return this;
   }
-  addSource() {}
+  addSource(id: string) {
+    this.sources.set(id, { setData: () => {} });
+  }
   addLayer() {}
-  getSource() {
-    return { setData: () => {} };
+  getSource(id: string) {
+    // Mirror MapLibre: only known sources resolve; unknown ids are undefined.
+    return this.sources.get(id);
   }
   easeTo() {}
   remove() {}

--- a/client/src/test/maplibreStub.ts
+++ b/client/src/test/maplibreStub.ts
@@ -1,0 +1,40 @@
+/**
+ * An inert MapLibre GL stub for jsdom tests. jsdom has no WebGL context, so any
+ * component that mounts the map (`GameMap`, and anything rendering it) needs the
+ * real module replaced. Use it as a `vi.mock` factory:
+ *
+ * ```ts
+ * vi.mock('maplibre-gl', async () => {
+ *   const { default: stub } = await import('../test/maplibreStub.ts');
+ *   return { default: stub };
+ * });
+ * ```
+ *
+ * Tests that need to assert on what the map was asked to do (see
+ * `GameMap.test.tsx`) instrument their own stub instead of using this one.
+ */
+class FakeMap {
+  on(event: string, cb: () => void) {
+    if (event === 'load') cb();
+    return this;
+  }
+  addSource() {}
+  addLayer() {}
+  getSource() {
+    return { setData: () => {} };
+  }
+  easeTo() {}
+  remove() {}
+}
+
+class FakeMarker {
+  setLngLat() {
+    return this;
+  }
+  addTo() {
+    return this;
+  }
+  remove() {}
+}
+
+export default { Map: FakeMap, Marker: FakeMarker };

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,13 +44,14 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.18"
       }
     },
     "client": {
       "name": "@manhunt/client",
       "version": "0.1.0",
       "dependencies": {
+        "maplibre-gl": "^5.24.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "socket.io-client": "^4.8.3"
@@ -2734,6 +2735,119 @@
       "resolved": "client",
       "link": true
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.1.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+      "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -3841,6 +3955,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -5736,6 +5856,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7209,6 +7335,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -8498,6 +8630,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -8610,6 +8748,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -9078,6 +9222,40 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
     "node_modules/markdown-it": {
@@ -9969,7 +10147,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9989,6 +10166,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -10426,6 +10609,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/pg": {
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
@@ -10708,6 +10903,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10778,6 +10979,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -10869,6 +11076,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
@@ -11114,6 +11327,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/reusify": {
@@ -12390,6 +12612,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",


### PR DESCRIPTION
Closes #9.

Renders the in-match screen's live map with **MapLibre GL**: the player's own pin, every other permitted player, and the play-area boundary overlaid — satisfying the issue's acceptance (map renders on mobile; own position + permitted others shown; boundary overlaid).

## What's in it

- **`geo.ts`** — pure boundary geometry: a geographic circle → closed GeoJSON polygon ring (equirectangular approximation, accurate to a few metres at play-area scale). No MapLibre/DOM dependency, so it's unit-tested directly.
- **`useLivePositions.ts`** — subscribes the socket to the game (`join`) and keeps the latest per-player positions from every `game_state` broadcast for the current game.
- **`GameMap.tsx`** — a thin MapLibre shell: the map is created once and then imperatively kept in sync as positions and the boundary change. Own pin is highlighted (teal), others plain (red); the boundary is a fill + line layer.
- **`ActiveGame.tsx`** — wires the map into the active-game screen. Own position comes from the live GPS fix (immediate, no round-trip); others come from the fan-out with the caller's own id de-duped so the player isn't drawn twice.

## Notes / scope

- **Boundary is a client-side placeholder.** There's no server-configured play area yet, so the client anchors a default circle to the first GPS fix and holds it for the match. A per-game server boundary replaces this later (BACKLOG.md #11/#27).
- **Visibility is already enforced server-side** — the `game_state` fan-out filters per role (hunters never receive hider coordinates, #14), so the map only ever draws what this player is permitted to see.
- **Tile source** is public OpenStreetMap raster tiles (no API key, works in dev/CI). Swap for a proper provider before a real deployment, as noted in the code and `docs/arc42.md`.

## Testing

- `geo.test.ts` — ring closure, radius accuracy (haversine), pole safety, feature shape.
- `useLivePositions.test.ts` — join on mount, tracks/ignores `game_state` by game id, cleanup.
- `GameMap.test.tsx` — map + boundary layers created, boundary drawn as a polygon, own + other pins rendered (own id de-duped), renders before a fix.
- `ActiveGame` / `Lobby` tests updated to stub MapLibre (jsdom has no WebGL).

Client suite 43 passing, server suite 87 passing; `typecheck` and `lint` clean; production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuixUa7S4hqZVVZwjJ9h2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuixUa7S4hqZVVZwjJ9h2d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an always-on in-match map with styled player pins and a play-area boundary overlay, including automatic centering and boundary updates, plus live tracking for other permitted players.
* **Documentation**
  * Updated the Client README to describe the installable offline app shell and the current lobby/GPS/mapping flow.
* **Tests**
  * Expanded map, boundary-geometry, and live-position test coverage using an inert MapLibre stub suitable for jsdom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->