### PR TITLE
feat(server): ping-reveal scheduler (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 
 | Event | Payload | Notes |
 | --- | --- | --- |
-| `game_state` | `{ gameId, positions }` | Latest per-player positions, fanned out to the game's room each tick. |
+| `game_state` | `{ gameId, positions, reveal? }` | Latest per-player positions, fanned out to the game's room each tick — filtered per recipient's role. `reveal: true` marks a scheduled ping reveal, where hider positions are disclosed to hunters. |
 | `catch_confirmed` | `{ gameId, hunterId, targetId, at }` | The server accepted a catch; broadcast to the game's room. |
 | `boundary_warning` | `{ gameId, playerId, warnings, warningsRemaining, metersOutside, at }` | Sent to a player the server saw outside the play area, before elimination. |
 | `player_eliminated` | `{ gameId, playerId, reason, at }` | Broadcast to the room when the server removes a player from play (`reason: 'boundary'` today). |
@@ -169,7 +169,12 @@ The **boundary geofence** (`server/live/boundary.ts`) then checks each accepted
 fix against the game's play area (set by the host via `set_boundary`): a player
 who strays outside is warned (`boundary_warning`), then eliminated
 (`player_eliminated`) once the warnings run out — every check server-side, per
-[`BACKLOG.md`](./BACKLOG.md) #11. See `docs/arc42.md` §6 for the runtime view.
+[`BACKLOG.md`](./BACKLOG.md) #11. The **ping-reveal scheduler**
+(`server/live/ping.ts`) runs a timer per active game: on the configured interval
+(`PING_INTERVAL_S`, default 180 s) it forces the game's current positions into a
+`game_state` broadcast with the per-role filter lifted, so hunters get a periodic
+fix on the hiders and can't just camp — the one exception to per-role filtering,
+per [`BACKLOG.md`](./BACKLOG.md) #13. See `docs/arc42.md` §6 for the runtime view.
 
 ### Live state (Redis)
 
@@ -180,9 +185,10 @@ pub/sub (see [`docs/arc42.md`](./docs/arc42.md) §5.2, ADR-004). On each validat
 the server writes the reported position to a per-game Redis hash and publishes
 the game's positions to every instance, which emit `game_state` to the sockets in
 that game's room — **filtered per recipient's role** (resolved from the lobby
-roster) so hunters never receive hider coordinates. The scheduled-reveal
-exception and the authoritative tick cadence are part of the rules engine
-([BACKLOG.md](./BACKLOG.md) #14).
+roster) so hunters never receive hider coordinates
+([BACKLOG.md](./BACKLOG.md) #14), except on a scheduled **ping reveal**
+(`server/live/ping.ts`), which lifts the filter for one broadcast so hunters get
+a periodic fix on the hiders ([BACKLOG.md](./BACKLOG.md) #13).
 
 Point the server at Redis with `REDIS_URL` (see [`.env.example`](./.env.example);
 `docker compose up` provides one). Redis is **optional in development**: with no

--- a/server/app.ping.test.ts
+++ b/server/app.ping.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { once } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import { createServer, type ServerHandle } from './app.ts';
+import {
+  createLocalBroadcaster,
+  createMemoryPositionStore,
+  type PingTimerApi,
+} from './live/index.ts';
+import { createMemoryLobby } from './lobby/rooms.ts';
+import type { GameStateEvent } from './protocol/messages.ts';
+
+/**
+ * A controllable timer backing the server's ping-reveal scheduler: instead of a
+ * real interval, it records the registered handlers so a test can fire a reveal
+ * tick on demand (`fire()`), making the reveal deterministic.
+ */
+function fakeTimers(): PingTimerApi & { fire: () => void } {
+  const handlers = new Map<number, () => void>();
+  let nextId = 1;
+  return {
+    setInterval(handler) {
+      const id = nextId++;
+      handlers.set(id, handler);
+      return id;
+    },
+    clearInterval(handle) {
+      handlers.delete(handle as number);
+    },
+    fire() {
+      for (const handler of handlers.values()) handler();
+    },
+  };
+}
+
+async function bootServer(
+  timers: PingTimerApi,
+): Promise<{ handle: ServerHandle; url: string }> {
+  const handle = createServer({
+    staticDir: path.join(os.tmpdir(), 'nope'),
+    liveState: {
+      store: createMemoryPositionStore(),
+      broadcaster: createLocalBroadcaster(),
+      close: () => Promise.resolve(),
+    },
+    lobby: createMemoryLobby(),
+    pingTimers: timers,
+  });
+  handle.httpServer.listen(0);
+  await once(handle.httpServer, 'listening');
+  const { port } = handle.httpServer.address() as AddressInfo;
+  return { handle, url: `http://127.0.0.1:${port}` };
+}
+
+function connect(url: string): Socket {
+  return ioClient(url, { transports: ['websocket'], reconnection: false });
+}
+
+function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+/** Resolve on the first `event` payload that satisfies `pred`, ignoring the rest. */
+function waitForMatch<T = unknown>(
+  socket: Socket,
+  event: string,
+  pred: (payload: T) => boolean,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!pred(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+type LobbyAck =
+  | { ok: true; game: { id: string; roomCode: string }; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Stand up an active game: host (hunter) + guest (hider), both ready, started. */
+async function startedGame(
+  hunter: Socket,
+  hider: Socket,
+): Promise<{ gameId: string; hiderId: string }> {
+  const created = (await hunter.emitWithAck('create_game', { name: 'Seeker' })) as LobbyAck;
+  if (!created.ok) throw new Error('create_game failed');
+  const { id: gameId, roomCode } = created.game;
+  const joined = (await hider.emitWithAck('join_game', { roomCode, name: 'Runner' })) as LobbyAck;
+  if (!joined.ok) throw new Error('join_game failed');
+  await hunter.emitWithAck('set_ready', { ready: true });
+  await hider.emitWithAck('set_ready', { ready: true });
+  const started = (await hunter.emitWithAck('start_game', {})) as LobbyAck;
+  if (!started.ok) throw new Error(`start_game failed: ${started.error}`);
+  return { gameId, hiderId: joined.playerId };
+}
+
+describe('ping-reveal scheduler over the socket', () => {
+  let handle: ServerHandle;
+  const clients: Socket[] = [];
+
+  async function open(url: string): Promise<Socket> {
+    const c = connect(url);
+    clients.push(c);
+    await waitFor(c, 'connect');
+    return c;
+  }
+
+  afterEach(async () => {
+    handle.pingScheduler.stopAll();
+    for (const c of clients.splice(0)) c.close();
+    handle.io.close();
+    handle.httpServer.close();
+    await once(handle.httpServer, 'close');
+    await handle.liveState.close();
+  });
+
+  it('reveals hider positions to a hunter on a reveal tick, not before', async () => {
+    const timers = fakeTimers();
+    const booted = await bootServer(timers);
+    handle = booted.handle;
+
+    const hunter = await open(booted.url); // room host — a hunter
+    const hider = await open(booted.url);
+    const { gameId, hiderId } = await startedGame(hunter, hider);
+    expect(handle.pingScheduler.isRunning(gameId)).toBe(true);
+
+    // Record every state the hunter receives so we can prove no un-revealed
+    // broadcast ever leaks the hider.
+    const hunterStates: GameStateEvent[] = [];
+    hunter.on('game_state', (s: GameStateEvent) => hunterStates.push(s));
+
+    // The hider reports a position. Awaiting the hider's own fan-out guarantees
+    // the fix is stored (the write precedes the broadcast) before we reveal.
+    const hiderSelf = waitFor<GameStateEvent>(hider, 'game_state');
+    hider.emit('position_update', { gameId, playerId: hiderId, lat: 52.1, lng: 4.3 });
+    const hiderSaw = await hiderSelf;
+    expect(hiderSaw.positions[hiderId]).toMatchObject({ lat: 52.1, lng: 4.3 });
+
+    // Steady state: nothing the hunter has seen so far carries the hider.
+    for (const s of hunterStates) expect(s.positions[hiderId]).toBeUndefined();
+
+    // Fire a reveal tick. The hunter now receives the hider's position, flagged
+    // as a reveal — the one broadcast where the per-role filter is lifted.
+    const revealed = waitForMatch<GameStateEvent>(hunter, 'game_state', (s) => s.reveal === true);
+    timers.fire();
+    const reveal = await revealed;
+    expect(reveal.gameId).toBe(gameId);
+    expect(reveal.reveal).toBe(true);
+    expect(reveal.positions[hiderId]).toMatchObject({ lat: 52.1, lng: 4.3 });
+
+    // And no un-revealed broadcast ever carried the hider.
+    for (const s of hunterStates) {
+      if (!s.reveal) expect(s.positions[hiderId]).toBeUndefined();
+    }
+  });
+
+  it('does not broadcast an empty reveal before anyone has reported a position', async () => {
+    const timers = fakeTimers();
+    const booted = await bootServer(timers);
+    handle = booted.handle;
+
+    const hunter = await open(booted.url);
+    const hider = await open(booted.url);
+    const { gameId } = await startedGame(hunter, hider);
+
+    let got = false;
+    hunter.on('game_state', () => {
+      got = true;
+    });
+    hider.on('game_state', () => {
+      got = true;
+    });
+
+    // No positions reported yet → the reveal has nothing to disclose and is skipped.
+    timers.fire();
+    // Ordered barrier: once this round-trips, the server has handled the (skipped)
+    // reveal, so a stray broadcast would already have arrived.
+    await hunter.emitWithAck('join', { gameId });
+    expect(got).toBe(false);
+  });
+
+  it('stops revealing once the game is torn down', async () => {
+    const timers = fakeTimers();
+    const booted = await bootServer(timers);
+    handle = booted.handle;
+
+    const hunter = await open(booted.url);
+    const hider = await open(booted.url);
+    const { gameId } = await startedGame(hunter, hider);
+    expect(handle.pingScheduler.isRunning(gameId)).toBe(true);
+
+    // Both players leave → the room is deleted → the reveal timer is cleared.
+    await hider.emitWithAck('leave_game', {});
+    await hunter.emitWithAck('leave_game', {});
+    expect(handle.pingScheduler.isRunning(gameId)).toBe(false);
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -12,12 +12,16 @@ import { Server, type Socket } from 'socket.io';
 import {
   createBoundaryMonitor,
   createLiveState,
+  createPingScheduler,
   createTickEngine,
   evaluateCatch,
   DEFAULT_CATCH_RADIUS_M,
+  DEFAULT_PING_INTERVAL_MS,
   type BoundaryMonitor,
   type CatchRejectReason,
   type LiveState,
+  type PingScheduler,
+  type PingTimerApi,
   type PlayerRole,
   type PositionsByPlayer,
   type GameStateMessage,
@@ -90,6 +94,17 @@ export interface CreateServerOptions {
    * once game settings land (BACKLOG.md #27).
    */
   catchRadiusM?: number;
+  /**
+   * Reveal interval in milliseconds for the ping-reveal scheduler (BACKLOG.md
+   * #13). Defaults to {@link resolvePingIntervalMs} (from `PING_INTERVAL_S`).
+   */
+  pingIntervalMs?: number;
+  /**
+   * Timer primitives backing the ping-reveal scheduler. Defaults to the global
+   * timers; tests inject a controllable fake so they can fire a reveal tick on
+   * demand and assert the resulting broadcast, without leaning on wall-clock time.
+   */
+  pingTimers?: PingTimerApi;
 }
 
 export interface ServerHandle {
@@ -102,6 +117,8 @@ export interface ServerHandle {
   tickEngine: TickEngine;
   /** The boundary geofence monitor (warn → eliminate) applied on every accepted tick. */
   boundaryMonitor: BoundaryMonitor;
+  /** The ping-reveal scheduler; running per active game, stopped on teardown. */
+  pingScheduler: PingScheduler;
 }
 
 /** Socket.IO room a game's broadcasts are emitted to. */
@@ -114,16 +131,20 @@ function gameRoom(gameId: string): string {
  * ever sees positions explicitly marked `hunter`, so anything unlabelled (a
  * hider, or a record whose role we couldn't resolve) is withheld rather than
  * leaked. A hider (or a recipient whose own role is unknown) sees the full set.
- * The scheduled-reveal exception is part of the rules engine (BACKLOG.md #14).
  * The stored `role` marker is stripped so the roster isn't leaked to clients.
+ *
+ * `reveal` is the scheduled ping-reveal exception (BACKLOG.md #13/#14): on a
+ * reveal tick the per-role filter is lifted, so a hunter receives every position
+ * — including the hiders' — for that one broadcast.
  */
 function visibleTo(
   recipientRole: PlayerRole | undefined,
   positions: PositionsByPlayer,
+  reveal = false,
 ): PositionsByPlayer {
   const out: PositionsByPlayer = {};
   for (const [playerId, pos] of Object.entries(positions)) {
-    if (recipientRole === 'hunter' && pos.role !== 'hunter') continue;
+    if (!reveal && recipientRole === 'hunter' && pos.role !== 'hunter') continue;
     out[playerId] = { lat: pos.lat, lng: pos.lng, recordedAt: pos.recordedAt };
   }
   return out;
@@ -151,6 +172,22 @@ export function resolveTrustProxy(
   const n = Number(value);
   if (Number.isInteger(n) && n >= 0) return n;
   return value;
+}
+
+/**
+ * Resolve the ping-reveal interval (ms) from `PING_INTERVAL_S` (seconds — the
+ * name and unit the deploy config and `db/schema.sql` use). Falls back to
+ * {@link DEFAULT_PING_INTERVAL_MS} when unset, empty, or not a positive number,
+ * so a missing or garbled env can never yield a zero/negative reveal timer.
+ * Per-game override is a later concern (BACKLOG.md #27).
+ */
+export function resolvePingIntervalMs(
+  raw: string | undefined = process.env.PING_INTERVAL_S,
+): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_PING_INTERVAL_MS;
+  const seconds = Number(raw.trim());
+  if (!Number.isFinite(seconds) || seconds <= 0) return DEFAULT_PING_INTERVAL_MS;
+  return Math.trunc(seconds * 1000);
 }
 
 /** What we remember about a socket that has created or joined a lobby. */
@@ -215,6 +252,8 @@ export function createServer({
   tickEngine: tickEngineOption,
   boundaryMonitor = createBoundaryMonitor(),
   catchRadiusM = DEFAULT_CATCH_RADIUS_M,
+  pingIntervalMs = resolvePingIntervalMs(),
+  pingTimers,
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -258,13 +297,20 @@ export function createServer({
   // Fan-out path: a game-state message — published locally or received from
   // another instance over Redis pub/sub — is emitted to the game's sockets on
   // THIS instance, filtered per recipient's role (looked up from the lobby) so
-  // hunters never receive hider coordinates (see BACKLOG.md #14).
-  async function fanOut({ gameId, positions }: GameStateMessage): Promise<void> {
+  // hunters never receive hider coordinates (see BACKLOG.md #14). On a scheduled
+  // ping reveal (`reveal`) the filter is lifted so hunters do get the hiders'
+  // positions for that one broadcast (BACKLOG.md #13); the flag is echoed to
+  // clients so they can surface the reveal.
+  async function fanOut({ gameId, positions, reveal }: GameStateMessage): Promise<void> {
     const sockets = await io.in(gameRoom(gameId)).fetchSockets();
     for (const s of sockets) {
       const membership = (s.data as { lobby?: LobbyMembership }).lobby;
       const recipientRole = roleOf(gameId, membership?.playerId);
-      const message: GameStateEvent = { gameId, positions: visibleTo(recipientRole, positions) };
+      const message: GameStateEvent = {
+        gameId,
+        positions: visibleTo(recipientRole, positions, reveal),
+        ...(reveal ? { reveal: true } : {}),
+      };
       s.emit('game_state', message);
     }
   }
@@ -273,6 +319,30 @@ export function createServer({
       const reason = err instanceof Error ? err.message : String(err);
       console.error('game_state fan-out failed:', reason);
     });
+  });
+
+  // Ping-reveal scheduler: on the configured interval it forces a running game's
+  // current positions into a reveal broadcast, so hunters get a periodic fix on
+  // the hiders and can't just camp (BACKLOG.md #13, docs/arc42.md §6.4). A reveal
+  // reads the tick engine's latest snapshot and publishes it with `reveal` set;
+  // fan-out then lifts the per-role filter for that one message. Nothing to
+  // disclose yet (no reported positions) is skipped rather than broadcasting an
+  // empty reveal. The reveal rides the same broadcaster as ticks, so it fans out
+  // across instances too.
+  async function revealPing(gameId: string): Promise<void> {
+    const positions = await tickEngine.latest(gameId);
+    if (Object.keys(positions).length === 0) return;
+    await broadcaster.publish({ gameId, positions, reveal: true });
+  }
+  const pingScheduler = createPingScheduler({
+    intervalMs: pingIntervalMs,
+    ...(pingTimers ? { timers: pingTimers } : {}),
+    onReveal: (gameId) => {
+      void revealPing(gameId).catch((err: unknown) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error('ping reveal failed:', reason);
+      });
+    },
   });
 
   // Push the current roster/status to everyone in a room after any change.
@@ -338,6 +408,9 @@ export function createServer({
     // room itself is gone, sweep whatever remains for the (recyclable) game id.
     boundaryMonitor.forget(membership.gameId, membership.playerId);
     if (!game) boundaryMonitor.forget(membership.gameId);
+    // Once the room empties (the game is gone), stop its ping-reveal timer so no
+    // scheduler outlives the game it reveals (BACKLOG.md #13).
+    if (!game) pingScheduler.stop(membership.gameId);
     if (game) emitLobby(game);
   };
 
@@ -453,6 +526,9 @@ export function createServer({
         const membership = membershipOf(socket);
         if (!membership) throw new LobbyError('player_not_found', 'Not in a game');
         const game = lobby.startGame(membership.gameId, membership.playerId);
+        // The match is under way — begin periodic ping reveals for it (idempotent,
+        // so a double start_game won't stack timers). BACKLOG.md #13.
+        pingScheduler.start(game.id);
         ack?.({ ok: true, game, playerId: membership.playerId });
         emitLobby(game);
       });
@@ -569,5 +645,5 @@ export function createServer({
     });
   });
 
-  return { app, httpServer, io, liveState, lobby, tickEngine, boundaryMonitor };
+  return { app, httpServer, io, liveState, lobby, tickEngine, boundaryMonitor, pingScheduler };
 }

--- a/server/live/broadcaster.ts
+++ b/server/live/broadcaster.ts
@@ -12,6 +12,13 @@ import type { PositionsByPlayer } from './positions.ts';
 export interface GameStateMessage {
   gameId: string;
   positions: PositionsByPlayer;
+  /**
+   * A scheduled ping reveal (BACKLOG.md #13): when set, the per-role fan-out
+   * filter is lifted for this message so hunters receive hider coordinates for
+   * this one tick. Absent on an ordinary position broadcast, where the usual
+   * per-role filtering (BACKLOG.md #14) applies.
+   */
+  reveal?: boolean;
 }
 
 export type GameStateHandler = (message: GameStateMessage) => void;

--- a/server/live/index.ts
+++ b/server/live/index.ts
@@ -21,6 +21,7 @@ export * from './broadcaster.ts';
 export * from './tick.ts';
 export * from './boundary.ts';
 export * from './catch.ts';
+export * from './ping.ts';
 
 /** The hot-state layer wired into the server. */
 export interface LiveState {

--- a/server/live/ping.test.ts
+++ b/server/live/ping.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPingScheduler,
+  DEFAULT_PING_INTERVAL_MS,
+  type PingTimerApi,
+} from './ping.ts';
+
+/**
+ * A controllable timer stand-in. Instead of real wall-clock intervals it records
+ * each registered handler so a test can fire reveals on demand and assert exactly
+ * how many times each game was revealed — deterministic, no `setTimeout`.
+ */
+function fakeTimers(): PingTimerApi & {
+  tickAll: () => void;
+  active: () => number;
+  lastMs: number | undefined;
+} {
+  const handlers = new Map<number, () => void>();
+  let nextId = 1;
+  let lastMs: number | undefined;
+  return {
+    setInterval(handler, ms) {
+      lastMs = ms;
+      const id = nextId++;
+      handlers.set(id, handler);
+      return id;
+    },
+    clearInterval(handle) {
+      handlers.delete(handle as number);
+    },
+    tickAll() {
+      for (const handler of handlers.values()) handler();
+    },
+    active() {
+      return handlers.size;
+    },
+    get lastMs() {
+      return lastMs;
+    },
+  };
+}
+
+describe('createPingScheduler', () => {
+  it('fires a reveal for a running game on each interval tick', () => {
+    const revealed: string[] = [];
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({
+      onReveal: (gameId) => revealed.push(gameId),
+      timers,
+    });
+
+    scheduler.start('game-1');
+    expect(scheduler.isRunning('game-1')).toBe(true);
+
+    timers.tickAll();
+    timers.tickAll();
+    expect(revealed).toEqual(['game-1', 'game-1']);
+  });
+
+  it('reveals each running game independently', () => {
+    const revealed: string[] = [];
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({
+      onReveal: (gameId) => revealed.push(gameId),
+      timers,
+    });
+
+    scheduler.start('game-1');
+    scheduler.start('game-2');
+    expect(timers.active()).toBe(2);
+
+    timers.tickAll();
+    expect(revealed).toEqual(['game-1', 'game-2']);
+  });
+
+  it('is idempotent: starting a running game does not stack timers', () => {
+    const revealed: string[] = [];
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({
+      onReveal: (gameId) => revealed.push(gameId),
+      timers,
+    });
+
+    scheduler.start('game-1');
+    scheduler.start('game-1');
+    expect(timers.active()).toBe(1);
+
+    timers.tickAll();
+    expect(revealed).toEqual(['game-1']);
+  });
+
+  it('stops revealing a game once stopped', () => {
+    const revealed: string[] = [];
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({
+      onReveal: (gameId) => revealed.push(gameId),
+      timers,
+    });
+
+    scheduler.start('game-1');
+    scheduler.stop('game-1');
+    expect(scheduler.isRunning('game-1')).toBe(false);
+    expect(timers.active()).toBe(0);
+
+    timers.tickAll();
+    expect(revealed).toEqual([]);
+  });
+
+  it('stop is a no-op for a game that was never started', () => {
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({ onReveal: () => {}, timers });
+    expect(() => scheduler.stop('unknown')).not.toThrow();
+    expect(scheduler.isRunning('unknown')).toBe(false);
+  });
+
+  it('stopAll clears every running game', () => {
+    const revealed: string[] = [];
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({
+      onReveal: (gameId) => revealed.push(gameId),
+      timers,
+    });
+
+    scheduler.start('game-1');
+    scheduler.start('game-2');
+    scheduler.stopAll();
+    expect(timers.active()).toBe(0);
+    expect(scheduler.isRunning('game-1')).toBe(false);
+    expect(scheduler.isRunning('game-2')).toBe(false);
+
+    timers.tickAll();
+    expect(revealed).toEqual([]);
+  });
+
+  it('uses the default interval when none is configured', () => {
+    const timers = fakeTimers();
+    const scheduler = createPingScheduler({ onReveal: () => {}, timers });
+    scheduler.start('game-1');
+    expect(timers.lastMs).toBe(DEFAULT_PING_INTERVAL_MS);
+  });
+
+  it('honours a configured interval and coerces a bad one to a positive integer', () => {
+    const timersA = fakeTimers();
+    createPingScheduler({ onReveal: () => {}, intervalMs: 5_000, timers: timersA }).start('g');
+    expect(timersA.lastMs).toBe(5_000);
+
+    // Zero/negative/fractional intervals are clamped up to a valid 1 ms minimum
+    // rather than producing a nonsensical timer.
+    const timersB = fakeTimers();
+    createPingScheduler({ onReveal: () => {}, intervalMs: 0, timers: timersB }).start('g');
+    expect(timersB.lastMs).toBe(1);
+  });
+});

--- a/server/live/ping.ts
+++ b/server/live/ping.ts
@@ -1,0 +1,116 @@
+/**
+ * The ping-reveal scheduler — the rules-engine timer that periodically forces
+ * hider positions into the broadcast (BACKLOG.md #13, docs/arc42.md §6.4 "Ping
+ * reveal"). Per-role state filtering (BACKLOG.md #14) keeps hunters from ever
+ * receiving hider coordinates in the steady state; this scheduler punches a
+ * periodic hole in that veil: on a fixed interval it fires a *reveal tick* for a
+ * running game, and the transport layer answers by fanning out the game's current
+ * positions with the per-role filter lifted — so hunters get a momentary "ping"
+ * of where the hiders are, then the veil closes again until the next reveal. This
+ * is what stops a hunter from simply camping (docs/arc42.md §8 risk "camping").
+ *
+ * The scheduler owns only *timing*, not the reveal payload: it fires
+ * {@link PingSchedulerOptions.onReveal} with the game id, and the caller decides
+ * what to disclose (see `server/app.ts`). Keeping it payload-agnostic mirrors the
+ * boundary monitor — pure, focused mechanism the transport wires an effect onto.
+ * The timer primitives are injectable so tests can drive reveals deterministically
+ * without leaning on real wall-clock timers.
+ */
+
+/**
+ * Default reveal interval, in milliseconds. Matches the `PING_INTERVAL_S` default
+ * (180 s) in `.env.example` and the `games.ping_interval_s` column default in
+ * `db/schema.sql`, so the same cadence is described everywhere. Tunable per game
+ * once game settings land (BACKLOG.md #27).
+ */
+export const DEFAULT_PING_INTERVAL_MS = 180_000;
+
+/**
+ * The subset of the timer API the scheduler needs. `setInterval` returns an
+ * opaque handle the scheduler stores and later passes back to `clearInterval`;
+ * its concrete type is deliberately hidden behind `unknown` so a fake (or the
+ * global timers) can supply whatever handle it likes. Defaults to the global
+ * timers, un-refed so a scheduled reveal never keeps the process alive on its own.
+ */
+export interface PingTimerApi {
+  setInterval(handler: () => void, ms: number): unknown;
+  clearInterval(handle: unknown): void;
+}
+
+const defaultTimers: PingTimerApi = {
+  setInterval: (handler, ms) => setInterval(handler, ms).unref(),
+  clearInterval: (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
+};
+
+/** Tunables for {@link createPingScheduler}. */
+export interface PingSchedulerOptions {
+  /**
+   * Called once per reveal tick for a running game, with that game's id. The
+   * caller reads the game's current positions and broadcasts them with the
+   * per-role filter lifted (a reveal). Kept synchronous-in, effect-out: the
+   * scheduler doesn't await it, so a slow or throwing handler can't wedge the
+   * timer — the caller is responsible for catching its own async failures.
+   */
+  onReveal: (gameId: string) => void;
+  /**
+   * Milliseconds between reveals. Defaults to {@link DEFAULT_PING_INTERVAL_MS}.
+   * Coerced to a positive integer so a zero/negative/fractional config can't make
+   * a nonsensical timer.
+   */
+  intervalMs?: number;
+  /** Timer primitives; injected in tests for deterministic reveals. */
+  timers?: PingTimerApi;
+}
+
+/** Per-game reveal timer. Starts on game start, stops on teardown. */
+export interface PingScheduler {
+  /**
+   * Begin periodic reveals for a game. Idempotent — starting an already-running
+   * game is a no-op, so a double `start_game` (reconnect race, double-submit)
+   * can't stack two timers on one game.
+   */
+  start(gameId: string): void;
+  /** Stop reveals for a game (it ended, or the room emptied). A no-op if not running. */
+  stop(gameId: string): void;
+  /** Whether a game currently has reveals scheduled. */
+  isRunning(gameId: string): boolean;
+  /** Stop every game's reveals — full teardown (server shutdown, test cleanup). */
+  stopAll(): void;
+}
+
+/**
+ * Build a ping-reveal scheduler. State is one interval handle per running game,
+ * keyed by game id; {@link PingScheduler.stop}/{@link PingScheduler.stopAll} clear
+ * them so no timer outlives the game it reveals.
+ */
+export function createPingScheduler({
+  onReveal,
+  intervalMs = DEFAULT_PING_INTERVAL_MS,
+  timers = defaultTimers,
+}: PingSchedulerOptions): PingScheduler {
+  const period = Math.max(1, Math.trunc(intervalMs));
+  const handles = new Map<string, unknown>();
+
+  return {
+    start(gameId) {
+      if (handles.has(gameId)) return;
+      handles.set(
+        gameId,
+        timers.setInterval(() => onReveal(gameId), period),
+      );
+    },
+    stop(gameId) {
+      const handle = handles.get(gameId);
+      if (!handles.has(gameId)) return;
+      timers.clearInterval(handle);
+      handles.delete(gameId);
+    },
+    isRunning(gameId) {
+      return handles.has(gameId);
+    },
+    stopAll() {
+      for (const handle of handles.values()) timers.clearInterval(handle);
+      handles.clear();
+    },
+  };
+}

--- a/server/protocol/messages.ts
+++ b/server/protocol/messages.ts
@@ -88,6 +88,13 @@ export interface SetBoundaryPayload {
 export interface GameStateEvent {
   gameId: string;
   positions: PositionsByPlayer;
+  /**
+   * True when this broadcast is a scheduled ping reveal (BACKLOG.md #13): hider
+   * positions are disclosed to hunters for this tick. Absent on an ordinary
+   * per-role-filtered broadcast. Clients can use it to surface the reveal (e.g. a
+   * "you've been pinged" cue for hiders, a fix flash for hunters).
+   */
+  reveal?: boolean;
 }
 
 /** `catch_confirmed` — the server accepted a catch; broadcast to the game's room. */


### PR DESCRIPTION
Closes #13.

## What & why

Per-role state filtering keeps hunters from ever seeing hider coordinates in the steady state. This adds the **ping-reveal scheduler**: on a configurable interval it forces each running game's current positions into the broadcast with that filter lifted, so hunters get a periodic fix on the hiders and can't simply camp (docs/arc42.md §6.4).

**Acceptance criteria**
- ✅ **Configurable interval** — `PING_INTERVAL_S` (seconds, default 180), matching the existing `.env.example` value and the `games.ping_interval_s` column default. Per-game tuning is left to BACKLOG.md #27.
- ✅ **Hiders revealed to hunters only on reveal ticks** — the `visibleTo` filter is lifted only for a `reveal`-flagged broadcast; every other `game_state` stays per-role filtered.

## How

- **`server/live/ping.ts`** — `createPingScheduler`: a per-game reveal timer keyed by game id, idempotent `start`, `stop`/`stopAll` teardown, and injectable timer primitives (`PingTimerApi`) so tests drive reveals deterministically. Global timers are un-refed so a reveal never keeps the process alive on its own.
- **Message contract** — `GameStateMessage` / `GameStateEvent` gain an optional `reveal` flag. On a reveal tick `visibleTo` returns the full set to hunters, and the flag is echoed to clients so the UI can surface the ping.
- **`server/app.ts` wiring** — the scheduler starts on `start_game` and stops when a room is torn down. Each reveal reads the tick engine's latest snapshot and publishes over the same broadcaster (so it fans out across instances too); an empty snapshot is skipped rather than broadcasting nothing. `resolvePingIntervalMs` reads `PING_INTERVAL_S`.

## Tests

- `server/live/ping.test.ts` — unit tests for the scheduler (per-game reveals, idempotent start, stop/stopAll, interval resolution/coercion).
- `server/app.ping.test.ts` — socket-level integration: a hunter sees the hider only on a fired reveal tick (never on an ordinary broadcast), empty reveals aren't broadcast, and the timer stops on teardown.

`npm run typecheck`, `npm run lint`, and `npm run test:server` (166 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAs2ABSbT4pekwbRCMrN9b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled “ping reveal” events that temporarily show hider locations to hunters.
  * Added configurable reveal timing with safe defaults and validation.
  * Reveal notifications now include an optional indicator in game-state updates.
  * Reveal scheduling automatically stops when a game ends or its room is empty.

* **Documentation**
  * Clarified WebSocket payloads, role-based visibility, and scheduled reveal behavior.

* **Tests**
  * Added coverage for reveal timing, filtering, empty states, configuration, and game cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->