### PR TITLE
feat(server): boundary enforcement geofence (warn then eliminate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | `join` | `{ gameId }` | `{ ok }` | Subscribe the socket to a game's broadcasts. |
 | `position_update` | `{ gameId, playerId, lat, lng }` | — | One location tick. `lat`/`lng` are validated to WGS84 bounds; the server stamps the authoritative `recordedAt` and the tick engine drops fixes that imply an impossible speed (teleport/GPS spoof). Malformed or implausible ticks are dropped silently. |
 | `claim_catch` | `{ gameId, hunterId, targetId }` | `{ ok, catch }` / `{ ok:false, error, code }` | A hunter claims a catch (`targetId` must differ from `hunterId`). |
+| `set_boundary` | `{ boundary: { center: { lat, lng }, radiusM } }` | `{ ok, game, playerId }` / error | Host-only: define the circular play area the rules engine geofences against. `radiusM` is bounded to a sane range. |
 | `create_game` · `join_game` · `set_role` · `set_ready` · `start_game` | see [Lobby](#lobby-rooms-roles-ready-start) | `{ ok, game, playerId }` / error | Room lifecycle; payloads validated by the lobby manager. |
 
 #### Outbound (server → client)
@@ -149,6 +150,8 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | --- | --- | --- |
 | `game_state` | `{ gameId, positions }` | Latest per-player positions, fanned out to the game's room each tick. |
 | `catch_confirmed` | `{ gameId, hunterId, targetId, at }` | The server accepted a catch; broadcast to the game's room. |
+| `boundary_warning` | `{ gameId, playerId, warnings, warningsRemaining, metersOutside, at }` | Sent to a player the server saw outside the play area, before elimination. |
+| `player_eliminated` | `{ gameId, playerId, reason, at }` | Broadcast to the room when the server removes a player from play (`reason: 'boundary'` today). |
 | `lobby_update` | `{ game }` | Full roster/status after any lobby change. |
 
 The **catch flow** is wired end to end here (validate → broadcast
@@ -157,7 +160,11 @@ hider→hunter role switch are the rules engine's job and gate this broadcast �
 [`BACKLOG.md`](./BACKLOG.md) #12. The **tick engine** (`server/live/tick.ts`)
 ingests each `position_update`, validates it, rejects an implausible jump, writes
 the accepted fix, and exposes the latest per-player snapshot to the rules engine.
-See `docs/arc42.md` §6 for the runtime view.
+The **boundary geofence** (`server/live/boundary.ts`) then checks each accepted
+fix against the game's play area (set by the host via `set_boundary`): a player
+who strays outside is warned (`boundary_warning`), then eliminated
+(`player_eliminated`) once the warnings run out — every check server-side, per
+[`BACKLOG.md`](./BACKLOG.md) #11. See `docs/arc42.md` §6 for the runtime view.
 
 ### Live state (Redis)
 

--- a/server/app.boundary.test.ts
+++ b/server/app.boundary.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { once } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import { createServer, type ServerHandle } from './app.ts';
+import {
+  createBoundaryMonitor,
+  createLocalBroadcaster,
+  createMemoryPositionStore,
+  type BoundaryMonitor,
+} from './live/index.ts';
+import { createMemoryLobby } from './lobby/rooms.ts';
+import type { BoundaryWarningEvent, PlayerEliminatedEvent } from './protocol/messages.ts';
+
+/** A tight play area at the origin so a nearby fix is unambiguously in or out. */
+const BOUNDARY = { center: { lat: 0, lng: 0 }, radiusM: 100 };
+const INSIDE = { lat: 0, lng: 0 };
+// ~1.1 km north of the centre — comfortably outside the 100 m circle.
+const OUTSIDE = { lat: 0.01, lng: 0 };
+
+type LobbyAck =
+  | { ok: true; game: { id: string; roomCode: string }; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Boot the real server with in-memory hot state and an explicit warn policy. */
+async function bootServer(
+  boundaryMonitor: BoundaryMonitor,
+): Promise<{ handle: ServerHandle; url: string }> {
+  const handle = createServer({
+    staticDir: path.join(os.tmpdir(), 'nope'),
+    liveState: {
+      store: createMemoryPositionStore(),
+      broadcaster: createLocalBroadcaster(),
+      close: () => Promise.resolve(),
+    },
+    lobby: createMemoryLobby(),
+    boundaryMonitor,
+  });
+  handle.httpServer.listen(0);
+  await once(handle.httpServer, 'listening');
+  const { port } = handle.httpServer.address() as AddressInfo;
+  return { handle, url: `http://127.0.0.1:${port}` };
+}
+
+function connect(url: string): Socket {
+  return ioClient(url, { transports: ['websocket'], reconnection: false });
+}
+
+function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('boundary enforcement over the socket', () => {
+  let handle: ServerHandle;
+  const clients: Socket[] = [];
+
+  async function open(url: string): Promise<Socket> {
+    const c = connect(url);
+    clients.push(c);
+    await waitFor(c, 'connect');
+    return c;
+  }
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    handle.io.close();
+    handle.httpServer.close();
+    await once(handle.httpServer, 'close');
+    await handle.liveState.close();
+  });
+
+  it('warns a player who leaves the area, then eliminates on a continued exit', async () => {
+    const booted = await bootServer(createBoundaryMonitor({ warningsBeforeElimination: 1 }));
+    handle = booted.handle;
+
+    const host = await open(booted.url);
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create_game failed');
+    const { id: gameId, roomCode } = created.game;
+    const hostId = created.playerId;
+
+    const boundaryAck = (await host.emitWithAck('set_boundary', { boundary: BOUNDARY })) as LobbyAck;
+    expect(boundaryAck.ok).toBe(true);
+    expect(handle.lobby.get(gameId)?.boundary).toEqual(BOUNDARY);
+
+    // A second player in the room observes the (room-wide) elimination broadcast.
+    const observer = await open(booted.url);
+    await observer.emitWithAck('join_game', { roomCode, name: 'Watcher' });
+
+    let observerEliminated: PlayerEliminatedEvent | undefined;
+    observer.on('player_eliminated', (e: PlayerEliminatedEvent) => {
+      observerEliminated = e;
+    });
+
+    // First fix is outside → a personal warning to the offending player only.
+    const warned = waitFor<BoundaryWarningEvent>(host, 'boundary_warning');
+    host.emit('position_update', { gameId, playerId: hostId, ...OUTSIDE });
+    const warning = await warned;
+    expect(warning).toMatchObject({
+      gameId,
+      playerId: hostId,
+      warnings: 1,
+      warningsRemaining: 0,
+    });
+    expect(warning.metersOutside).toBeGreaterThan(1000);
+    expect(observerEliminated).toBeUndefined();
+
+    // A continued exit (same spot, so the plausibility guard passes) eliminates.
+    const eliminated = waitFor<PlayerEliminatedEvent>(observer, 'player_eliminated');
+    host.emit('position_update', { gameId, playerId: hostId, ...OUTSIDE });
+    const event = await eliminated;
+    expect(event).toMatchObject({ gameId, playerId: hostId, reason: 'boundary' });
+    expect(typeof event.at).toBe('string');
+  });
+
+  it('raises no warning while a player stays inside the area', async () => {
+    const booted = await bootServer(createBoundaryMonitor({ warningsBeforeElimination: 1 }));
+    handle = booted.handle;
+
+    const host = await open(booted.url);
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create_game failed');
+    const { id: gameId } = created.game;
+    await host.emitWithAck('set_boundary', { boundary: BOUNDARY });
+
+    let warned = false;
+    host.on('boundary_warning', () => {
+      warned = true;
+    });
+    let eliminated = false;
+    host.on('player_eliminated', () => {
+      eliminated = true;
+    });
+
+    host.emit('position_update', { gameId, playerId: created.playerId, ...INSIDE });
+    await wait(60);
+    expect(warned).toBe(false);
+    expect(eliminated).toBe(false);
+  });
+
+  it('rejects set_boundary from a non-host and never enforces it', async () => {
+    const booted = await bootServer(createBoundaryMonitor());
+    handle = booted.handle;
+
+    const host = await open(booted.url);
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create_game failed');
+
+    const guest = await open(booted.url);
+    await guest.emitWithAck('join_game', { roomCode: created.game.roomCode, name: 'Guest' });
+
+    const ack = (await guest.emitWithAck('set_boundary', { boundary: BOUNDARY })) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected non-host to be rejected');
+    expect(ack.code).toBe('not_host');
+    expect(handle.lobby.get(created.game.id)?.boundary).toBeUndefined();
+  });
+
+  it('rejects a malformed set_boundary with an error ack', async () => {
+    const booted = await bootServer(createBoundaryMonitor());
+    handle = booted.handle;
+
+    const host = await open(booted.url);
+    await host.emitWithAck('create_game', { name: 'Host' });
+
+    const ack = (await host.emitWithAck('set_boundary', {
+      boundary: { center: { lat: 0, lng: 0 }, radiusM: 0 },
+    })) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected invalid radius to be rejected');
+    expect(ack.code).toBe('invalid_radius');
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -10,8 +10,10 @@ import express, {
 } from 'express';
 import { Server, type Socket } from 'socket.io';
 import {
+  createBoundaryMonitor,
   createLiveState,
   createTickEngine,
+  type BoundaryMonitor,
   type LiveState,
   type PlayerRole,
   type PositionsByPlayer,
@@ -29,9 +31,12 @@ import {
   validateClaimCatch,
   validateJoin,
   validatePositionUpdate,
+  validateSetBoundary,
+  type BoundaryWarningEvent,
   type CatchConfirmedEvent,
   type GameStateEvent,
   type LobbyUpdateEvent,
+  type PlayerEliminatedEvent,
 } from './protocol/messages.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -69,6 +74,12 @@ export interface CreateServerOptions {
    * plausibility behavior.
    */
   tickEngine?: TickEngine;
+  /**
+   * The boundary (geofence) monitor that warns then eliminates players who leave
+   * the play area. Defaults to one with the standard warning policy; tests inject
+   * one (e.g. with `warningsBeforeElimination: 0`) for deterministic enforcement.
+   */
+  boundaryMonitor?: BoundaryMonitor;
 }
 
 export interface ServerHandle {
@@ -79,6 +90,8 @@ export interface ServerHandle {
   lobby: LobbyManager;
   /** The authoritative tick engine; `tickEngine.latest(gameId)` is the rules-engine read model. */
   tickEngine: TickEngine;
+  /** The boundary geofence monitor (warn → eliminate) applied on every accepted tick. */
+  boundaryMonitor: BoundaryMonitor;
 }
 
 /** Socket.IO room a game's broadcasts are emitted to. */
@@ -179,6 +192,7 @@ export function createServer({
   liveState = createLiveState(),
   lobby = createMemoryLobby(),
   tickEngine: tickEngineOption,
+  boundaryMonitor = createBoundaryMonitor(),
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -245,6 +259,47 @@ export function createServer({
     io.to(gameRoom(game.id)).emit('lobby_update', message);
   };
 
+  // Geofence one accepted fix against the game's play area. A warning is personal
+  // — emitted only to the offending socket — while an elimination is broadcast to
+  // the whole room so everyone (and later the win check, BACKLOG.md #15) learns a
+  // player is out. Only the state-changing tick emits; steady state is silent.
+  const enforceBoundary = (
+    socket: Socket,
+    membership: LobbyMembership,
+    lat: number,
+    lng: number,
+  ): void => {
+    const boundary = lobby.get(membership.gameId)?.boundary;
+    if (!boundary) return;
+    const verdict = boundaryMonitor.evaluate({
+      gameId: membership.gameId,
+      playerId: membership.playerId,
+      position: { lat, lng },
+      boundary,
+    });
+    if (!verdict.changed) return;
+    const at = new Date().toISOString();
+    if (verdict.status === 'warned') {
+      const warning: BoundaryWarningEvent = {
+        gameId: membership.gameId,
+        playerId: membership.playerId,
+        warnings: verdict.warnings,
+        warningsRemaining: verdict.warningsRemaining,
+        metersOutside: verdict.metersOutside,
+        at,
+      };
+      socket.emit('boundary_warning', warning);
+    } else if (verdict.status === 'eliminated') {
+      const eliminated: PlayerEliminatedEvent = {
+        gameId: membership.gameId,
+        playerId: membership.playerId,
+        reason: 'boundary',
+        at,
+      };
+      io.to(gameRoom(membership.gameId)).emit('player_eliminated', eliminated);
+    }
+  };
+
   // Remove a socket from whatever lobby it currently holds: drop the player
   // server-side, leave the socket room, clear the membership, and broadcast the
   // updated roster if the room survives. A no-op when the socket isn't in a room.
@@ -256,6 +311,9 @@ export function createServer({
     const game = lobby.removePlayer(membership.gameId, membership.playerId);
     socket.leave(gameRoom(membership.gameId));
     delete (socket.data as { lobby?: LobbyMembership }).lobby;
+    // Once the room is gone, drop its geofence state so eliminations/warnings
+    // don't linger for a recycled game id.
+    if (!game) boundaryMonitor.forget(membership.gameId);
     if (game) emitLobby(game);
   };
 
@@ -331,6 +389,28 @@ export function createServer({
       });
     });
 
+    // Host-only: define (or replace) the play area the rules engine geofences
+    // against. Identity is the socket's membership; the payload carries only the
+    // boundary shape, validated to a WGS84 centre and a sane radius.
+    socket.on('set_boundary', (payload: unknown, ack?: (res: LobbyAck) => void) => {
+      const result = validateSetBoundary(payload);
+      if (!result.ok) {
+        ack?.({ ok: false, error: result.error, code: result.code });
+        return;
+      }
+      withLobbyErrors(ack, () => {
+        const membership = membershipOf(socket);
+        if (!membership) throw new LobbyError('player_not_found', 'Not in a game');
+        const game = lobby.setBoundary(
+          membership.gameId,
+          membership.playerId,
+          result.value.boundary,
+        );
+        ack?.({ ok: true, game, playerId: membership.playerId });
+        emitLobby(game);
+      });
+    });
+
     // Toggle the caller's ready flag.
     socket.on('set_ready', (payload: unknown, ack?: (res: LobbyAck) => void) => {
       withLobbyErrors(ack, () => {
@@ -390,6 +470,11 @@ export function createServer({
         // or a broadcast, so the last good fix stands (BACKLOG.md #26).
         if (!tick.ok) return;
         await broadcaster.publish({ gameId: membership.gameId, positions: tick.positions });
+        // Geofence the accepted fix against the game's play area (BACKLOG.md #11).
+        // Leaving warns the player, then eliminates them once the warnings run
+        // out — an authoritative, server-side decision. A game with no boundary
+        // configured is simply unenforced.
+        enforceBoundary(socket, membership, lat, lng);
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         console.error('position_update failed:', reason);
@@ -425,5 +510,5 @@ export function createServer({
     });
   });
 
-  return { app, httpServer, io, liveState, lobby, tickEngine };
+  return { app, httpServer, io, liveState, lobby, tickEngine, boundaryMonitor };
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -311,8 +311,10 @@ export function createServer({
     const game = lobby.removePlayer(membership.gameId, membership.playerId);
     socket.leave(gameRoom(membership.gameId));
     delete (socket.data as { lobby?: LobbyMembership }).lobby;
-    // Once the room is gone, drop its geofence state so eliminations/warnings
-    // don't linger for a recycled game id.
+    // Drop the departing player's geofence state so a mid-game leaver doesn't
+    // leave a stale warn/eliminate entry parked for the game's lifetime; once the
+    // room itself is gone, sweep whatever remains for the (recyclable) game id.
+    boundaryMonitor.forget(membership.gameId, membership.playerId);
     if (!game) boundaryMonitor.forget(membership.gameId);
     if (game) emitLobby(game);
   };

--- a/server/live/boundary.test.ts
+++ b/server/live/boundary.test.ts
@@ -120,4 +120,19 @@ describe('createBoundaryMonitor', () => {
     const afresh = monitor.evaluate({ gameId: 'g', playerId: 'p', position: inside, boundary });
     expect(afresh).toMatchObject({ status: 'inside', changed: false });
   });
+
+  it('forgets a single player without disturbing others in the game', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 1 });
+    // Both players accrue a warning.
+    monitor.evaluate({ gameId: 'g', playerId: 'leaver', position: outside, boundary });
+    monitor.evaluate({ gameId: 'g', playerId: 'stayer', position: outside, boundary });
+
+    monitor.forget('g', 'leaver');
+
+    // The leaver starts clean, while the stayer keeps their accrued warning.
+    const leaverFresh = monitor.evaluate({ gameId: 'g', playerId: 'leaver', position: outside, boundary });
+    expect(leaverFresh).toMatchObject({ status: 'warned', warnings: 1 });
+    const stayerNext = monitor.evaluate({ gameId: 'g', playerId: 'stayer', position: outside, boundary });
+    expect(stayerNext).toMatchObject({ status: 'eliminated' });
+  });
 });

--- a/server/live/boundary.test.ts
+++ b/server/live/boundary.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createBoundaryMonitor,
+  DEFAULT_BOUNDARY_WARNINGS,
+  isInsideBoundary,
+  metersOutside,
+  type BoundaryCircle,
+} from './boundary.ts';
+
+/** A 500 m circle centred on Amsterdam's Dam square, for the geofence tests. */
+const boundary: BoundaryCircle = {
+  center: { lat: 52.3731, lng: 4.8922 },
+  radiusM: 500,
+};
+
+/**
+ * A point due north of `boundary.center` by roughly `meters`. One degree of
+ * latitude is ~111.32 km, enough precision to sit a fix a known distance out.
+ */
+function northOf(center: { lat: number; lng: number }, meters: number): { lat: number; lng: number } {
+  return { lat: center.lat + meters / 111_320, lng: center.lng };
+}
+
+describe('metersOutside / isInsideBoundary', () => {
+  it('reports zero and inside for the centre', () => {
+    expect(metersOutside(boundary, boundary.center)).toBe(0);
+    expect(isInsideBoundary(boundary, boundary.center)).toBe(true);
+  });
+
+  it('reports zero and inside for a point within the radius', () => {
+    const near = northOf(boundary.center, 300);
+    expect(metersOutside(boundary, near)).toBe(0);
+    expect(isInsideBoundary(boundary, near)).toBe(true);
+  });
+
+  it('reports the overshoot and outside for a point beyond the radius', () => {
+    const out = northOf(boundary.center, 800);
+    // ~800 m from the centre of a 500 m circle → ~300 m outside.
+    expect(metersOutside(boundary, out)).toBeGreaterThan(280);
+    expect(metersOutside(boundary, out)).toBeLessThan(320);
+    expect(isInsideBoundary(boundary, out)).toBe(false);
+  });
+});
+
+describe('createBoundaryMonitor', () => {
+  const inside = boundary.center;
+  const outside = northOf(boundary.center, 900);
+
+  it('reports inside with no change while the player stays in the area', () => {
+    const monitor = createBoundaryMonitor();
+    const v = monitor.evaluate({ gameId: 'g', playerId: 'p', position: inside, boundary });
+    expect(v).toMatchObject({ status: 'inside', changed: false, warnings: 0, metersOutside: 0 });
+    expect(v.warningsRemaining).toBe(DEFAULT_BOUNDARY_WARNINGS);
+  });
+
+  it('warns on exit, then eliminates on a continued exit (default policy = 1)', () => {
+    const monitor = createBoundaryMonitor(); // one warning, then out
+    const first = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(first).toMatchObject({ status: 'warned', changed: true, warnings: 1, warningsRemaining: 0 });
+    expect(first.metersOutside).toBeGreaterThan(390);
+
+    const second = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(second).toMatchObject({ status: 'eliminated', changed: true, warningsRemaining: 0 });
+  });
+
+  it('honours a custom warning count before eliminating', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 2 });
+    const one = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(one).toMatchObject({ status: 'warned', warnings: 1, warningsRemaining: 1 });
+    const two = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(two).toMatchObject({ status: 'warned', warnings: 2, warningsRemaining: 0 });
+    const three = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(three).toMatchObject({ status: 'eliminated', changed: true });
+  });
+
+  it('eliminates on the first exit with a zero-warning policy', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 0 });
+    const v = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(v).toMatchObject({ status: 'eliminated', changed: true, warnings: 1 });
+  });
+
+  it('resets the warning count when the player returns inside', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 2 });
+    monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+
+    const back = monitor.evaluate({ gameId: 'g', playerId: 'p', position: inside, boundary });
+    expect(back).toMatchObject({ status: 'inside', changed: true, warnings: 0, warningsRemaining: 2 });
+
+    // A fresh excursion starts the count over rather than resuming near elimination.
+    const again = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(again).toMatchObject({ status: 'warned', warnings: 1, warningsRemaining: 1 });
+  });
+
+  it('stays eliminated idempotently, even back inside the area', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 0 });
+    monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+
+    const stillOut = monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    expect(stillOut).toMatchObject({ status: 'eliminated', changed: false });
+
+    const backInside = monitor.evaluate({ gameId: 'g', playerId: 'p', position: inside, boundary });
+    expect(backInside).toMatchObject({ status: 'eliminated', changed: false });
+  });
+
+  it('tracks players and games independently', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 0 });
+    const a = monitor.evaluate({ gameId: 'g1', playerId: 'p1', position: outside, boundary });
+    expect(a.status).toBe('eliminated');
+    // A different player in a different game is unaffected.
+    const b = monitor.evaluate({ gameId: 'g2', playerId: 'p1', position: inside, boundary });
+    expect(b.status).toBe('inside');
+    const c = monitor.evaluate({ gameId: 'g1', playerId: 'p2', position: inside, boundary });
+    expect(c.status).toBe('inside');
+  });
+
+  it('forgets a game so a recycled id starts clean', () => {
+    const monitor = createBoundaryMonitor({ warningsBeforeElimination: 0 });
+    monitor.evaluate({ gameId: 'g', playerId: 'p', position: outside, boundary });
+    monitor.forget('g');
+    const afresh = monitor.evaluate({ gameId: 'g', playerId: 'p', position: inside, boundary });
+    expect(afresh).toMatchObject({ status: 'inside', changed: false });
+  });
+});

