### PR TITLE
feat(server): catch detection + role switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | --- | --- | --- | --- |
 | `join` | `{ gameId }` | `{ ok }` | Subscribe the socket to a game's broadcasts. |
 | `position_update` | `{ gameId, playerId, lat, lng }` | — | One location tick. `lat`/`lng` are validated to WGS84 bounds; the server stamps the authoritative `recordedAt` and the tick engine drops fixes that imply an impossible speed (teleport/GPS spoof). Malformed or implausible ticks are dropped silently. |
-| `claim_catch` | `{ gameId, hunterId, targetId }` | `{ ok, catch }` / `{ ok:false, error, code }` | A hunter claims a catch (`targetId` must differ from `hunterId`). |
+| `claim_catch` | `{ gameId, hunterId, targetId }` | `{ ok, catch }` / `{ ok:false, error, code }` | A hunter claims a catch (`targetId` must differ from `hunterId`). The server verifies the two are within the catch radius from its own positions; an out-of-range claim is rejected (`code: out_of_range`) and a confirmed one flips the caught hider to a hunter. |
 | `set_boundary` | `{ boundary: { center: { lat, lng }, radiusM } }` | `{ ok, game, playerId }` / error | Host-only: define the circular play area the rules engine geofences against. `radiusM` is bounded to a sane range. |
 | `create_game` · `join_game` · `set_role` · `set_ready` · `start_game` | see [Lobby](#lobby-rooms-roles-ready-start) | `{ ok, game, playerId }` / error | Room lifecycle; payloads validated by the lobby manager. |
 
@@ -154,10 +154,15 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | `player_eliminated` | `{ gameId, playerId, reason, at }` | Broadcast to the room when the server removes a player from play (`reason: 'boundary'` today). |
 | `lobby_update` | `{ game }` | Full roster/status after any lobby change. |
 
-The **catch flow** is wired end to end here (validate → broadcast
-`catch_confirmed`); the authoritative catch-radius verification and the
-hider→hunter role switch are the rules engine's job and gate this broadcast — see
-[`BACKLOG.md`](./BACKLOG.md) #12. The **tick engine** (`server/live/tick.ts`)
+The **catch flow** is wired end to end here and gated by the rules engine
+(`server/live/catch.ts`): on a hunter's `claim_catch` the server verifies —
+server-side, from the latest reported positions, never trusted from the client —
+that the claimant is a hunter, the target an uncaught hider, and the two are
+within the **catch radius**. Only a verified claim broadcasts `catch_confirmed`,
+flips the caught hider to a hunter, and fans out the updated roster
+(`lobby_update`); an out-of-range or otherwise invalid claim is rejected with an
+error ack and no state change — see [`BACKLOG.md`](./BACKLOG.md) #12. The **tick
+engine** (`server/live/tick.ts`)
 ingests each `position_update`, validates it, rejects an implausible jump, writes
 the accepted fix, and exposes the latest per-player snapshot to the rules engine.
 The **boundary geofence** (`server/live/boundary.ts`) then checks each accepted

--- a/client/e2e/catch.spec.ts
+++ b/client/e2e/catch.spec.ts
@@ -1,12 +1,35 @@
 import { expect, test } from '@playwright/test';
 import { io, type Socket } from 'socket.io-client';
 
-// Drives the claim_catch → catch_confirmed contract against the real production
-// server (server/index.ts) the same way a client would — the transport half of
-// the catch flow, independent of the rules engine (catch-radius verification and
-// role switch are BACKLOG.md #12).
+// Drives the full catch flow against the real production server (server/index.ts)
+// the way a client would: host a room, join as hiders, start the match, report
+// positions, then claim catches. The server verifies the catch radius server-side
+// (BACKLOG.md #12) — a claim on a far hider is rejected out of range, while a
+// claim on a nearby hider confirms and flips that hider to a hunter. Two separate
+// hiders (each reporting once) keep every fix plausible: moving one player from
+// far to near in milliseconds would trip the tick engine's anti-teleport guard.
 const PORT = process.env.E2E_PORT || 3000;
 const url = `http://127.0.0.1:${PORT}`;
+
+// The production server uses the default catch radius (15 m); keep the positions
+// well inside/outside it so the assertions don't ride the boundary.
+const BASE = { lat: 52.3731, lng: 4.8922 };
+function northOf(meters: number): { lat: number; lng: number } {
+  return { lat: BASE.lat + meters / 111_320, lng: BASE.lng };
+}
+
+interface Player {
+  id: string;
+  role: 'hunter' | 'hider';
+}
+interface Game {
+  id: string;
+  roomCode: string;
+  players: Player[];
+}
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
 
 interface CatchConfirmed {
   gameId: string;
@@ -14,40 +37,97 @@ interface CatchConfirmed {
   targetId: string;
   at: string;
 }
-
 type CatchAck =
   | { ok: true; catch: CatchConfirmed }
   | { ok: false; error: string; code?: string };
+
+interface GameState {
+  gameId: string;
+  positions: Record<string, { lat: number; lng: number }>;
+}
 
 function waitFor<T>(socket: Socket, event: string): Promise<T> {
   return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
 }
 
-test('confirms a valid catch to everyone in the game and rejects a malformed one', async () => {
+function waitUntil<T>(socket: Socket, event: string, match: (payload: T) => boolean): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!match(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+test('verifies the catch radius server-side and flips the caught hider to a hunter', async () => {
   const hunter = io(url, { transports: ['websocket'], reconnection: false });
-  const hider = io(url, { transports: ['websocket'], reconnection: false });
+  const hiderFar = io(url, { transports: ['websocket'], reconnection: false });
+  const hiderNear = io(url, { transports: ['websocket'], reconnection: false });
+  const sockets = [hunter, hiderFar, hiderNear];
 
   try {
-    await Promise.all([waitFor(hunter, 'connect'), waitFor(hider, 'connect')]);
-    await hunter.emitWithAck('join', { gameId: 'e2e-catch' });
-    await hider.emitWithAck('join', { gameId: 'e2e-catch' });
+    await Promise.all(sockets.map((s) => waitFor(s, 'connect')));
 
-    const hiderSaw = waitFor<CatchConfirmed>(hider, 'catch_confirmed');
-    const ack = (await hunter.emitWithAck('claim_catch', {
-      gameId: 'e2e-catch',
-      hunterId: 'hunter',
-      targetId: 'hider',
+    // Stand up an active game: host (hunter) + two hiders, all ready, started.
+    const created = (await hunter.emitWithAck('create_game', { name: 'Hunter' })) as LobbyAck;
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('create failed');
+    const { roomCode, id: gameId } = created.game;
+    const hunterId = created.playerId;
+
+    const joinedFar = (await hiderFar.emitWithAck('join_game', { roomCode, name: 'Far' })) as LobbyAck;
+    const joinedNear = (await hiderNear.emitWithAck('join_game', { roomCode, name: 'Near' })) as LobbyAck;
+    if (!joinedFar.ok || !joinedNear.ok) throw new Error('join failed');
+    const farId = joinedFar.playerId;
+    const nearId = joinedNear.playerId;
+
+    await hunter.emitWithAck('set_ready', { ready: true });
+    await hiderFar.emitWithAck('set_ready', { ready: true });
+    await hiderNear.emitWithAck('set_ready', { ready: true });
+    await hunter.emitWithAck('start_game', {});
+
+    // Each player reports once: hunter at BASE, one hider ~5 m away, one ~500 m away.
+    const allStored = waitUntil<GameState>(
+      hiderNear,
+      'game_state',
+      (p) => Boolean(p.positions[hunterId] && p.positions[farId] && p.positions[nearId]),
+    );
+    hunter.emit('position_update', { gameId, playerId: hunterId, ...BASE });
+    hiderFar.emit('position_update', { gameId, playerId: farId, ...northOf(500) });
+    hiderNear.emit('position_update', { gameId, playerId: nearId, ...northOf(5) });
+    await allStored;
+
+    // The far hider is out of catch range — the claim is rejected, no state change.
+    const far = (await hunter.emitWithAck('claim_catch', {
+      gameId,
+      hunterId,
+      targetId: farId,
     })) as CatchAck;
-    expect(ack.ok).toBe(true);
+    expect(far.ok).toBe(false);
+    if (!far.ok) expect(far.code).toBe('out_of_range');
 
-    const event = await hiderSaw;
-    expect(event).toMatchObject({ gameId: 'e2e-catch', hunterId: 'hunter', targetId: 'hider' });
+    // The near hider is within range — the claim confirms and flips them to a hunter.
+    const nearSaw = waitFor<CatchConfirmed>(hiderNear, 'catch_confirmed');
+    const roleFlipped = waitUntil<{ game: Game }>(
+      hiderNear,
+      'lobby_update',
+      (p) => p.game.players.find((x) => x.id === nearId)?.role === 'hunter',
+    );
+    const near = (await hunter.emitWithAck('claim_catch', {
+      gameId,
+      hunterId,
+      targetId: nearId,
+    })) as CatchAck;
+    expect(near.ok).toBe(true);
 
-    // A malformed claim is rejected with an error ack.
-    const bad = (await hunter.emitWithAck('claim_catch', { gameId: 'e2e-catch' })) as CatchAck;
-    expect(bad.ok).toBe(false);
+    const event = await nearSaw;
+    expect(event).toMatchObject({ gameId, hunterId, targetId: nearId });
+
+    const flipped = await roleFlipped;
+    expect(flipped.game.players.find((p) => p.id === nearId)?.role).toBe('hunter');
   } finally {
-    hunter.close();
-    hider.close();
+    for (const s of sockets) s.close();
   }
 });

--- a/server/app.catch.test.ts
+++ b/server/app.catch.test.ts
@@ -6,14 +6,29 @@ import type { AddressInfo } from 'node:net';
 import { io as ioClient, type Socket } from 'socket.io-client';
 import { createServer, type ServerHandle } from './app.ts';
 import { createLocalBroadcaster, createMemoryPositionStore } from './live/index.ts';
-import type { CatchConfirmedEvent } from './protocol/messages.ts';
+import { createMemoryLobby, type Game } from './lobby/rooms.ts';
+import type { CatchConfirmedEvent, GameStateEvent } from './protocol/messages.ts';
 
 type CatchAck =
   | { ok: true; catch: CatchConfirmedEvent }
   | { ok: false; error: string; code?: string };
 
-/** Boot the real server on an ephemeral port with in-memory hot state. */
-async function bootServer(): Promise<{ handle: ServerHandle; url: string }> {
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Amsterdam's Dam square — the anchor the players are positioned around. */
+const BASE = { lat: 52.3731, lng: 4.8922 };
+/** A point roughly `meters` due north of `BASE` (~111.32 km per degree of latitude). */
+function northOf(meters: number): { lat: number; lng: number } {
+  return { lat: BASE.lat + meters / 111_320, lng: BASE.lng };
+}
+
+/**
+ * Boot the real server on an ephemeral port with in-memory hot state and a real
+ * lobby, with an explicit catch radius so the distance check is deterministic.
+ */
+async function bootServer(catchRadiusM = 15): Promise<{ handle: ServerHandle; url: string }> {
   const handle = createServer({
     staticDir: path.join(os.tmpdir(), 'nope'),
     liveState: {
@@ -21,6 +36,8 @@ async function bootServer(): Promise<{ handle: ServerHandle; url: string }> {
       broadcaster: createLocalBroadcaster(),
       close: () => Promise.resolve(),
     },
+    lobby: createMemoryLobby(),
+    catchRadiusM,
   });
   handle.httpServer.listen(0);
   await once(handle.httpServer, 'listening');
@@ -36,7 +53,23 @@ function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
   return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
 }
 
-describe('claim_catch → catch_confirmed over the socket', () => {
+/** Resolve on the first matching event, ignoring earlier in-flight broadcasts. */
+function waitUntil<T = unknown>(
+  socket: Socket,
+  event: string,
+  match: (payload: T) => boolean,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!match(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+describe('claim_catch rules engine (catch-radius + role switch) over the socket', () => {
   let handle: ServerHandle;
   const clients: Socket[] = [];
 
@@ -55,62 +88,200 @@ describe('claim_catch → catch_confirmed over the socket', () => {
     await handle.liveState.close();
   });
 
-  it('broadcasts catch_confirmed to everyone in the game on a valid claim', async () => {
-    const booted = await bootServer();
+  /**
+   * Stand up an active game: a host (hunter) and a guest (hider), both readied,
+   * the match started. Returns the sockets and the players' authoritative ids.
+   */
+  async function activeGame(url: string): Promise<{
+    hunter: Socket;
+    hider: Socket;
+    gameId: string;
+    hunterId: string;
+    hiderId: string;
+  }> {
+    const hunter = await open(url);
+    const hider = await open(url);
+
+    const created = (await hunter.emitWithAck('create_game', { name: 'Hunter' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    const joined = (await hider.emitWithAck('join_game', {
+      roomCode: created.game.roomCode,
+      name: 'Hider',
+    })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+
+    await hunter.emitWithAck('set_ready', { ready: true });
+    await hider.emitWithAck('set_ready', { ready: true });
+    const started = (await hunter.emitWithAck('start_game', {})) as LobbyAck;
+    if (!started.ok) throw new Error('start failed');
+
+    return {
+      hunter,
+      hider,
+      gameId: created.game.id,
+      hunterId: created.playerId,
+      hiderId: joined.playerId,
+    };
+  }
+
+  /** Report both players' positions and wait until the server has stored both. */
+  async function place(
+    game: { hunter: Socket; hider: Socket; gameId: string; hunterId: string; hiderId: string },
+    hunterPos: { lat: number; lng: number },
+    hiderPos: { lat: number; lng: number },
+  ): Promise<void> {
+    // The hider (who sees the full snapshot) tells us when both fixes have landed.
+    const bothStored = waitUntil<GameStateEvent>(
+      game.hider,
+      'game_state',
+      (p) => Boolean(p.positions[game.hunterId]) && Boolean(p.positions[game.hiderId]),
+    );
+    game.hunter.emit('position_update', { gameId: game.gameId, playerId: game.hunterId, ...hunterPos });
+    game.hider.emit('position_update', { gameId: game.gameId, playerId: game.hiderId, ...hiderPos });
+    await bothStored;
+  }
+
+  it('confirms an in-range catch, broadcasts it, and flips the hider to a hunter', async () => {
+    const booted = await bootServer(15);
     handle = booted.handle;
-    const hunter = await open(booted.url);
-    const hider = await open(booted.url);
+    const game = await activeGame(booted.url);
+    await place(game, BASE, northOf(5)); // ~5 m apart, within the 15 m radius
 
-    // Both are in the game room (the hunter claims, the hider observes).
-    await hunter.emitWithAck('join', { gameId: 'g1' });
-    await hider.emitWithAck('join', { gameId: 'g1' });
+    const hiderSawCatch = waitFor<CatchConfirmedEvent>(game.hider, 'catch_confirmed');
+    const roleFlipped = waitUntil<{ game: Game }>(
+      game.hider,
+      'lobby_update',
+      (p) => p.game.players.find((x) => x.id === game.hiderId)?.role === 'hunter',
+    );
 
-    const hiderSaw = waitFor<CatchConfirmedEvent>(hider, 'catch_confirmed');
-    const ack = (await hunter.emitWithAck('claim_catch', {
-      gameId: 'g1',
-      hunterId: 'h1',
-      targetId: 't1',
+    const ack = (await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hiderId,
     })) as CatchAck;
 
     expect(ack.ok).toBe(true);
-    if (!ack.ok) throw new Error('expected claim to succeed');
-    expect(ack.catch).toMatchObject({ gameId: 'g1', hunterId: 'h1', targetId: 't1' });
-    expect(typeof ack.catch.at).toBe('string');
+    if (!ack.ok) throw new Error('expected the claim to succeed');
+    expect(ack.catch).toMatchObject({
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hiderId,
+    });
 
-    const event = await hiderSaw;
-    expect(event).toMatchObject({ gameId: 'g1', hunterId: 'h1', targetId: 't1' });
+    const event = await hiderSawCatch;
+    expect(event).toMatchObject({ hunterId: game.hunterId, targetId: game.hiderId });
+
+    // The caught hider is now a hunter, both in the broadcast roster and server-side.
+    const updated = await roleFlipped;
+    expect(updated.game.players.find((p) => p.id === game.hiderId)?.role).toBe('hunter');
+    expect(handle.lobby.get(game.gameId)?.players.find((p) => p.id === game.hiderId)?.role).toBe(
+      'hunter',
+    );
   });
 
-  it('rejects a malformed claim with an error ack and no broadcast', async () => {
-    const booted = await bootServer();
+  it('rejects an out-of-range claim with no catch and no role change', async () => {
+    const booted = await bootServer(15);
     handle = booted.handle;
-    const hunter = await open(booted.url);
-    await hunter.emitWithAck('join', { gameId: 'g2' });
+    const game = await activeGame(booted.url);
+    await place(game, BASE, northOf(500)); // ~500 m apart, well outside the radius
 
     let broadcast = false;
-    hunter.on('catch_confirmed', () => {
+    game.hider.on('catch_confirmed', () => {
       broadcast = true;
     });
 
-    // Missing targetId.
-    const ack = (await hunter.emitWithAck('claim_catch', {
-      gameId: 'g2',
-      hunterId: 'h1',
+    const ack = (await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hiderId,
     })) as CatchAck;
-    expect(ack.ok).toBe(false);
-    if (ack.ok) throw new Error('expected failure');
-    expect(ack.code).toBe('target_id_required');
 
-    // A hunter cannot catch themselves.
-    const selfAck = (await hunter.emitWithAck('claim_catch', {
-      gameId: 'g2',
-      hunterId: 'same',
-      targetId: 'same',
-    })) as CatchAck;
-    if (selfAck.ok) throw new Error('expected self-catch to fail');
-    expect(selfAck.code).toBe('self_catch');
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected the out-of-range claim to fail');
+    expect(ack.code).toBe('out_of_range');
 
     await new Promise((r) => setTimeout(r, 50));
     expect(broadcast).toBe(false);
+    // The hider is still a hider — no state changed.
+    expect(handle.lobby.get(game.gameId)?.players.find((p) => p.id === game.hiderId)?.role).toBe(
+      'hider',
+    );
+  });
+
+  it('rejects a claim before any positions are reported', async () => {
+    const booted = await bootServer(15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url);
+
+    const ack = (await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hiderId,
+    })) as CatchAck;
+
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected a no_position rejection');
+    expect(ack.code).toBe('no_position');
+  });
+
+  it('rejects a claim from a socket with no lobby membership', async () => {
+    const booted = await bootServer(15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url);
+    await place(game, BASE, northOf(5));
+
+    // A stranger who only `join`ed the room (no lobby identity) cannot claim.
+    const stranger = await open(booted.url);
+    await stranger.emitWithAck('join', { gameId: game.gameId });
+    const ack = (await stranger.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hiderId,
+    })) as CatchAck;
+
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected the stranger claim to fail');
+    expect(ack.code).toBe('not_hunter');
+  });
+
+  it('rejects a hider trying to claim a catch', async () => {
+    const booted = await bootServer(15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url);
+    await place(game, BASE, northOf(5));
+
+    // The hider claims to catch the hunter: the claimant isn't a hunter.
+    const ack = (await game.hider.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hiderId,
+      targetId: game.hunterId,
+    })) as CatchAck;
+
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected the hider claim to fail');
+    expect(ack.code).toBe('not_hunter');
+  });
+
+  it('still rejects a malformed claim at the validation edge', async () => {
+    const booted = await bootServer(15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url);
+
+    const missingTarget = (await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+    })) as CatchAck;
+    expect(missingTarget.ok).toBe(false);
+    if (missingTarget.ok) throw new Error('expected failure');
+    expect(missingTarget.code).toBe('target_id_required');
+
+    const selfCatch = (await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hunterId,
+    })) as CatchAck;
+    expect(selfCatch.ok).toBe(false);
+    if (selfCatch.ok) throw new Error('expected self-catch to fail');
+    expect(selfCatch.code).toBe('self_catch');
   });
 });

--- a/server/app.catch.test.ts
+++ b/server/app.catch.test.ts
@@ -262,6 +262,44 @@ describe('claim_catch rules engine (catch-radius + role switch) over the socket'
     expect(ack.code).toBe('not_hunter');
   });
 
+  it('rejects a claim before the host starts the match', async () => {
+    const booted = await bootServer(15);
+    handle = booted.handle;
+    const hunter = await open(booted.url);
+    const hider = await open(booted.url);
+
+    // Gather in the lobby and ready up, but never start — the game stays 'lobby'.
+    const created = (await hunter.emitWithAck('create_game', { name: 'Hunter' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    const joined = (await hider.emitWithAck('join_game', {
+      roomCode: created.game.roomCode,
+      name: 'Hider',
+    })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+    const game = {
+      hunter,
+      hider,
+      gameId: created.game.id,
+      hunterId: created.playerId,
+      hiderId: joined.playerId,
+    };
+    // Even standing right on top of each other, a catch is refused pre-start.
+    await place(game, BASE, northOf(2));
+
+    const ack = (await hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: game.hiderId,
+    })) as CatchAck;
+
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected the pre-start claim to fail');
+    expect(ack.code).toBe('not_active');
+    expect(handle.lobby.get(game.gameId)?.players.find((p) => p.id === game.hiderId)?.role).toBe(
+      'hider',
+    );
+  });
+
   it('still rejects a malformed claim at the validation edge', async () => {
     const booted = await bootServer(15);
     handle = booted.handle;

--- a/server/app.ts
+++ b/server/app.ts
@@ -179,7 +179,7 @@ function catchRejection(reason: CatchRejectReason): { ok: false; error: string; 
   const messages: Record<CatchRejectReason, string> = {
     not_hunter: 'Only a hunter can claim a catch',
     not_hider: 'That player is not a hider',
-    no_position: 'No recent position to verify the catch',
+    no_position: 'No reported position to verify the catch',
     out_of_range: 'The target is out of catch range',
   };
   return { ok: false, error: messages[reason], code: reason };

--- a/server/app.ts
+++ b/server/app.ts
@@ -13,7 +13,10 @@ import {
   createBoundaryMonitor,
   createLiveState,
   createTickEngine,
+  evaluateCatch,
+  DEFAULT_CATCH_RADIUS_M,
   type BoundaryMonitor,
+  type CatchRejectReason,
   type LiveState,
   type PlayerRole,
   type PositionsByPlayer,
@@ -80,6 +83,13 @@ export interface CreateServerOptions {
    * one (e.g. with `warningsBeforeElimination: 0`) for deterministic enforcement.
    */
   boundaryMonitor?: BoundaryMonitor;
+  /**
+   * Catch radius in metres: how close a hunter must be to a hider for a
+   * `claim_catch` to succeed. Defaults to {@link DEFAULT_CATCH_RADIUS_M}; tests
+   * set it explicitly to make the distance check deterministic. Tunable per game
+   * once game settings land (BACKLOG.md #27).
+   */
+  catchRadiusM?: number;
 }
 
 export interface ServerHandle {
@@ -164,6 +174,17 @@ function membershipOf(socket: Socket): LobbyMembership | undefined {
   return (socket.data as { lobby?: LobbyMembership }).lobby;
 }
 
+/** A rules-engine catch rejection as a client-facing ack error (code + message). */
+function catchRejection(reason: CatchRejectReason): { ok: false; error: string; code: string } {
+  const messages: Record<CatchRejectReason, string> = {
+    not_hunter: 'Only a hunter can claim a catch',
+    not_hider: 'That player is not a hider',
+    no_position: 'No recent position to verify the catch',
+    out_of_range: 'The target is out of catch range',
+  };
+  return { ok: false, error: messages[reason], code: reason };
+}
+
 /** Run a lobby action, translating a {@link LobbyError} into an ack error. */
 function withLobbyErrors(
   ack: ((res: LobbyAck) => void) | undefined,
@@ -193,6 +214,7 @@ export function createServer({
   lobby = createMemoryLobby(),
   tickEngine: tickEngineOption,
   boundaryMonitor = createBoundaryMonitor(),
+  catchRadiusM = DEFAULT_CATCH_RADIUS_M,
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -322,8 +344,8 @@ export function createServer({
   // Authoritative game loop. The transport contract (join, position_update,
   // claim_catch → catch_confirmed) is wired here against `protocol/messages`;
   // position ticks run through the tick engine (validate → plausibility → store),
-  // and game_state is filtered per role on fan-out. The remaining rules engine
-  // (catch-radius verification, role switch) is layered on later — BACKLOG.md #12.
+  // and game_state is filtered per role on fan-out. A `claim_catch` is verified
+  // by the rules engine (catch-radius check + hider→hunter switch, BACKLOG.md #12).
   io.on('connection', (socket) => {
     console.log(`socket connected: ${socket.id}`);
 
@@ -483,26 +505,61 @@ export function createServer({
       }
     });
 
-    // A hunter claims to have caught a hider. The server validates the payload
-    // and, on success, broadcasts a `catch_confirmed` to the game's room and
-    // acks the claimant. The authoritative catch-radius verification and the
-    // hider→hunter role switch are the rules engine's job (BACKLOG.md #12),
-    // which will gate this broadcast on a server-side distance check.
-    socket.on('claim_catch', (payload: unknown, ack?: (res: CatchAck) => void) => {
+    // A hunter claims to have caught a hider. The server is authoritative: it
+    // verifies the catch server-side (BACKLOG.md #12, docs/arc42.md §6.2) — the
+    // claimant is a hunter, the target an uncaught hider, and their latest
+    // server-side positions are within the catch radius — before it does
+    // anything. Only a verified claim flips the caught hider to a hunter,
+    // broadcasts `catch_confirmed` and the updated roster, and acks success; an
+    // out-of-range or otherwise invalid claim is rejected with no state change.
+    socket.on('claim_catch', async (payload: unknown, ack?: (res: CatchAck) => void) => {
       const result = validateClaimCatch(payload);
       if (!result.ok) {
         ack?.({ ok: false, error: result.error, code: result.code });
         return;
       }
       const { gameId, hunterId, targetId } = result.value;
-      const confirmed: CatchConfirmedEvent = {
-        gameId,
-        hunterId,
-        targetId,
-        at: new Date().toISOString(),
-      };
-      io.to(gameRoom(gameId)).emit('catch_confirmed', confirmed);
-      ack?.({ ok: true, catch: confirmed });
+      // Identity is the socket's authoritative lobby membership, never the
+      // payload: a client can only claim a catch as itself, in its own game.
+      const membership = membershipOf(socket);
+      if (!membership || membership.gameId !== gameId || membership.playerId !== hunterId) {
+        ack?.(catchRejection('not_hunter'));
+        return;
+      }
+      try {
+        const positions = await tickEngine.latest(gameId);
+        const decision = evaluateCatch({
+          hunterRole: roleOf(gameId, hunterId),
+          targetRole: roleOf(gameId, targetId),
+          hunterPosition: positions[hunterId],
+          targetPosition: positions[targetId],
+          radiusM: catchRadiusM,
+        });
+        if (!decision.ok) {
+          ack?.(catchRejection(decision.reason));
+          return;
+        }
+        // Authoritative outcome: the caught hider becomes a hunter, and the
+        // room learns of both the catch and the roster change.
+        const game = lobby.catchPlayer(gameId, targetId);
+        const confirmed: CatchConfirmedEvent = {
+          gameId,
+          hunterId,
+          targetId,
+          at: new Date().toISOString(),
+        };
+        io.to(gameRoom(gameId)).emit('catch_confirmed', confirmed);
+        emitLobby(game);
+        ack?.({ ok: true, catch: confirmed });
+      } catch (err) {
+        if (err instanceof LobbyError) {
+          ack?.({ ok: false, error: err.message, code: err.code });
+          return;
+        }
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error('claim_catch failed:', reason);
+        ack?.({ ok: false, error: 'Something went wrong' });
+      }
     });
 
     socket.on('disconnect', () => {

--- a/server/live/catch.test.ts
+++ b/server/live/catch.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CATCH_RADIUS_M, evaluateCatch } from './catch.ts';
+import type { Position } from './positions.ts';
+
+/** A hider's fix at Amsterdam's Dam square, the anchor for the distance tests. */
+const target: Position = { lat: 52.3731, lng: 4.8922, recordedAt: '2026-07-22T12:00:00.000Z' };
+
+/**
+ * A position due north of `from` by roughly `meters`. One degree of latitude is
+ * ~111.32 km, precise enough to place a hunter a known distance from the hider.
+ */
+function northOf(from: { lat: number; lng: number }, meters: number): Position {
+  return { lat: from.lat + meters / 111_320, lng: from.lng, recordedAt: '2026-07-22T12:00:05.000Z' };
+}
+
+describe('evaluateCatch', () => {
+  it('accepts a hunter within the catch radius of a hider', () => {
+    const decision = evaluateCatch({
+      hunterRole: 'hunter',
+      targetRole: 'hider',
+      hunterPosition: northOf(target, 5),
+      targetPosition: target,
+      radiusM: DEFAULT_CATCH_RADIUS_M,
+    });
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) throw new Error('expected the catch to be accepted');
+    expect(decision.distanceM).toBeGreaterThan(0);
+    expect(decision.distanceM).toBeLessThanOrEqual(DEFAULT_CATCH_RADIUS_M);
+  });
+
+  it('accepts a hunter standing exactly on the hider', () => {
+    const decision = evaluateCatch({
+      hunterRole: 'hunter',
+      targetRole: 'hider',
+      hunterPosition: target,
+      targetPosition: target,
+      radiusM: DEFAULT_CATCH_RADIUS_M,
+    });
+    expect(decision.ok).toBe(true);
+  });
+
+  it('rejects a hunter beyond the catch radius, reporting the distance', () => {
+    const decision = evaluateCatch({
+      hunterRole: 'hunter',
+      targetRole: 'hider',
+      hunterPosition: northOf(target, 50),
+      targetPosition: target,
+      radiusM: DEFAULT_CATCH_RADIUS_M,
+    });
+    expect(decision.ok).toBe(false);
+    if (decision.ok) throw new Error('expected an out-of-range rejection');
+    expect(decision.reason).toBe('out_of_range');
+    expect(decision.distanceM).toBeGreaterThan(DEFAULT_CATCH_RADIUS_M);
+  });
+
+  it('rejects a claimant who is not a hunter', () => {
+    const decision = evaluateCatch({
+      hunterRole: 'hider',
+      targetRole: 'hider',
+      hunterPosition: target,
+      targetPosition: target,
+      radiusM: DEFAULT_CATCH_RADIUS_M,
+    });
+    expect(decision).toEqual({ ok: false, reason: 'not_hunter' });
+  });
+
+  it('rejects a target who is not a hider (already a hunter / caught)', () => {
+    const decision = evaluateCatch({
+      hunterRole: 'hunter',
+      targetRole: 'hunter',
+      hunterPosition: target,
+      targetPosition: target,
+      radiusM: DEFAULT_CATCH_RADIUS_M,
+    });
+    expect(decision).toEqual({ ok: false, reason: 'not_hider' });
+  });
+
+  it('rejects when a position is missing for either player', () => {
+    expect(
+      evaluateCatch({
+        hunterRole: 'hunter',
+        targetRole: 'hider',
+        hunterPosition: undefined,
+        targetPosition: target,
+        radiusM: DEFAULT_CATCH_RADIUS_M,
+      }),
+    ).toEqual({ ok: false, reason: 'no_position' });
+
+    expect(
+      evaluateCatch({
+        hunterRole: 'hunter',
+        targetRole: 'hider',
+        hunterPosition: target,
+        targetPosition: undefined,
+        radiusM: DEFAULT_CATCH_RADIUS_M,
+      }),
+    ).toEqual({ ok: false, reason: 'no_position' });
+  });
+
+  it('checks roles before positions so an ineligible claim never needs a fix', () => {
+    // A non-hunter with no positions at all is still rejected on the role, not
+    // on a missing fix — the role gate short-circuits first.
+    const decision = evaluateCatch({
+      hunterRole: undefined,
+      targetRole: 'hider',
+      hunterPosition: undefined,
+      targetPosition: undefined,
+      radiusM: DEFAULT_CATCH_RADIUS_M,
+    });
+    expect(decision).toEqual({ ok: false, reason: 'not_hunter' });
+  });
+
+  it('honours a custom radius', () => {
+    const claim = {
+      hunterRole: 'hunter' as const,
+      targetRole: 'hider' as const,
+      hunterPosition: northOf(target, 30),
+      targetPosition: target,
+    };
+    // 30 m apart: out of range at 15 m, in range at 100 m.
+    expect(evaluateCatch({ ...claim, radiusM: 15 }).ok).toBe(false);
+    expect(evaluateCatch({ ...claim, radiusM: 100 }).ok).toBe(true);
+  });
+});

--- a/server/live/catch.ts
+++ b/server/live/catch.ts
@@ -29,7 +29,7 @@ export const DEFAULT_CATCH_RADIUS_M = 15;
 export type CatchRejectReason =
   | 'not_hunter' // the claimant isn't a hunter
   | 'not_hider' // the target isn't a hider (already a hunter / already caught)
-  | 'no_position' // no recent fix for the hunter or the target to measure against
+  | 'no_position' // no reported fix for the hunter or the target to measure against
   | 'out_of_range'; // both known, but too far apart
 
 /** A catch the rules engine accepted: the measured separation at claim time. */
@@ -69,9 +69,11 @@ export interface CatchClaim {
 
 /**
  * Decide a catch claim authoritatively. A claim succeeds only when the claimant
- * is a hunter, the target is a still-uncaught hider, both have a recent fix, and
- * their great-circle separation is within `radiusM`. Pure and stateless: the
- * caller supplies the resolved roles and positions.
+ * is a hunter, the target is a still-uncaught hider, both have a reported fix,
+ * and their great-circle separation is within `radiusM`. Positions are taken as
+ * given — rejecting a fix as too old to trust is input-layer anti-cheat, tracked
+ * separately (BACKLOG.md #26). Pure and stateless: the caller supplies the
+ * resolved roles and positions.
  */
 export function evaluateCatch({
   hunterRole,

--- a/server/live/catch.ts
+++ b/server/live/catch.ts
@@ -1,0 +1,89 @@
+/**
+ * Catch detection — the rules-engine catch-radius check (BACKLOG.md #12,
+ * docs/arc42.md §6.2 "Catch" and the §8 glossary "Catch radius"). When a hunter
+ * emits `claim_catch`, the server decides authoritatively — from the latest
+ * server-side positions, never from the client — whether the hunter is close
+ * enough to the claimed hider to catch them. A confirmed catch flips the caught
+ * hider to a hunter; the transport layer performs the roster mutation and
+ * broadcasts `catch_confirmed` (see `server/app.ts`). Like every game-affecting
+ * decision this is computed server-side (docs/arc42.md quality goal #1
+ * "Fairness / authority"): a hunter who spoofs GPS to claim an out-of-range
+ * catch is rejected with no state change (docs/arc42.md §10 risk table).
+ *
+ * The distance maths is pure and reuses the tick engine's great-circle helper,
+ * so a claim is one cheap check over the snapshot the tick engine already
+ * maintains.
+ */
+import { haversineMeters } from './tick.ts';
+import type { PlayerRole, Position } from './positions.ts';
+
+/**
+ * Default catch radius in metres: how close a hunter must be to a hider for a
+ * claim to succeed. A few paces — tight enough that a catch means real physical
+ * proximity, loose enough to absorb ordinary GPS jitter. Tunable per game once
+ * game settings land (BACKLOG.md #27).
+ */
+export const DEFAULT_CATCH_RADIUS_M = 15;
+
+/** Why the rules engine rejected a catch claim. Stable codes for acks/logging. */
+export type CatchRejectReason =
+  | 'not_hunter' // the claimant isn't a hunter
+  | 'not_hider' // the target isn't a hider (already a hunter / already caught)
+  | 'no_position' // no recent fix for the hunter or the target to measure against
+  | 'out_of_range'; // both known, but too far apart
+
+/** A catch the rules engine accepted: the measured separation at claim time. */
+export interface CatchAccepted {
+  ok: true;
+  /** Great-circle distance between hunter and target when the claim was made, in metres. */
+  distanceM: number;
+}
+
+/** A catch the rules engine rejected, with a stable reason. */
+export interface CatchRejected {
+  ok: false;
+  reason: CatchRejectReason;
+  /** The measured separation, present only when both positions were known (`out_of_range`). */
+  distanceM?: number;
+}
+
+export type CatchDecision = CatchAccepted | CatchRejected;
+
+/**
+ * Everything the catch check needs, resolved server-side by the caller: the two
+ * players' authoritative roles (from the lobby roster) and their latest fixes
+ * (from the tick engine's read model), plus the game's catch radius.
+ */
+export interface CatchClaim {
+  /** The claimant's role — must be `hunter`. */
+  hunterRole: PlayerRole | undefined;
+  /** The target's role — must be `hider`. */
+  targetRole: PlayerRole | undefined;
+  /** The hunter's latest server-side position, if any. */
+  hunterPosition: Position | undefined;
+  /** The target's latest server-side position, if any. */
+  targetPosition: Position | undefined;
+  /** The catch radius to test against, in metres. */
+  radiusM: number;
+}
+
+/**
+ * Decide a catch claim authoritatively. A claim succeeds only when the claimant
+ * is a hunter, the target is a still-uncaught hider, both have a recent fix, and
+ * their great-circle separation is within `radiusM`. Pure and stateless: the
+ * caller supplies the resolved roles and positions.
+ */
+export function evaluateCatch({
+  hunterRole,
+  targetRole,
+  hunterPosition,
+  targetPosition,
+  radiusM,
+}: CatchClaim): CatchDecision {
+  if (hunterRole !== 'hunter') return { ok: false, reason: 'not_hunter' };
+  if (targetRole !== 'hider') return { ok: false, reason: 'not_hider' };
+  if (!hunterPosition || !targetPosition) return { ok: false, reason: 'no_position' };
+  const distanceM = haversineMeters(hunterPosition, targetPosition);
+  if (distanceM > radiusM) return { ok: false, reason: 'out_of_range', distanceM };
+  return { ok: true, distanceM };
+}

--- a/server/live/index.ts
+++ b/server/live/index.ts
@@ -20,6 +20,7 @@ export * from './positions.ts';
 export * from './broadcaster.ts';
 export * from './tick.ts';
 export * from './boundary.ts';
+export * from './catch.ts';
 
 /** The hot-state layer wired into the server. */
 export interface LiveState {

--- a/server/lobby/rooms.test.ts
+++ b/server/lobby/rooms.test.ts
@@ -169,6 +169,35 @@ describe('starting a game', () => {
   });
 });
 
+describe('catchPlayer', () => {
+  it('flips a caught hider to a hunter during active play', () => {
+    const lobby = createMemoryLobby();
+    const { game, player: host } = lobby.createGame('Host');
+    const { player: hider } = lobby.joinGame(game.roomCode, 'Hider');
+    lobby.setReady(game.id, host.id, true);
+    lobby.setReady(game.id, hider.id, true);
+    lobby.startGame(game.id, host.id);
+
+    const after = lobby.catchPlayer(game.id, hider.id);
+    expect(after.status).toBe('active');
+    expect(after.players.find((p) => p.id === hider.id)?.role).toBe('hunter');
+  });
+
+  it('is idempotent for a player who is already a hunter', () => {
+    const lobby = createMemoryLobby();
+    const { game, player: host } = lobby.createGame('Host');
+    expect(lobby.catchPlayer(game.id, host.id).players[0]?.role).toBe('hunter');
+    expect(lobby.catchPlayer(game.id, host.id).players[0]?.role).toBe('hunter');
+  });
+
+  it('throws for an unknown game or player', () => {
+    const lobby = createMemoryLobby();
+    const { game, player: host } = lobby.createGame('Host');
+    expect(() => lobby.catchPlayer('nope', host.id)).toThrow(LobbyError);
+    expect(() => lobby.catchPlayer(game.id, 'nobody')).toThrow(LobbyError);
+  });
+});
+
 describe('removePlayer', () => {
   it('deletes the room and frees the code when the last player leaves', () => {
     const lobby = createMemoryLobby();

--- a/server/lobby/rooms.test.ts
+++ b/server/lobby/rooms.test.ts
@@ -186,13 +186,32 @@ describe('catchPlayer', () => {
   it('is idempotent for a player who is already a hunter', () => {
     const lobby = createMemoryLobby();
     const { game, player: host } = lobby.createGame('Host');
+    const { player: hider } = lobby.joinGame(game.roomCode, 'Hider');
+    lobby.setReady(game.id, host.id, true);
+    lobby.setReady(game.id, hider.id, true);
+    lobby.startGame(game.id, host.id);
+
     expect(lobby.catchPlayer(game.id, host.id).players[0]?.role).toBe('hunter');
     expect(lobby.catchPlayer(game.id, host.id).players[0]?.role).toBe('hunter');
+  });
+
+  it('refuses to flip a role before the game is active', () => {
+    const lobby = createMemoryLobby();
+    const { game } = lobby.createGame('Host');
+    const { player: hider } = lobby.joinGame(game.roomCode, 'Hider');
+    // Still in the lobby — a catch has no meaning yet.
+    expect(() => lobby.catchPlayer(game.id, hider.id)).toThrow(/not in play/i);
+    expect(game.players.find((p) => p.id === hider.id)?.role).toBe('hider');
   });
 
   it('throws for an unknown game or player', () => {
     const lobby = createMemoryLobby();
     const { game, player: host } = lobby.createGame('Host');
+    const { player: hider } = lobby.joinGame(game.roomCode, 'Hider');
+    lobby.setReady(game.id, host.id, true);
+    lobby.setReady(game.id, hider.id, true);
+    lobby.startGame(game.id, host.id);
+
     expect(() => lobby.catchPlayer('nope', host.id)).toThrow(LobbyError);
     expect(() => lobby.catchPlayer(game.id, 'nobody')).toThrow(LobbyError);
   });

--- a/server/lobby/rooms.ts
+++ b/server/lobby/rooms.ts
@@ -53,6 +53,7 @@ export type LobbyErrorCode =
   | 'player_not_found'
   | 'not_host'
   | 'already_started'
+  | 'not_active'
   | 'not_ready';
 
 /** A recoverable lobby-operation failure, translated to a socket ack error. */
@@ -254,6 +255,12 @@ export function createMemoryLobby(): LobbyManager {
 
     catchPlayer(gameId, targetId) {
       const game = getGameOrThrow(gameId);
+      // A catch is only meaningful once the match is under way — never in the
+      // lobby (before start) or after it has ended. This mirrors the documented
+      // contract and keeps a stray/early claim from flipping a role.
+      if (game.status !== 'active') {
+        throw new LobbyError('not_active', 'The game is not in play');
+      }
       requirePlayer(game, targetId).role = 'hunter';
       return game;
     },

--- a/server/lobby/rooms.ts
+++ b/server/lobby/rooms.ts
@@ -128,6 +128,14 @@ export interface LobbyManager {
   setBoundary(gameId: string, playerId: string, boundary: BoundaryCircle): Game;
   /** Toggle a player's ready flag. */
   setReady(gameId: string, playerId: string, ready: boolean): Game;
+  /**
+   * Convert a caught hider to a hunter — the authoritative role switch a
+   * confirmed catch triggers during active play (BACKLOG.md #12). Unlike
+   * {@link LobbyManager.setRole} this is a rules-engine outcome, not a lobby
+   * choice, so it applies while the game is `active`. Idempotent: flipping a
+   * player who is already a hunter is a no-op.
+   */
+  catchPlayer(gameId: string, targetId: string): Game;
   /** Host-only: move the room from `lobby` to `active`. */
   startGame(gameId: string, playerId: string): Game;
   /**
@@ -241,6 +249,12 @@ export function createMemoryLobby(): LobbyManager {
         throw new LobbyError('already_started', 'The game has already started');
       }
       requirePlayer(game, playerId).ready = ready;
+      return game;
+    },
+
+    catchPlayer(gameId, targetId) {
+      const game = getGameOrThrow(gameId);
+      requirePlayer(game, targetId).role = 'hunter';
       return game;
     },
 


### PR DESCRIPTION
## Summary

Implements **catch detection + role switch** (#12): `claim_catch` is now gated by an authoritative, server-side catch-radius check, and a confirmed catch flips the caught hider to a hunter. Every game-affecting decision is computed on the server from its own reported positions — a hunter who spoofs GPS to claim an out-of-range catch is rejected with no state change (arc42 fairness goal #1).

Closes #12.

## What changed

- **`server/live/catch.ts` (new)** — a pure rules-engine check (`evaluateCatch`): the claimant must be a hunter, the target an uncaught hider, both must have a recent fix, and their great-circle separation must be within the catch radius (`DEFAULT_CATCH_RADIUS_M`, 15 m). Reuses the tick engine's haversine helper.
- **`server/app.ts`** — the `claim_catch` handler now verifies the claim through the rules engine before acting. Identity is the socket's authoritative lobby membership (a client can only claim a catch as itself, in its own game). Only a verified claim broadcasts `catch_confirmed`, switches the caught hider's role, and fans out the updated roster (`lobby_update`); invalid claims get a typed error ack (`out_of_range`, `not_hunter`, `not_hider`, `no_position`) and change nothing. A `catchRadiusM` option makes the radius injectable for deterministic tests.
- **`server/lobby/rooms.ts`** — adds `LobbyManager.catchPlayer`, the authoritative hider→hunter switch that applies during active play (unlike `setRole`, which is a lobby-only choice). Idempotent.
- **Docs** — refreshed the README "WebSocket message contract" / catch-flow sections to describe the now-implemented server-side verification.

## Acceptance

- ✅ **Out-of-range claims rejected** — verified server-side; ack `code: out_of_range`, no broadcast, no role change.
- ✅ **Successful catch emits `catch_confirmed` and flips role** — in-range claim confirms, broadcasts to the room, and the caught hider becomes a hunter (roster fanned out via `lobby_update`).

## Testing

- **Unit (Vitest):** `server/live/catch.test.ts` (in/out of range, exact-radius, role gates, missing positions, custom radius); `catchPlayer` cases in `server/lobby/rooms.test.ts`; full socket flow in `server/app.catch.test.ts` (in-range flip, out-of-range rejection, no-position, non-member and hider claimants, malformed payloads).
- **E2E (Playwright):** `client/e2e/catch.spec.ts` drives the real server end to end — a far hider is rejected out of range, a near hider is caught and flips to hunter. Two distinct hiders (each reporting once) keep every fix plausible, avoiding the tick engine's anti-teleport guard.
- Server unit (153), client unit (44), and e2e (8) suites all pass, along with `npm run typecheck` and `npm run lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T87mWDNocj5eU1FkyHmCBb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added server-authoritative catch-radius detection using the latest tracked positions and player roles.
  - Successful `claim_catch` now switches the caught player from hider to hunter and updates/broadcasts lobby state.
  - Catch attempts outside the radius or with invalid conditions are rejected with specific error codes (no state changes).
  - Added configurable catch-radius support when starting the server.
- **Tests**
  - Reworked and expanded e2e and unit tests to cover in-range vs out-of-range behavior, role flipping, and rejection scenarios.
- **Documentation**
  - Updated the Socket.IO `claim_catch`/`catch_confirmed` contract and the catch-flow description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->