### PR TITLE
feat(server): authoritative tick engine (ingest, validate, store)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | Event | Payload | Ack | Notes |
 | --- | --- | --- | --- |
 | `join` | `{ gameId }` | `{ ok }` | Subscribe the socket to a game's broadcasts. |
-| `position_update` | `{ gameId, playerId, lat, lng }` | — | One location tick. `lat`/`lng` are validated to WGS84 bounds; the server stamps the authoritative `recordedAt`. Malformed ticks are dropped silently. |
+| `position_update` | `{ gameId, playerId, lat, lng }` | — | One location tick. `lat`/`lng` are validated to WGS84 bounds; the server stamps the authoritative `recordedAt` and the tick engine drops fixes that imply an impossible speed (teleport/GPS spoof). Malformed or implausible ticks are dropped silently. |
 | `claim_catch` | `{ gameId, hunterId, targetId }` | `{ ok, catch }` / `{ ok:false, error, code }` | A hunter claims a catch (`targetId` must differ from `hunterId`). |
 | `create_game` · `join_game` · `set_role` · `set_ready` · `start_game` | see [Lobby](#lobby-rooms-roles-ready-start) | `{ ok, game, playerId }` / error | Room lifecycle; payloads validated by the lobby manager. |
 
@@ -154,8 +154,10 @@ is rejected (with an error ack where the event acks) and never mutates state.
 The **catch flow** is wired end to end here (validate → broadcast
 `catch_confirmed`); the authoritative catch-radius verification and the
 hider→hunter role switch are the rules engine's job and gate this broadcast — see
-[`BACKLOG.md`](./BACKLOG.md) #12 (and #10 for the tick engine). See
-`docs/arc42.md` §6 for the runtime view.
+[`BACKLOG.md`](./BACKLOG.md) #12. The **tick engine** (`server/live/tick.ts`)
+ingests each `position_update`, validates it, rejects an implausible jump, writes
+the accepted fix, and exposes the latest per-player snapshot to the rules engine.
+See `docs/arc42.md` §6 for the runtime view.
 
 ### Live state (Redis)
 

--- a/server/app.live.test.ts
+++ b/server/app.live.test.ts
@@ -8,18 +8,25 @@ import { createServer, type ServerHandle } from './app.ts';
 import {
   createLocalBroadcaster,
   createMemoryPositionStore,
+  createTickEngine,
   type GameStateMessage,
+  type PositionStore,
+  type TickEngine,
 } from './live/index.ts';
 
 /** Boot the real server on an ephemeral port with an in-memory live state. */
-async function bootServer(): Promise<{ handle: ServerHandle; url: string }> {
+async function bootServer(
+  makeTickEngine?: (store: PositionStore) => TickEngine,
+): Promise<{ handle: ServerHandle; url: string }> {
+  const store = createMemoryPositionStore();
   const handle = createServer({
     staticDir: path.join(os.tmpdir(), 'nope'),
     liveState: {
-      store: createMemoryPositionStore(),
+      store,
       broadcaster: createLocalBroadcaster(),
       close: () => Promise.resolve(),
     },
+    tickEngine: makeTickEngine?.(store),
   });
   handle.httpServer.listen(0);
   await once(handle.httpServer, 'listening'); // node EventEmitter — safe
@@ -147,6 +154,52 @@ describe('live position tick over the socket', () => {
     await guest.emitWithAck('set_ready', { ready: true });
     expect(broadcast).toBe(false);
     expect(await handle.liveState.store.readPositions(gameId)).toEqual({});
+  });
+
+  it('drops an implausible teleport, keeping the last good fix', async () => {
+    // Inject a monotonic clock (each tick stamped 1s after the last) so the
+    // elapsed interval between the two fixes is fixed — the implausibility of the
+    // jump then depends only on distance, not on real-time scheduling jitter.
+    let ticks = 0;
+    const booted = await bootServer((store) =>
+      createTickEngine(store, {
+        now: () => new Date(Date.parse('2026-07-22T00:00:00.000Z') + ticks++ * 1000),
+      }),
+    );
+    handle = booted.handle;
+
+    const host = connect(booted.url); // hunter
+    const guest = connect(booted.url); // hider — sees everyone, so it observes the fan-out
+    clients.push(host, guest);
+    await Promise.all([waitFor(host, 'connect'), waitFor(guest, 'connect')]);
+
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    const gameId = created.game.id;
+    const hostId = created.playerId;
+    const joined = (await guest.emitWithAck('join_game', {
+      roomCode: created.game.roomCode,
+      name: 'Guest',
+    })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+
+    // First fix establishes the player's position and fans out.
+    let broadcasts = 0;
+    guest.on('game_state', () => {
+      broadcasts += 1;
+    });
+    const firstSeen = waitFor<GameStateMessage>(guest, 'game_state');
+    host.emit('position_update', { gameId, playerId: hostId, lat: 52.37, lng: 4.9 });
+    await firstSeen; // the first write is committed before we send the teleport
+
+    // A jump of ~110 km an instant later is physically impossible — the engine
+    // rejects it, so no second broadcast and the stored fix is unchanged.
+    host.emit('position_update', { gameId, playerId: hostId, lat: 52.37, lng: 6.5 });
+    await host.emitWithAck('set_ready', { ready: true }); // ordered barrier
+
+    expect(broadcasts).toBe(1);
+    const stored = await handle.tickEngine.latest(gameId);
+    expect(stored[hostId]).toMatchObject({ lat: 52.37, lng: 4.9 });
   });
 
   it('does not leak hider coordinates to a hunter (roles from the lobby roster)', async () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -11,11 +11,12 @@ import express, {
 import { Server, type Socket } from 'socket.io';
 import {
   createLiveState,
+  createTickEngine,
   type LiveState,
-  type Position,
   type PlayerRole,
   type PositionsByPlayer,
   type GameStateMessage,
+  type TickEngine,
 } from './live/index.ts';
 import {
   createMemoryLobby,
@@ -62,6 +63,12 @@ export interface CreateServerOptions {
    * inject one so they can assert on room state directly.
    */
   lobby?: LobbyManager;
+  /**
+   * The authoritative tick engine. Defaults to one built over `liveState.store`;
+   * tests inject one (e.g. with a deterministic clock) for reproducible
+   * plausibility behavior.
+   */
+  tickEngine?: TickEngine;
 }
 
 export interface ServerHandle {
@@ -70,6 +77,8 @@ export interface ServerHandle {
   io: Server;
   liveState: LiveState;
   lobby: LobbyManager;
+  /** The authoritative tick engine; `tickEngine.latest(gameId)` is the rules-engine read model. */
+  tickEngine: TickEngine;
 }
 
 /** Socket.IO room a game's broadcasts are emitted to. */
@@ -169,6 +178,7 @@ export function createServer({
   staticDir = resolveStaticDir(),
   liveState = createLiveState(),
   lobby = createMemoryLobby(),
+  tickEngine: tickEngineOption,
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -197,6 +207,9 @@ export function createServer({
   const httpServer = http.createServer(app);
   const io = new Server(httpServer);
   const { store, broadcaster } = liveState;
+  // The authoritative tick engine wraps the hot store: it ingests and validates
+  // each position tick and exposes the latest snapshot to the rules engine.
+  const tickEngine = tickEngineOption ?? createTickEngine(store);
 
   // The authoritative role of a player in a game, from the lobby roster (the
   // single source of truth for who is a hunter vs a hider). `undefined` when the
@@ -247,10 +260,10 @@ export function createServer({
   };
 
   // Authoritative game loop. The transport contract (join, position_update,
-  // claim_catch → catch_confirmed) is wired here against `protocol/messages`,
-  // with per-role game_state filtering applied on fan-out; the rest of the rules
-  // engine (catch-radius verification, role switch) is layered on later — see
-  // BACKLOG.md #10/#12.
+  // claim_catch → catch_confirmed) is wired here against `protocol/messages`;
+  // position ticks run through the tick engine (validate → plausibility → store),
+  // and game_state is filtered per role on fan-out. The remaining rules engine
+  // (catch-radius verification, role switch) is layered on later — BACKLOG.md #12.
   io.on('connection', (socket) => {
     console.log(`socket connected: ${socket.id}`);
 
@@ -348,10 +361,11 @@ export function createServer({
       ack?.({ ok: true });
     });
 
-    // One tick: a client reports its position. The server validates the payload,
-    // stamps the authoritative time, writes it to the hot store, and publishes
-    // the game's live positions for cross-instance fan-out. Malformed payloads
-    // are dropped silently (this is a fire-and-forget event with no ack).
+    // One tick: a client reports its position. The tick engine validates the
+    // payload, stamps the authoritative time, applies a plausibility guard, and
+    // writes the accepted fix to the hot store; we then publish the game's live
+    // positions for cross-instance fan-out. Malformed or implausible payloads are
+    // dropped silently (this is a fire-and-forget event with no ack).
     socket.on('position_update', async (payload: unknown) => {
       const result = validatePositionUpdate(payload);
       if (!result.ok) return;
@@ -362,18 +376,20 @@ export function createServer({
       if (!membership) return;
       const { gameId, playerId, lat, lng } = result.value;
       if (gameId !== membership.gameId || playerId !== membership.playerId) return;
-      // Stamp the writer's role (from the lobby roster) so fan-out can filter
-      // per recipient — hunters never receive hider coordinates (BACKLOG.md #14).
-      const position: Position = {
-        lat,
-        lng,
-        recordedAt: new Date().toISOString(),
-        role: roleOf(membership.gameId, membership.playerId),
-      };
       try {
-        await store.writePosition(membership.gameId, membership.playerId, position);
-        const positions = await store.readPositions(membership.gameId);
-        await broadcaster.publish({ gameId: membership.gameId, positions });
+        // Stamp the writer's role (from the lobby roster) so fan-out can filter
+        // per recipient — hunters never receive hider coordinates (BACKLOG.md #14).
+        const tick = await tickEngine.ingest({
+          gameId: membership.gameId,
+          playerId: membership.playerId,
+          role: roleOf(membership.gameId, membership.playerId),
+          lat,
+          lng,
+        });
+        // An implausible jump (GPS spoof / teleport) is dropped without a write
+        // or a broadcast, so the last good fix stands (BACKLOG.md #26).
+        if (!tick.ok) return;
+        await broadcaster.publish({ gameId: membership.gameId, positions: tick.positions });
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         console.error('position_update failed:', reason);
@@ -409,5 +425,5 @@ export function createServer({
     });
   });
 
-  return { app, httpServer, io, liveState, lobby };
+  return { app, httpServer, io, liveState, lobby, tickEngine };
 }

--- a/server/live/index.ts
+++ b/server/live/index.ts
@@ -18,6 +18,7 @@ import {
 
 export * from './positions.ts';
 export * from './broadcaster.ts';
+export * from './tick.ts';
 
 /** The hot-state layer wired into the server. */
 export interface LiveState {

--- a/server/live/tick.test.ts
+++ b/server/live/tick.test.ts
@@ -149,6 +149,58 @@ describe('createTickEngine.ingest', () => {
     expect(fast).toEqual({ ok: false, reason: 'implausible_speed' });
   });
 
+  it('serializes concurrent ticks for one player so the guard sees the latest fix', async () => {
+    // Two ticks for the same player fired without awaiting the first. If the
+    // read-check-write weren't serialized, both would read the seed as `previous`
+    // and both would pass; the far jump would slip through. Serialized, the
+    // second tick is checked against the first's accepted fix — a teleport — and
+    // is rejected.
+    const store = createMemoryPositionStore();
+    const engine = createTickEngine(store);
+    await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 0,
+      lng: 0,
+      at: new Date('2026-07-22T00:00:00.000Z'),
+    });
+
+    const [near, far] = await Promise.all([
+      // +100 s, ~1.1 km north of the seed — ~11 m/s, plausible.
+      engine.ingest({
+        gameId: 'g1',
+        playerId: 'p1',
+        lat: 0.01,
+        lng: 0,
+        at: new Date('2026-07-22T00:01:40.000Z'),
+      }),
+      // 1 s later, ~2.2 km back south of `near` — plausible vs the seed but a
+      // teleport vs `near`, which is what the guard must compare against.
+      engine.ingest({
+        gameId: 'g1',
+        playerId: 'p1',
+        lat: -0.01,
+        lng: 0,
+        at: new Date('2026-07-22T00:01:41.000Z'),
+      }),
+    ]);
+
+    expect(near.ok).toBe(true);
+    expect(far).toEqual({ ok: false, reason: 'implausible_speed' });
+    expect(await store.readPositions('g1')).toMatchObject({ p1: { lat: 0.01, lng: 0 } });
+  });
+
+  it('does not serialize across different players', async () => {
+    // Distinct players must not block one another; both first fixes are accepted.
+    const engine = createTickEngine(createMemoryPositionStore());
+    const [a, b] = await Promise.all([
+      engine.ingest({ gameId: 'g1', playerId: 'p1', lat: 1, lng: 1 }),
+      engine.ingest({ gameId: 'g1', playerId: 'p2', lat: 2, lng: 2 }),
+    ]);
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+
   it('checks plausibility per player, not across players', async () => {
     const engine = createTickEngine(createMemoryPositionStore());
     const at = new Date('2026-07-22T00:00:00.000Z');

--- a/server/live/tick.test.ts
+++ b/server/live/tick.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryPositionStore } from './positions.ts';
+import {
+  createTickEngine,
+  haversineMeters,
+  MAX_PLAUSIBLE_SPEED_MPS,
+} from './tick.ts';
+
+describe('haversineMeters', () => {
+  it('is zero for the same point', () => {
+    expect(haversineMeters({ lat: 52.37, lng: 4.9 }, { lat: 52.37, lng: 4.9 })).toBe(0);
+  });
+
+  it('measures a short distance to within a few metres', () => {
+    // One arc-minute of latitude is ~1852 m (a nautical mile).
+    const meters = haversineMeters({ lat: 0, lng: 0 }, { lat: 1 / 60, lng: 0 });
+    expect(meters).toBeGreaterThan(1840);
+    expect(meters).toBeLessThan(1860);
+  });
+});
+
+describe('createTickEngine.ingest', () => {
+  it('writes the first fix and returns the fresh snapshot', async () => {
+    const store = createMemoryPositionStore();
+    const engine = createTickEngine(store);
+
+    const at = new Date('2026-07-22T00:00:00.000Z');
+    const result = await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      role: 'hider',
+      lat: 52.37,
+      lng: 4.9,
+      at,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.position).toEqual({
+      lat: 52.37,
+      lng: 4.9,
+      recordedAt: at.toISOString(),
+      role: 'hider',
+    });
+    expect(result.positions).toEqual({ p1: result.position });
+    // The write is durable in the store, too.
+    expect(await store.readPositions('g1')).toEqual({ p1: result.position });
+  });
+
+  it('stamps the current time when no `at` is given', async () => {
+    const engine = createTickEngine(createMemoryPositionStore());
+    const before = Date.now();
+    const result = await engine.ingest({ gameId: 'g1', playerId: 'p1', lat: 1, lng: 2 });
+    const after = Date.now();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const stamped = Date.parse(result.position.recordedAt);
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(after);
+  });
+
+  it('omits role when the writer has none', async () => {
+    const engine = createTickEngine(createMemoryPositionStore());
+    const result = await engine.ingest({ gameId: 'g1', playerId: 'p1', lat: 1, lng: 2 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.position).not.toHaveProperty('role');
+  });
+
+  it('accepts plausible movement between two fixes', async () => {
+    const store = createMemoryPositionStore();
+    const engine = createTickEngine(store);
+
+    await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.37,
+      lng: 4.9,
+      at: new Date('2026-07-22T00:00:00.000Z'),
+    });
+    // ~66 m north over 10 s — a brisk jog, well within the limit.
+    const second = await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.3706,
+      lng: 4.9,
+      at: new Date('2026-07-22T00:00:10.000Z'),
+    });
+
+    expect(second.ok).toBe(true);
+    expect(await store.readPositions('g1')).toEqual({ p1: (second as { position: unknown }).position });
+  });
+
+  it('rejects an implausible jump without writing it', async () => {
+    const store = createMemoryPositionStore();
+    const engine = createTickEngine(store);
+
+    const first = await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.37,
+      lng: 4.9,
+      at: new Date('2026-07-22T00:00:00.000Z'),
+    });
+    if (!first.ok) throw new Error('first fix should have been accepted');
+
+    // ~110 km east in one second — a teleport no player could make.
+    const jump = await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.37,
+      lng: 6.5,
+      at: new Date('2026-07-22T00:00:01.000Z'),
+    });
+
+    expect(jump).toEqual({ ok: false, reason: 'implausible_speed' });
+    // The last good fix stands; the teleport was never stored.
+    expect(await store.readPositions('g1')).toEqual({ p1: first.position });
+  });
+
+  it('does not treat two fixes in the same instant as an infinite-speed teleport', async () => {
+    const engine = createTickEngine(createMemoryPositionStore());
+    const at = new Date('2026-07-22T00:00:00.000Z');
+    await engine.ingest({ gameId: 'g1', playerId: 'p1', lat: 52.37, lng: 4.9, at });
+    // Same timestamp, a large jump: elapsed time is zero, so speed is unknowable
+    // and the fix is allowed through rather than rejected as a division by zero.
+    const same = await engine.ingest({ gameId: 'g1', playerId: 'p1', lat: 52.37, lng: 6.5, at });
+    expect(same.ok).toBe(true);
+  });
+
+  it('honors a custom max speed', async () => {
+    // A 1 m/s cap: the same jog that passes the default limit is now implausible.
+    const engine = createTickEngine(createMemoryPositionStore(), { maxSpeedMps: 1 });
+    await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.37,
+      lng: 4.9,
+      at: new Date('2026-07-22T00:00:00.000Z'),
+    });
+    const fast = await engine.ingest({
+      gameId: 'g1',
+      playerId: 'p1',
+      lat: 52.3706,
+      lng: 4.9,
+      at: new Date('2026-07-22T00:00:10.000Z'),
+    });
+    expect(fast).toEqual({ ok: false, reason: 'implausible_speed' });
+  });
+
+  it('checks plausibility per player, not across players', async () => {
+    const engine = createTickEngine(createMemoryPositionStore());
+    const at = new Date('2026-07-22T00:00:00.000Z');
+    const later = new Date('2026-07-22T00:00:01.000Z');
+    await engine.ingest({ gameId: 'g1', playerId: 'p1', lat: 52.37, lng: 4.9, at });
+    // p2's first fix is far from p1's, but it's p2's *first* fix, so there's no
+    // previous position to compare against — it must be accepted.
+    const p2 = await engine.ingest({ gameId: 'g1', playerId: 'p2', lat: 52.37, lng: 6.5, at: later });
+    expect(p2.ok).toBe(true);
+  });
+
+  it('defaults to the shared max-speed constant', () => {
+    expect(MAX_PLAUSIBLE_SPEED_MPS).toBeGreaterThan(90);
+  });
+});
+
+describe('createTickEngine.latest', () => {
+  it('exposes every player’s latest position for the rules engine', async () => {
+    const store = createMemoryPositionStore();
+    const engine = createTickEngine(store);
+    await engine.ingest({ gameId: 'g1', playerId: 'p1', role: 'hunter', lat: 1, lng: 2 });
+    await engine.ingest({ gameId: 'g1', playerId: 'p2', role: 'hider', lat: 3, lng: 4 });
+
+    const latest = await engine.latest('g1');
+    expect(Object.keys(latest).sort()).toEqual(['p1', 'p2']);
+    expect(latest.p1).toMatchObject({ lat: 1, lng: 2, role: 'hunter' });
+    expect(latest.p2).toMatchObject({ lat: 3, lng: 4, role: 'hider' });
+  });
+
+  it('returns an empty snapshot for an unknown game', async () => {
+    const engine = createTickEngine(createMemoryPositionStore());
+    expect(await engine.latest('nope')).toEqual({});
+  });
+});

--- a/server/live/tick.ts
+++ b/server/live/tick.ts
@@ -1,0 +1,165 @@
+/**
+ * The authoritative tick engine (see docs/arc42.md §5 "Tick engine" and §6.1
+ * "Game tick"). One tick is a single `position_update`: the engine ingests a
+ * player's reported position, validates it, applies a plausibility guard, and
+ * writes the accepted position to the hot store. It also exposes the latest
+ * position of every player in a game — the snapshot the rules engine (boundary,
+ * catch-radius, ping, win checks — BACKLOG.md #11/#12/#13/#15) consumes.
+ *
+ * Payload shape and WGS84 coordinate bounds are validated one layer up, at the
+ * transport edge (`server/protocol/messages.ts`), so the engine works with an
+ * already-normalized, identity-bound input. What the engine adds is the
+ * *stateful* validation the message validator can't do on a lone payload:
+ * comparing a new fix against the player's previous one to reject an implausible
+ * jump. A fuller input-layer anti-cheat pass (multi-sample smoothing, accuracy
+ * weighting) is tracked separately — BACKLOG.md #26.
+ */
+import type { PlayerRole, Position, PositionsByPlayer, PositionStore } from './positions.ts';
+
+/** Mean Earth radius, for great-circle distance between two fixes. */
+export const EARTH_RADIUS_M = 6_371_008.8;
+
+/**
+ * Maximum ground speed the engine treats as plausible between two consecutive
+ * fixes, in metres per second. Set well above any real player (a sprint is
+ * ~10 m/s, a car ~40, a fast train ~90) so honest movement — even in a vehicle —
+ * is never rejected, while an instant hop across the map (GPS spoof / teleport)
+ * is. The rules and settings work (BACKLOG.md #26/#27) may tune this per game.
+ */
+export const MAX_PLAUSIBLE_SPEED_MPS = 150;
+
+/** Why the engine rejected a tick. Stable codes for logging and future acks. */
+export type TickRejectReason = 'implausible_speed';
+
+/** A tick the engine accepted: the stored fix plus the game's fresh snapshot. */
+export interface TickAccepted {
+  ok: true;
+  /** The position the engine wrote for this player. */
+  position: Position;
+  /** Every player's latest position after this write — the rules-engine input. */
+  positions: PositionsByPlayer;
+}
+
+/** A tick the engine dropped without writing, with a stable reason code. */
+export interface TickRejected {
+  ok: false;
+  reason: TickRejectReason;
+}
+
+export type TickResult = TickAccepted | TickRejected;
+
+/**
+ * One tick's input: a player's reported coordinates, already validated and bound
+ * to the socket's authoritative lobby identity by the caller. The engine never
+ * trusts a client-supplied timestamp — it stamps `at` (defaulting to now) as the
+ * authoritative record time.
+ */
+export interface TickInput {
+  gameId: string;
+  playerId: string;
+  /** The player's role, stored alongside the fix for per-role fan-out filtering. */
+  role?: PlayerRole;
+  lat: number;
+  lng: number;
+  /** Authoritative server time for this tick. Defaults to the current time. */
+  at?: Date;
+}
+
+/** Tunables for {@link createTickEngine}. */
+export interface TickEngineOptions {
+  /** Reject a fix implying a ground speed above this (m/s). */
+  maxSpeedMps?: number;
+  /**
+   * Clock used to stamp a tick's authoritative record time when the input
+   * doesn't carry an explicit `at`. Defaults to the system clock; injected in
+   * tests for a deterministic, monotonic sequence of record times.
+   */
+  now?: () => Date;
+}
+
+/** The authoritative ingest pipeline plus the rules engine's read model. */
+export interface TickEngine {
+  /**
+   * Ingest one tick: validate against the player's previous fix, and on success
+   * write it and return the game's fresh position snapshot. Rejections do not
+   * mutate the store.
+   */
+  ingest(input: TickInput): Promise<TickResult>;
+  /**
+   * The latest position of every player in a game — the read model the rules
+   * engine runs its boundary/catch/ping/win checks against.
+   */
+  latest(gameId: string): Promise<PositionsByPlayer>;
+}
+
+/** Convert degrees to radians. */
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/**
+ * Great-circle (haversine) distance between two lat/lng points, in metres. Exact
+ * enough at the scale of a play area, and cheap enough to run on every tick.
+ */
+export function haversineMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+): number {
+  const dLat = toRadians(b.lat - a.lat);
+  const dLng = toRadians(b.lng - a.lng);
+  const lat1 = toRadians(a.lat);
+  const lat2 = toRadians(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Decide whether moving from `prev` to `next` is physically plausible. Uses the
+ * elapsed time between the two authoritative record stamps; only rejects when we
+ * can measure a positive interval AND the implied speed exceeds `maxSpeedMps`. A
+ * zero/negative interval (two fixes within the same millisecond, or a clock
+ * quirk) can't yield a meaningful speed, so it's allowed through rather than
+ * treated as an infinite-speed teleport.
+ */
+function isImplausibleJump(prev: Position, next: Position, maxSpeedMps: number): boolean {
+  const elapsedMs = Date.parse(next.recordedAt) - Date.parse(prev.recordedAt);
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return false;
+  const distanceM = haversineMeters(prev, next);
+  return distanceM / (elapsedMs / 1000) > maxSpeedMps;
+}
+
+/**
+ * Build a tick engine over a {@link PositionStore}. Ingest reads the game's
+ * current snapshot once (to find the player's previous fix for the plausibility
+ * check), writes on acceptance, and returns the snapshot updated in place — so a
+ * normal tick costs one read and one write, and the caller gets the fresh state
+ * to fan out without a second read.
+ */
+export function createTickEngine(
+  store: PositionStore,
+  { maxSpeedMps = MAX_PLAUSIBLE_SPEED_MPS, now = () => new Date() }: TickEngineOptions = {},
+): TickEngine {
+  return {
+    async ingest({ gameId, playerId, role, lat, lng, at }) {
+      const position: Position = {
+        lat,
+        lng,
+        recordedAt: (at ?? now()).toISOString(),
+        ...(role ? { role } : {}),
+      };
+      const positions = await store.readPositions(gameId);
+      const previous = positions[playerId];
+      if (previous && isImplausibleJump(previous, position, maxSpeedMps)) {
+        return { ok: false, reason: 'implausible_speed' };
+      }
+      await store.writePosition(gameId, playerId, position);
+      positions[playerId] = position;
+      return { ok: true, position, positions };
+    },
+
+    latest(gameId) {
+      return store.readPositions(gameId);
+    },
+  };
+}

--- a/server/live/tick.ts
+++ b/server/live/tick.ts
@@ -140,22 +140,52 @@ export function createTickEngine(
   store: PositionStore,
   { maxSpeedMps = MAX_PLAUSIBLE_SPEED_MPS, now = () => new Date() }: TickEngineOptions = {},
 ): TickEngine {
+  // A tick's read-check-write must be atomic per player. The socket handler runs
+  // ticks concurrently (Socket.IO doesn't await one before the next), so two
+  // fixes for the same player arriving close together could otherwise both read
+  // the same `previous`, both pass the plausibility check, and both write —
+  // silently defeating the anti-teleport guard. Chaining a player's ticks makes
+  // each one observe the prior one's write before its own check. Different
+  // players stay fully concurrent, and a key is dropped once its chain drains so
+  // the map stays bounded to active players. This closes the race within one
+  // instance; a multi-instance deployment sharing a store needs a store-side
+  // atomic check-and-set (a follow-up alongside the fuller anti-cheat, #26).
+  const chains = new Map<string, Promise<unknown>>();
+
+  function serialize<T>(key: string, task: () => Promise<T>): Promise<T> {
+    // Run after the player's previous tick settles (resolve or reject — a failed
+    // tick must not wedge the next one). Return the real result to the caller,
+    // but chain the next tick off a non-rejecting continuation.
+    const run = (chains.get(key) ?? Promise.resolve()).then(task, task);
+    const settled = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    chains.set(key, settled);
+    void settled.then(() => {
+      if (chains.get(key) === settled) chains.delete(key);
+    });
+    return run;
+  }
+
   return {
-    async ingest({ gameId, playerId, role, lat, lng, at }) {
-      const position: Position = {
-        lat,
-        lng,
-        recordedAt: (at ?? now()).toISOString(),
-        ...(role ? { role } : {}),
-      };
-      const positions = await store.readPositions(gameId);
-      const previous = positions[playerId];
-      if (previous && isImplausibleJump(previous, position, maxSpeedMps)) {
-        return { ok: false, reason: 'implausible_speed' };
-      }
-      await store.writePosition(gameId, playerId, position);
-      positions[playerId] = position;
-      return { ok: true, position, positions };
+    ingest({ gameId, playerId, role, lat, lng, at }) {
+      return serialize(`${gameId}:${playerId}`, async () => {
+        const position: Position = {
+          lat,
+          lng,
+          recordedAt: (at ?? now()).toISOString(),
+          ...(role ? { role } : {}),
+        };
+        const positions = await store.readPositions(gameId);
+        const previous = positions[playerId];
+        if (previous && isImplausibleJump(previous, position, maxSpeedMps)) {
+          return { ok: false, reason: 'implausible_speed' } as TickResult;
+        }
+        await store.writePosition(gameId, playerId, position);
+        positions[playerId] = position;
+        return { ok: true, position, positions } as TickResult;
+      });
     },
 
     latest(gameId) {

--- a/server/protocol/messages.ts
+++ b/server/protocol/messages.ts
@@ -44,10 +44,11 @@ export interface JoinPayload {
 
 /**
  * `position_update` — one tick of a client's reported location. Advisory input:
- * the server assigns the authoritative `recordedAt` timestamp, and the rules
- * engine (boundary/catch/role filtering) is layered on separately (BACKLOG.md
- * #10/#11/#14). Coordinates are validated to the WGS84 ranges here; the game's
- * play-area geofence is a separate, per-game rule (#11).
+ * the server assigns the authoritative `recordedAt` timestamp, the tick engine
+ * (`server/live/tick.ts`) applies its plausibility guard, and the rules engine
+ * (boundary/catch/role filtering) is layered on separately (BACKLOG.md #11/#14).
+ * Coordinates are validated to the WGS84 ranges here; the game's play-area
+ * geofence is a separate, per-game rule (#11).
  */
 export interface PositionUpdatePayload {
   gameId: string;


### PR DESCRIPTION
Closes #10.

## What

Adds a dedicated **authoritative tick engine** (`server/live/tick.ts`) that owns the position-ingest pipeline for one game tick, satisfying both acceptance criteria of the issue:

- **Invalid/implausible payloads rejected** — payload shape and WGS84 bounds are already validated at the transport edge (`protocol/messages.ts`); the engine adds the *stateful* validation a lone payload can't do: it compares each new fix against the player's previous one and rejects a physically impossible jump (a GPS spoof / teleport implying a ground speed above a generous cap). Rejected ticks are dropped without a write or a broadcast, so the last good fix stands.
- **Latest positions available to the rules engine** — `tickEngine.latest(gameId)` exposes every player's most recent position as the read model the rules engine (boundary/catch/ping/win) will consume, and it's surfaced on `ServerHandle`.

## How

- `createTickEngine(store, opts)` stamps the authoritative record time, runs a haversine-based plausibility guard, writes the accepted fix, and returns the game's fresh snapshot updated in place — one read + one write per tick.
- The `position_update` handler now routes through the engine instead of writing the store inline. Behavior for malformed payloads and identity-spoofing is unchanged; implausible fixes are now dropped too.
- The engine is injectable into `createServer` (with an optional clock override), mirroring the existing `liveState`/`lobby` dependency injection, so tests are deterministic.
- The max-speed cap and clock are tunable — a hook for the fuller input-layer anti-cheat (#26) and configurable game settings (#27).

## Tests

- New `server/live/tick.test.ts`: haversine accuracy, first-fix acceptance, time stamping, role handling, plausible movement, teleport rejection (no write), same-instant guard, custom cap, per-player isolation, and the `latest()` read model.
- New socket-level integration test in `app.live.test.ts` proving a teleport is dropped end to end (no second broadcast, stored fix unchanged), using an injected monotonic clock for determinism.
- Full suite: **101 passing** (was 87). `typecheck`, `lint:js`, and `lint:md` all clean.

## Docs

- Updated `README.md` (message contract + live-state sections) and `protocol/messages.ts` / `app.ts` comments; refreshed the now-stale `#10` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1v3Vw9D1V9sNm5sQUFdK8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authoritative tick engine for `position_update` processing.
  - Implausible moves are dropped, the last accepted coordinates are retained, and game state is broadcast only after acceptance.
  - Server now supports injecting a custom tick engine and exposes it via the server handle.
- **Documentation**
  - Updated the WebSocket `position_update` contract with WGS84 validation, server-stamped timestamps, and implausible jump rejection details.
- **Tests**
  - Expanded unit and integration tests for plausibility, timestamping, concurrency behavior, and per-player latest snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->