--- a/server/live/boundary.ts
+++ b/server/live/boundary.ts
@@ -95,8 +95,12 @@ export interface BoundaryMonitor {
     position: { lat: number; lng: number };
     boundary: BoundaryCircle;
   }): BoundaryVerdict;
-  /** Forget a game's tracked state, e.g. once the game ends or is torn down. */
-  forget(gameId: string): void;
+  /**
+   * Forget tracked state. With a `playerId`, drops just that player's entry —
+   * called when a single player leaves a still-running game so their warn/
+   * eliminate state doesn't linger. Without one, drops the whole game (teardown).
+   */
+  forget(gameId: string, playerId?: string): void;
 }
 
 /** A player's tracked boundary state within one game. */
@@ -172,7 +176,11 @@ export function createBoundaryMonitor({
       };
     },
 
-    forget(gameId) {
+    forget(gameId, playerId) {
+      if (playerId !== undefined) {
+        states.delete(`${gameId}:${playerId}`);
+        return;
+      }
       const prefix = `${gameId}:`;
       for (const key of states.keys()) {
         if (key.startsWith(prefix)) states.delete(key);

--- a/server/live/boundary.ts
+++ b/server/live/boundary.ts
@@ -1,0 +1,182 @@
+/**
+ * Boundary enforcement — the rules-engine geofence (BACKLOG.md #11, docs/arc42.md
+ * §5 "Rules engine" and the §8 glossary "Boundary"). A game may define a circular
+ * play area; every accepted position tick is checked against it, and a player who
+ * strays outside is warned, then eliminated once the warnings run out. Like every
+ * game-affecting decision, this is computed server-side from reported positions
+ * and never trusted from the client (docs/arc42.md quality goal #1 "Fairness /
+ * authority").
+ *
+ * The geofence maths is pure and reuses the tick engine's great-circle helper;
+ * the warn→eliminate policy is a small per-player state machine so the transport
+ * layer only has to react to the transitions this reports, not re-derive them.
+ */
+import { haversineMeters } from './tick.ts';
+
+/**
+ * A circular play area: a centre point and a radius in metres. This is the same
+ * shape the client draws as its boundary overlay (`client/src/game/geo.ts`) and
+ * the `games.boundary` column stores (see `db/schema.sql`), so one definition
+ * describes the play area everywhere.
+ */
+export interface BoundaryCircle {
+  center: { lat: number; lng: number };
+  radiusM: number;
+}
+
+/**
+ * Default number of warnings a player gets while outside the boundary before
+ * being eliminated: one warning, then elimination on continued exit — the literal
+ * "warns, then eliminates" of the issue's acceptance. Tunable per game once game
+ * settings land (BACKLOG.md #27).
+ */
+export const DEFAULT_BOUNDARY_WARNINGS = 1;
+
+/**
+ * How far a position sits outside a boundary, in metres. `0` when the point is
+ * inside or exactly on the radius. Pure — this is the geofence test itself.
+ */
+export function metersOutside(
+  boundary: BoundaryCircle,
+  pos: { lat: number; lng: number },
+): number {
+  return Math.max(0, haversineMeters(boundary.center, pos) - boundary.radiusM);
+}
+
+/** Whether a position is inside (or exactly on the edge of) a boundary. */
+export function isInsideBoundary(
+  boundary: BoundaryCircle,
+  pos: { lat: number; lng: number },
+): boolean {
+  return metersOutside(boundary, pos) === 0;
+}
+
+/** What the monitor decided for one player on one tick against the boundary. */
+export type BoundaryStatus = 'inside' | 'warned' | 'eliminated';
+
+/** The monitor's verdict for a single evaluated tick. */
+export interface BoundaryVerdict {
+  status: BoundaryStatus;
+  /**
+   * True only on the tick that changes a player's state — the edge the transport
+   * layer emits on: a fresh warning, the elimination, or a return inside after an
+   * excursion. Steady state (still comfortably inside, or already eliminated)
+   * reports `false` so nothing is re-emitted every tick.
+   */
+  changed: boolean;
+  /** Warnings issued on the current excursion so far (`0` while inside). */
+  warnings: number;
+  /** Warnings left before elimination (`0` once eliminated). */
+  warningsRemaining: number;
+  /** How far outside the boundary this fix sits, in metres (`0` while inside). */
+  metersOutside: number;
+}
+
+/** Tunables for {@link createBoundaryMonitor}. */
+export interface BoundaryMonitorOptions {
+  /**
+   * Warnings a player receives while outside before being eliminated. `0`
+   * eliminates on the first exit with no grace. Defaults to
+   * {@link DEFAULT_BOUNDARY_WARNINGS}.
+   */
+  warningsBeforeElimination?: number;
+}
+
+/** Per-player geofence state machine over a game's play area. */
+export interface BoundaryMonitor {
+  /**
+   * Evaluate one player's fix against a boundary, advancing their warn/eliminate
+   * state and returning the verdict. Idempotent once a player is eliminated: they
+   * stay out and further ticks report `changed: false`.
+   */
+  evaluate(input: {
+    gameId: string;
+    playerId: string;
+    position: { lat: number; lng: number };
+    boundary: BoundaryCircle;
+  }): BoundaryVerdict;
+  /** Forget a game's tracked state, e.g. once the game ends or is torn down. */
+  forget(gameId: string): void;
+}
+
+/** A player's tracked boundary state within one game. */
+interface PlayerState {
+  /** Warnings issued on the current excursion (reset to 0 on re-entry). */
+  warnings: number;
+  /** Terminal: once eliminated for leaving, a player stays eliminated. */
+  eliminated: boolean;
+}
+
+/**
+ * Build a stateful boundary monitor. State is keyed per `gameId:playerId` and
+ * bounded to players who have actually strayed (a player who never leaves the
+ * area is never tracked); {@link BoundaryMonitor.forget} drops a whole game.
+ */
+export function createBoundaryMonitor({
+  warningsBeforeElimination = DEFAULT_BOUNDARY_WARNINGS,
+}: BoundaryMonitorOptions = {}): BoundaryMonitor {
+  // Guard against a negative config making `warningsRemaining` nonsensical.
+  const maxWarnings = Math.max(0, Math.trunc(warningsBeforeElimination));
+  const states = new Map<string, PlayerState>();
+
+  return {
+    evaluate({ gameId, playerId, position, boundary }) {
+      const key = `${gameId}:${playerId}`;
+      const outside = metersOutside(boundary, position);
+      const state = states.get(key);
+
+      // Already eliminated: terminal, idempotent — report it without a new edge.
+      if (state?.eliminated) {
+        return {
+          status: 'eliminated',
+          changed: false,
+          warnings: state.warnings,
+          warningsRemaining: 0,
+          metersOutside: outside,
+        };
+      }
+
+      // Inside the play area: clear any accrued warnings. `changed` is true only
+      // when this fix actually ends an excursion (the player had warnings).
+      if (outside === 0) {
+        const returned = (state?.warnings ?? 0) > 0;
+        if (state) states.delete(key);
+        return {
+          status: 'inside',
+          changed: returned,
+          warnings: 0,
+          warningsRemaining: maxWarnings,
+          metersOutside: 0,
+        };
+      }
+
+      // Outside and not yet eliminated: count this exit.
+      const warnings = (state?.warnings ?? 0) + 1;
+      if (warnings > maxWarnings) {
+        states.set(key, { warnings, eliminated: true });
+        return {
+          status: 'eliminated',
+          changed: true,
+          warnings,
+          warningsRemaining: 0,
+          metersOutside: outside,
+        };
+      }
+      states.set(key, { warnings, eliminated: false });
+      return {
+        status: 'warned',
+        changed: true,
+        warnings,
+        warningsRemaining: maxWarnings - warnings,
+        metersOutside: outside,
+      };
+    },
+
+    forget(gameId) {
+      const prefix = `${gameId}:`;
+      for (const key of states.keys()) {
+        if (key.startsWith(prefix)) states.delete(key);
+      }
+    },
+  };
+}

--- a/server/live/index.ts
+++ b/server/live/index.ts
@@ -19,6 +19,7 @@ import {
 export * from './positions.ts';
 export * from './broadcaster.ts';
 export * from './tick.ts';
+export * from './boundary.ts';
 
 /** The hot-state layer wired into the server. */
 export interface LiveState {

--- a/server/lobby/rooms.test.ts
+++ b/server/lobby/rooms.test.ts
@@ -91,6 +91,23 @@ describe('createMemoryLobby', () => {
     expect(() => lobby.setReady('nope', player.id, true)).toThrow(/not found/i);
     expect(() => lobby.setRole(game.id, 'ghost', 'hunter')).toThrow(/not found/i);
   });
+
+  it('lets the host set the play area', () => {
+    const lobby = createMemoryLobby();
+    const { game, player } = lobby.createGame('Host');
+    const boundary = { center: { lat: 52.37, lng: 4.9 }, radiusM: 500 };
+    lobby.setBoundary(game.id, player.id, boundary);
+    expect(lobby.get(game.id)?.boundary).toEqual(boundary);
+  });
+
+  it('refuses a non-host setting the play area', () => {
+    const lobby = createMemoryLobby();
+    const { game } = lobby.createGame('Host');
+    const { player: guest } = lobby.joinGame(game.roomCode, 'Guest');
+    const boundary = { center: { lat: 0, lng: 0 }, radiusM: 100 };
+    expect(() => lobby.setBoundary(game.id, guest.id, boundary)).toThrow(/host/i);
+    expect(lobby.get(game.id)?.boundary).toBeUndefined();
+  });
 });
 
 describe('starting a game', () => {

--- a/server/lobby/rooms.ts
+++ b/server/lobby/rooms.ts
@@ -10,6 +10,7 @@
  * for this milestone.
  */
 import { randomInt, randomUUID } from 'node:crypto';
+import type { BoundaryCircle } from '../live/boundary.ts';
 
 /** Which side a player is on. */
 export type Role = 'hunter' | 'hider';
@@ -35,6 +36,12 @@ export interface Game {
   roomCode: string;
   status: GameStatus;
   players: Player[];
+  /**
+   * The circular play area the rules engine geofences against (BACKLOG.md #11).
+   * Optional: a game with no boundary is simply unenforced. Mirrors the
+   * `games.boundary` column; set by the host via {@link LobbyManager.setBoundary}.
+   */
+  boundary?: BoundaryCircle;
   createdAt: string;
   startedAt?: string;
 }
@@ -117,6 +124,8 @@ export interface LobbyManager {
   joinGame(roomCode: unknown, name: unknown): { game: Game; player: Player };
   /** Switch a player's own side. */
   setRole(gameId: string, playerId: string, role: Role): Game;
+  /** Host-only: define (or replace) the play area the rules engine enforces. */
+  setBoundary(gameId: string, playerId: string, boundary: BoundaryCircle): Game;
   /** Toggle a player's ready flag. */
   setReady(gameId: string, playerId: string, ready: boolean): Game;
   /** Host-only: move the room from `lobby` to `active`. */
@@ -213,6 +222,16 @@ export function createMemoryLobby(): LobbyManager {
       }
       const player = requirePlayer(game, playerId);
       player.role = role;
+      return game;
+    },
+
+    setBoundary(gameId, playerId, boundary) {
+      const game = getGameOrThrow(gameId);
+      const player = requirePlayer(game, playerId);
+      if (!player.isHost) {
+        throw new LobbyError('not_host', 'Only the host can set the play area');
+      }
+      game.boundary = boundary;
       return game;
     },
 

--- a/server/protocol/messages.test.ts
+++ b/server/protocol/messages.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BOUNDARY_RADIUS_RANGE,
   validateClaimCatch,
   validateJoin,
   validatePositionUpdate,
+  validateSetBoundary,
 } from './messages.ts';
 
 describe('validateJoin', () => {
@@ -84,5 +86,62 @@ describe('validateClaimCatch', () => {
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('expected invalid');
     expect(res.code).toBe('self_catch');
+  });
+});
+
+describe('validateSetBoundary', () => {
+  const boundary = { center: { lat: 52.3731, lng: 4.8922 }, radiusM: 500 };
+
+  it('accepts a well-formed circular boundary', () => {
+    const res = validateSetBoundary({ boundary });
+    expect(res).toEqual({ ok: true, value: { boundary } });
+  });
+
+  it('keeps only the recognized boundary fields', () => {
+    const res = validateSetBoundary({
+      boundary: { center: { lat: 1, lng: 2, extra: 'x' }, radiusM: 100, name: 'zone' },
+      junk: true,
+    });
+    if (!res.ok) throw new Error('expected valid');
+    expect(res.value).toEqual({ boundary: { center: { lat: 1, lng: 2 }, radiusM: 100 } });
+  });
+
+  it.each([undefined, null, 'boundary', 42])('rejects non-objects: %s', (payload) => {
+    expect(validateSetBoundary(payload).ok).toBe(false);
+  });
+
+  it('requires a boundary object', () => {
+    const res = validateSetBoundary({});
+    if (res.ok) throw new Error('expected invalid');
+    expect(res.code).toBe('boundary_required');
+  });
+
+  it.each([
+    ['missing center', { boundary: { radiusM: 500 } }],
+    ['non-object center', { boundary: { center: 'here', radiusM: 500 } }],
+    ['lat out of range', { boundary: { center: { lat: 91, lng: 2 }, radiusM: 500 } }],
+    ['lng out of range', { boundary: { center: { lat: 1, lng: 181 }, radiusM: 500 } }],
+    ['NaN lat', { boundary: { center: { lat: Number.NaN, lng: 2 }, radiusM: 500 } }],
+  ])('rejects a bad centre: %s', (_label, payload) => {
+    const res = validateSetBoundary(payload);
+    if (res.ok) throw new Error('expected invalid');
+    expect(res.code).toBe('invalid_center');
+  });
+
+  it.each([
+    ['zero radius', 0],
+    ['negative radius', -5],
+    ['NaN radius', Number.NaN],
+    ['above the max', BOUNDARY_RADIUS_RANGE.max + 1],
+  ])('rejects a bad radius: %s', (_label, radiusM) => {
+    const res = validateSetBoundary({ boundary: { center: { lat: 1, lng: 2 }, radiusM } });
+    if (res.ok) throw new Error('expected invalid');
+    expect(res.code).toBe('invalid_radius');
+  });
+
+  it('accepts the radius extremes', () => {
+    for (const radiusM of [BOUNDARY_RADIUS_RANGE.min, BOUNDARY_RADIUS_RANGE.max]) {
+      expect(validateSetBoundary({ boundary: { center: { lat: 0, lng: 0 }, radiusM } }).ok).toBe(true);
+    }
   });
 });

--- a/server/protocol/messages.ts
+++ b/server/protocol/messages.ts
@@ -18,7 +18,7 @@
  * (`server/lobby/rooms.ts`) and are named here so the contract lists every
  * event in one place.
  */
-import type { PositionsByPlayer } from '../live/index.ts';
+import type { BoundaryCircle, PositionsByPlayer } from '../live/index.ts';
 import type { Game } from '../lobby/rooms.ts';
 
 /** Inbound events (client → server) that carry a validated game-loop payload. */
@@ -26,6 +26,7 @@ export const INBOUND_EVENTS = {
   join: 'join',
   positionUpdate: 'position_update',
   claimCatch: 'claim_catch',
+  setBoundary: 'set_boundary',
 } as const;
 
 /** Outbound events (server → client) broadcast to a game's room. */
@@ -33,6 +34,8 @@ export const OUTBOUND_EVENTS = {
   gameState: 'game_state',
   catchConfirmed: 'catch_confirmed',
   lobbyUpdate: 'lobby_update',
+  boundaryWarning: 'boundary_warning',
+  playerEliminated: 'player_eliminated',
 } as const;
 
 // --- Inbound payloads (client → server) ------------------------------------
@@ -69,6 +72,16 @@ export interface ClaimCatchPayload {
   targetId: string;
 }
 
+/**
+ * `set_boundary` — the host defines (or replaces) the game's circular play area,
+ * the geofence the rules engine enforces (BACKLOG.md #11). Identity is the
+ * socket's lobby membership, so the payload carries only the boundary shape; the
+ * server checks the caller is the host.
+ */
+export interface SetBoundaryPayload {
+  boundary: BoundaryCircle;
+}
+
 // --- Outbound payloads (server → client) -----------------------------------
 
 /** `game_state` — a game's latest per-player positions, fanned out to its room. */
@@ -91,11 +104,50 @@ export interface LobbyUpdateEvent {
   game: Game;
 }
 
+/**
+ * `boundary_warning` — the server saw this player outside the play area and is
+ * warning them before elimination (BACKLOG.md #11). Sent to the offending player;
+ * `warningsRemaining` reaches 0 on the last warning, after which a continued exit
+ * eliminates.
+ */
+export interface BoundaryWarningEvent {
+  gameId: string;
+  playerId: string;
+  /** Warnings issued on this excursion so far. */
+  warnings: number;
+  /** Warnings left before elimination (0 means the next exit eliminates). */
+  warningsRemaining: number;
+  /** How far outside the boundary the player is, in metres. */
+  metersOutside: number;
+  /** When the server issued the warning (ISO-8601). */
+  at: string;
+}
+
+/**
+ * `player_eliminated` — the server removed a player from play. Broadcast to the
+ * whole room so everyone (and the win-condition check, BACKLOG.md #15) learns of
+ * it. `reason` is stable for future causes (boundary today; forfeit/timeout later).
+ */
+export interface PlayerEliminatedEvent {
+  gameId: string;
+  playerId: string;
+  reason: 'boundary';
+  /** When the server eliminated the player (ISO-8601). */
+  at: string;
+}
+
 // --- Validation ------------------------------------------------------------
 
 /** WGS84 coordinate bounds an inbound position must fall within. */
 export const LAT_RANGE = { min: -90, max: 90 } as const;
 export const LNG_RANGE = { min: -180, max: 180 } as const;
+
+/**
+ * Accepted range for a play-area radius, in metres. A boundary must enclose real
+ * ground (positive radius) yet stay sane — 100 km comfortably covers any playable
+ * area while rejecting a nonsensical planet-sized "boundary".
+ */
+export const BOUNDARY_RADIUS_RANGE = { min: 1, max: 100_000 } as const;
 
 /** A payload that passed validation, carrying the normalized value. */
 export interface Valid<T> {
@@ -186,4 +238,38 @@ export function validateClaimCatch(payload: unknown): Validation<ClaimCatchPaylo
     return invalid('self_catch', 'A hunter cannot catch themselves');
   }
   return valid({ gameId: body.gameId, hunterId: body.hunterId, targetId: body.targetId });
+}
+
+/** Whether a value is a finite number within an inclusive `[min, max]` range. */
+function isNumberInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max;
+}
+
+/**
+ * Validate a `set_boundary` payload: a circular play area with a WGS84 centre and
+ * a radius within {@link BOUNDARY_RADIUS_RANGE}. The normalized value carries only
+ * the recognized fields.
+ */
+export function validateSetBoundary(payload: unknown): Validation<SetBoundaryPayload> {
+  const body = asRecord(payload);
+  if (!body) return invalid('invalid_payload', 'Expected an object');
+  const boundary = asRecord(body.boundary);
+  if (!boundary) return invalid('boundary_required', 'boundary is required');
+  const center = asRecord(boundary.center);
+  if (
+    !center ||
+    !isNumberInRange(center.lat, LAT_RANGE.min, LAT_RANGE.max) ||
+    !isNumberInRange(center.lng, LNG_RANGE.min, LNG_RANGE.max)
+  ) {
+    return invalid('invalid_center', 'boundary.center must be a valid WGS84 coordinate');
+  }
+  if (!isNumberInRange(boundary.radiusM, BOUNDARY_RADIUS_RANGE.min, BOUNDARY_RADIUS_RANGE.max)) {
+    return invalid(
+      'invalid_radius',
+      `boundary.radiusM must be between ${BOUNDARY_RADIUS_RANGE.min} and ${BOUNDARY_RADIUS_RANGE.max} metres`,
+    );
+  }
+  return valid({
+    boundary: { center: { lat: center.lat, lng: center.lng }, radiusM: boundary.radiusM },
+  });
 }


### PR DESCRIPTION
Closes #11.

## What

Server-side play-area enforcement. A game may define a circular boundary; every accepted position tick is geofenced against it, and a player who strays outside is **warned**, then **eliminated** once the warnings run out — an authoritative, server-side decision, never trusted from the client (arc42 quality goal #1 "Fairness / authority").

## How

- **`server/live/boundary.ts`** — the rules-engine geofence:
  - Pure maths: `metersOutside` / `isInsideBoundary`, reusing the tick engine's great-circle `haversineMeters`.
  - `createBoundaryMonitor` — a per-`gameId:playerId` warn→eliminate state machine. Resets the warning count when a player returns inside; terminal and idempotent once eliminated. Warning count is configurable (`DEFAULT_BOUNDARY_WARNINGS = 1`, matching "warns, then eliminates"); tunable per game once settings land (#27).
- **Contract (`server/protocol/messages.ts`)** — new `set_boundary` inbound event with a validator (WGS84 centre + radius bounded to a sane 1 m–100 km range), and `boundary_warning` / `player_eliminated` outbound events.
- **Lobby (`server/lobby/rooms.ts`)** — host-only `setBoundary`; the boundary is stored on the game (mirrors the `games.boundary` column already in the schema).
- **Wiring (`server/app.ts`)** — the host defines the play area via `set_boundary`; each accepted `position_update` tick is geofenced. A warning is **personal** (emitted only to the offending socket); an elimination is **broadcast to the room** so everyone (and the eventual win check, #15) learns of it. A torn-down game's geofence state is forgotten.

Downstream concerns stay out of scope: removing an eliminated player from broadcasts / roster and win-condition handling are #14/#15; the client boundary-config UI is #27.

## Tests

- `server/live/boundary.test.ts` — geofence maths and the full state machine (warn→eliminate, custom/zero warning policy, reset on re-entry, idempotent elimination, per-game isolation, `forget`).
- `server/protocol/messages.test.ts` — `validateSetBoundary` (shape, WGS84 centre, radius range, field stripping).
- `server/lobby/rooms.test.ts` — host-only `setBoundary`.
- `server/app.boundary.test.ts` — socket-level integration: warn→eliminate over the wire, no warning while inside, and non-host / malformed rejection.

All server tests, lint, and typecheck pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwYi3UzV5THh3j6Jg52NBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwYi3UzV5THh3j6Jg52NBD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added circular play-area boundary enforcement for game rooms.
  * Hosts can configure boundaries via a host-only `set_boundary` event; invalid or non-host requests are rejected.
  * Players outside the boundary trigger `boundary_warning` and can be eliminated with `player_eliminated` (reason: boundary), including correct warn/eliminate transitions and re-entry behavior.

* **Documentation**
  * Updated the README with the new WebSocket contract and boundary event progression.

* **Tests**
  * Added unit/integration tests for boundary math, monitor state transitions, permission checks, validation rules, and server-wide boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->