### PR TITLE
feat(server): win conditions + end-screen summary (BACKLOG.md #15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,5 @@ DOMAIN=manhunt.example.com
 # Game defaults
 PING_INTERVAL_S=180
 POSITION_CADENCE_S=8
+# How long a match runs before the hiders win by surviving the timer (BACKLOG #15).
+GAME_DURATION_S=1800

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | `boundary_warning` | `{ gameId, playerId, warnings, warningsRemaining, metersOutside, at }` | Sent to a player the server saw outside the play area, before elimination. |
 | `player_eliminated` | `{ gameId, playerId, reason, at }` | Broadcast to the room when the server removes a player from play (`reason: 'boundary'` today). |
 | `lobby_update` | `{ game }` | Full roster/status after any lobby change. |
+| `game_over` | `{ gameId, summary }` | Broadcast when the server detects a win condition and ends the match. `summary` carries the winner (`hunters`/`hiders`), why (`all_caught`/`timer`), the match span, every catch, and each hider's survival time — the end-screen payload. |
 
 The **catch flow** is wired end to end here and gated by the rules engine
 (`server/live/catch.ts`): on a hunter's `claim_catch` the server verifies —
@@ -174,7 +175,14 @@ who strays outside is warned (`boundary_warning`), then eliminated
 (`PING_INTERVAL_S`, default 180 s) it forces the game's current positions into a
 `game_state` broadcast with the per-role filter lifted, so hunters get a periodic
 fix on the hiders and can't just camp — the one exception to per-role filtering,
-per [`BACKLOG.md`](./BACKLOG.md) #13. See `docs/arc42.md` §6 for the runtime view.
+per [`BACKLOG.md`](./BACKLOG.md) #13. The **outcome tracker**
+(`server/live/outcome.ts`) watches for a **win condition**: the match ends when
+the last hider is caught (the hunters win, `all_caught`) or when the game's
+duration elapses with a hider still free (the hiders win, `timer`, over
+`GAME_DURATION_S`, default 1800 s). Either way the server broadcasts `game_over`
+with a summary — winner, reason, span, every catch, and each hider's survival
+time — the payload the end screen renders, per
+[`BACKLOG.md`](./BACKLOG.md) #15. See `docs/arc42.md` §6 for the runtime view.
 
 ### Live state (Redis)
 

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -128,6 +128,12 @@ state, notifications, and map tiles for rendering.
 
 On the configured interval the rules engine forces each hider's position into the next broadcast so hunters get a periodic fix, preventing camping.
 
+### 6.5 Win condition + end screen
+
+1. The rules engine ends the match on one of two conditions: the last hider is caught (hunters win, `all_caught`), or the game's duration elapses with a hider still free (hiders win, `timer`).
+2. Whichever fires first, the server moves the game to `ended`, stops its timers, and produces a summary — winner, reason, span, every catch, and each hider's survival time.
+3. It broadcasts `game_over` with that summary so every client switches to the end screen.
+
 ---
 
 ## 7. Deployment view

--- a/server/app.ts
+++ b/server/app.ts
@@ -491,7 +491,13 @@ export function createServer({
       pingScheduler.stop(membership.gameId);
       outcomeTracker.stop(membership.gameId);
     }
-    if (game) emitLobby(game);
+    if (game) {
+      // The room lives on but this player is gone — drop them from the outcome
+      // snapshot so a departed hider can't keep the last-hider win from firing or
+      // be credited with a survival time (BACKLOG.md #15).
+      outcomeTracker.dropPlayer(membership.gameId, membership.playerId);
+      emitLobby(game);
+    }
   };
 
   // Authoritative game loop. The transport contract (join, position_update,

--- a/server/app.ts
+++ b/server/app.ts
@@ -12,14 +12,19 @@ import { Server, type Socket } from 'socket.io';
 import {
   createBoundaryMonitor,
   createLiveState,
+  createOutcomeTracker,
   createPingScheduler,
   createTickEngine,
   evaluateCatch,
   DEFAULT_CATCH_RADIUS_M,
+  DEFAULT_GAME_DURATION_MS,
   DEFAULT_PING_INTERVAL_MS,
   type BoundaryMonitor,
   type CatchRejectReason,
+  type EndReason,
+  type GameTimerApi,
   type LiveState,
+  type OutcomeTracker,
   type PingScheduler,
   type PingTimerApi,
   type PlayerRole,
@@ -41,6 +46,7 @@ import {
   validateSetBoundary,
   type BoundaryWarningEvent,
   type CatchConfirmedEvent,
+  type GameOverEvent,
   type GameStateEvent,
   type LobbyUpdateEvent,
   type PlayerEliminatedEvent,
@@ -105,6 +111,18 @@ export interface CreateServerOptions {
    * demand and assert the resulting broadcast, without leaning on wall-clock time.
    */
   pingTimers?: PingTimerApi;
+  /**
+   * Match duration in milliseconds for the survive-the-timer win condition
+   * (BACKLOG.md #15): how long hiders must last for them to win. Defaults to
+   * {@link resolveGameDurationMs} (from `GAME_DURATION_S`).
+   */
+  gameDurationMs?: number;
+  /**
+   * Timer primitives backing the survive-the-timer countdown. Defaults to the
+   * global timers; tests inject a controllable fake so they can fire the timeout
+   * on demand and assert the resulting `game_over`, without waiting out the clock.
+   */
+  gameTimers?: GameTimerApi;
 }
 
 export interface ServerHandle {
@@ -119,6 +137,8 @@ export interface ServerHandle {
   boundaryMonitor: BoundaryMonitor;
   /** The ping-reveal scheduler; running per active game, stopped on teardown. */
   pingScheduler: PingScheduler;
+  /** The end-of-game tracker; the win-condition read model + survive timer per active game. */
+  outcomeTracker: OutcomeTracker;
 }
 
 /** Socket.IO room a game's broadcasts are emitted to. */
@@ -190,6 +210,23 @@ export function resolvePingIntervalMs(
   return Math.trunc(seconds * 1000);
 }
 
+/**
+ * Resolve the match duration (ms) from `GAME_DURATION_S` (seconds — the name and
+ * unit `db/schema.sql`'s `games.duration_s` column uses) for the
+ * survive-the-timer win condition (BACKLOG.md #15). Falls back to
+ * {@link DEFAULT_GAME_DURATION_MS} when unset, empty, or not a positive number, so
+ * a missing or garbled env can never yield a zero/negative game timer. Per-game
+ * override is a later concern (BACKLOG.md #27).
+ */
+export function resolveGameDurationMs(
+  raw: string | undefined = process.env.GAME_DURATION_S,
+): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_GAME_DURATION_MS;
+  const seconds = Number(raw.trim());
+  if (!Number.isFinite(seconds) || seconds <= 0) return DEFAULT_GAME_DURATION_MS;
+  return Math.trunc(seconds * 1000);
+}
+
 /** What we remember about a socket that has created or joined a lobby. */
 interface LobbyMembership {
   gameId: string;
@@ -254,6 +291,8 @@ export function createServer({
   catchRadiusM = DEFAULT_CATCH_RADIUS_M,
   pingIntervalMs = resolvePingIntervalMs(),
   pingTimers,
+  gameDurationMs = resolveGameDurationMs(),
+  gameTimers,
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -345,11 +384,47 @@ export function createServer({
     },
   });
 
+  // End-of-game tracker: remembers each active game's start, original hiders and
+  // catches, and owns the survive-the-timer countdown (BACKLOG.md #15). When the
+  // countdown elapses with a hider still uncaught, the hiders have survived — end
+  // the game (reason `timer`). The complementary win — the last hider caught — is
+  // detected on the catch path (see `claim_catch`). Both routes converge on
+  // `finishGame`, which finalizes exactly once.
+  const outcomeTracker = createOutcomeTracker({
+    durationMs: gameDurationMs,
+    ...(gameTimers ? { timers: gameTimers } : {}),
+    onExpire: (gameId) => finishGame(gameId, 'timer'),
+  });
+
   // Push the current roster/status to everyone in a room after any change.
   const emitLobby = (game: Game): void => {
     const message: LobbyUpdateEvent = { game };
     io.to(gameRoom(game.id)).emit('lobby_update', message);
   };
+
+  // End a game on a win condition (BACKLOG.md #15). The outcome tracker finalizes
+  // exactly once — a second call (the catch path and the timer racing, or a
+  // torn-down game) returns no summary and this is a no-op — so both win routes
+  // can safely funnel through here. On the first finalize it stops the ping
+  // scheduler, moves the room to `ended`, and broadcasts `game_over` (the summary
+  // payload) then the final roster so every client can switch to the end screen.
+  function finishGame(gameId: string, reason: EndReason): void {
+    const summary = outcomeTracker.end(gameId, reason, new Date().toISOString());
+    if (!summary) return;
+    pingScheduler.stop(gameId);
+    const event: GameOverEvent = { gameId, summary };
+    io.to(gameRoom(gameId)).emit('game_over', event);
+    // Reflect the terminal state in the roster. The room may already be gone (a
+    // race with the last player leaving); tolerate that rather than throw.
+    try {
+      emitLobby(lobby.endGame(gameId));
+    } catch (err) {
+      if (!(err instanceof LobbyError)) {
+        const reasonText = err instanceof Error ? err.message : String(err);
+        console.error('ending game failed:', reasonText);
+      }
+    }
+  }
 
   // Geofence one accepted fix against the game's play area. A warning is personal
   // — emitted only to the offending socket — while an elimination is broadcast to
@@ -409,8 +484,13 @@ export function createServer({
     boundaryMonitor.forget(membership.gameId, membership.playerId);
     if (!game) boundaryMonitor.forget(membership.gameId);
     // Once the room empties (the game is gone), stop its ping-reveal timer so no
-    // scheduler outlives the game it reveals (BACKLOG.md #13).
-    if (!game) pingScheduler.stop(membership.gameId);
+    // scheduler outlives the game it reveals (BACKLOG.md #13), and drop its
+    // outcome tracking so the survive-the-timer countdown can't fire on a game
+    // that no longer exists (BACKLOG.md #15).
+    if (!game) {
+      pingScheduler.stop(membership.gameId);
+      outcomeTracker.stop(membership.gameId);
+    }
     if (game) emitLobby(game);
   };
 
@@ -529,6 +609,9 @@ export function createServer({
         // The match is under way — begin periodic ping reveals for it (idempotent,
         // so a double start_game won't stack timers). BACKLOG.md #13.
         pingScheduler.start(game.id);
+        // Begin tracking the outcome: snapshot the original hiders and arm the
+        // survive-the-timer countdown (also idempotent). BACKLOG.md #15.
+        outcomeTracker.start({ game, startedAt: game.startedAt ?? new Date().toISOString() });
         ack?.({ ok: true, game, playerId: membership.playerId });
         emitLobby(game);
       });
@@ -625,8 +708,17 @@ export function createServer({
           at: new Date().toISOString(),
         };
         io.to(gameRoom(gameId)).emit('catch_confirmed', confirmed);
+        // Record the catch for the end-screen summary and the win check (BACKLOG.md #15).
+        outcomeTracker.recordCatch(gameId, confirmed);
         emitLobby(game);
         ack?.({ ok: true, catch: confirmed });
+        // Win condition: that catch may have taken the last free hider. If no
+        // hider remains, the hunters have won — end the game and fan out the
+        // summary (after the catch/roster broadcasts, so clients see the final
+        // catch before the end screen).
+        if (outcomeTracker.remainingHiders(gameId) === 0) {
+          finishGame(gameId, 'all_caught');
+        }
       } catch (err) {
         if (err instanceof LobbyError) {
           ack?.({ ok: false, error: err.message, code: err.code });
@@ -645,5 +737,15 @@ export function createServer({
     });
   });
 
-  return { app, httpServer, io, liveState, lobby, tickEngine, boundaryMonitor, pingScheduler };
+  return {
+    app,
+    httpServer,
+    io,
+    liveState,
+    lobby,
+    tickEngine,
+    boundaryMonitor,
+    pingScheduler,
+    outcomeTracker,
+  };
 }

--- a/server/app.win.test.ts
+++ b/server/app.win.test.ts
@@ -279,6 +279,38 @@ describe('win conditions + end screen data over the socket', () => {
     expect(event.summary.catches).toHaveLength(1);
   });
 
+  it('lets the hunters win once every present hider is caught, ignoring a departed hider', async () => {
+    const booted = await bootServer(fakeTimers(), 15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url, 2);
+    const [first, second] = game.hiders as [
+      { socket: Socket; id: string; name: string },
+      { socket: Socket; id: string; name: string },
+    ];
+
+    // The second hider leaves mid-match — the tracker must forget them, or the
+    // last-hider win would wait for the timer instead of firing on the catch.
+    await second.socket.emitWithAck('leave_game', {});
+    expect(handle.outcomeTracker.remainingHiders(game.gameId)).toBe(1);
+
+    await place(game.hunter, game.gameId, game.hunterId, BASE);
+    await place(first.socket, game.gameId, first.id, northOf(5));
+
+    const gameOver = waitFor<GameOverEvent>(game.hunter, 'game_over');
+    await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: first.id,
+    });
+
+    const event = await gameOver;
+    expect(event.summary.winner).toBe('hunters');
+    expect(event.summary.reason).toBe('all_caught');
+    // The departed hider earns no survival line; only the caught hider appears.
+    expect(event.summary.hiders.map((h) => h.playerId)).toEqual([first.id]);
+    expect(event.summary.hiders.some((h) => h.playerId === second.id)).toBe(false);
+  });
+
   it('drops the survive timer when the room empties before it fires', async () => {
     const timers = fakeTimers();
     const booted = await bootServer(timers, 15);

--- a/server/app.win.test.ts
+++ b/server/app.win.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { once } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import { createServer, type ServerHandle } from './app.ts';
+import {
+  createLocalBroadcaster,
+  createMemoryPositionStore,
+  type GameTimerApi,
+} from './live/index.ts';
+import { createMemoryLobby, type Game } from './lobby/rooms.ts';
+import type { CatchConfirmedEvent, GameOverEvent, GameStateEvent } from './protocol/messages.ts';
+
+type CatchAck =
+  | { ok: true; catch: CatchConfirmedEvent }
+  | { ok: false; error: string; code?: string };
+
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/** Amsterdam's Dam square — the anchor the players are positioned around. */
+const BASE = { lat: 52.3731, lng: 4.8922 };
+/** A point roughly `meters` due north of `BASE` (~111.32 km per degree of latitude). */
+function northOf(meters: number): { lat: number; lng: number } {
+  return { lat: BASE.lat + meters / 111_320, lng: BASE.lng };
+}
+
+/**
+ * A controllable one-shot timer backing the server's survive-the-timer countdown:
+ * instead of a real timeout it records the registered handlers so a test can fire
+ * the countdown on demand (`fire()`), making the "hiders survive" win deterministic.
+ */
+function fakeTimers(): GameTimerApi & { fire: () => void } {
+  const handlers = new Map<number, () => void>();
+  let nextId = 1;
+  return {
+    setTimeout(handler) {
+      const id = nextId++;
+      handlers.set(id, handler);
+      return id;
+    },
+    clearTimeout(handle) {
+      handlers.delete(handle as number);
+    },
+    fire() {
+      for (const handler of [...handlers.values()]) handler();
+    },
+  };
+}
+
+/**
+ * Boot the real server on an ephemeral port with in-memory hot state, a real
+ * lobby, a deterministic catch radius, and a controllable survive-the-timer clock.
+ */
+async function bootServer(
+  gameTimers: GameTimerApi,
+  catchRadiusM = 15,
+): Promise<{ handle: ServerHandle; url: string }> {
+  const handle = createServer({
+    staticDir: path.join(os.tmpdir(), 'nope'),
+    liveState: {
+      store: createMemoryPositionStore(),
+      broadcaster: createLocalBroadcaster(),
+      close: () => Promise.resolve(),
+    },
+    lobby: createMemoryLobby(),
+    catchRadiusM,
+    gameTimers,
+  });
+  handle.httpServer.listen(0);
+  await once(handle.httpServer, 'listening');
+  const { port } = handle.httpServer.address() as AddressInfo;
+  return { handle, url: `http://127.0.0.1:${port}` };
+}
+
+function connect(url: string): Socket {
+  return ioClient(url, { transports: ['websocket'], reconnection: false });
+}
+
+function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+/** Resolve on the first matching event, ignoring earlier in-flight broadcasts. */
+function waitUntil<T = unknown>(
+  socket: Socket,
+  event: string,
+  match: (payload: T) => boolean,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!match(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+describe('win conditions + end screen data over the socket', () => {
+  let handle: ServerHandle;
+  const clients: Socket[] = [];
+
+  async function open(url: string): Promise<Socket> {
+    const c = connect(url);
+    clients.push(c);
+    await waitFor(c, 'connect');
+    return c;
+  }
+
+  afterEach(async () => {
+    handle.outcomeTracker.stopAll();
+    handle.pingScheduler.stopAll();
+    for (const c of clients.splice(0)) c.close();
+    handle.io.close();
+    handle.httpServer.close();
+    await once(handle.httpServer, 'close');
+    await handle.liveState.close();
+  });
+
+  /**
+   * Stand up an active game: a host (hunter) and `hiderCount` guests (hiders), all
+   * readied, the match started. Returns the sockets and authoritative ids.
+   */
+  async function activeGame(
+    url: string,
+    hiderCount = 1,
+  ): Promise<{
+    hunter: Socket;
+    hunterId: string;
+    gameId: string;
+    hiders: { socket: Socket; id: string; name: string }[];
+  }> {
+    const hunter = await open(url);
+    const created = (await hunter.emitWithAck('create_game', { name: 'Hunter' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+
+    const hiders: { socket: Socket; id: string; name: string }[] = [];
+    for (let i = 0; i < hiderCount; i += 1) {
+      const socket = await open(url);
+      const name = `Hider${i + 1}`;
+      const joined = (await socket.emitWithAck('join_game', {
+        roomCode: created.game.roomCode,
+        name,
+      })) as LobbyAck;
+      if (!joined.ok) throw new Error('join failed');
+      hiders.push({ socket, id: joined.playerId, name });
+    }
+
+    await hunter.emitWithAck('set_ready', { ready: true });
+    for (const h of hiders) await h.socket.emitWithAck('set_ready', { ready: true });
+    const started = (await hunter.emitWithAck('start_game', {})) as LobbyAck;
+    if (!started.ok) throw new Error(`start failed: ${started.error}`);
+
+    return { hunter, hunterId: created.playerId, gameId: created.game.id, hiders };
+  }
+
+  /**
+   * Report a player's own position from that player's socket and wait until the
+   * server has stored it. A `position_update` is dropped unless the emitting
+   * socket owns the claimed id, so `owner` is both the emitter and (since every
+   * player sees their own fix) the socket we await the fan-out on.
+   */
+  async function place(
+    owner: Socket,
+    gameId: string,
+    playerId: string,
+    pos: { lat: number; lng: number },
+  ): Promise<void> {
+    const stored = waitUntil<GameStateEvent>(
+      owner,
+      'game_state',
+      (p) => Boolean(p.positions[playerId]),
+    );
+    owner.emit('position_update', { gameId, playerId, ...pos });
+    await stored;
+  }
+
+  it('ends the game when the last hider is caught: hunters win, with a summary', async () => {
+    const booted = await bootServer(fakeTimers(), 15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url, 1);
+    const hider = game.hiders[0]!;
+
+    // Both stand within the catch radius so the claim will succeed.
+    await place(game.hunter, game.gameId, game.hunterId, BASE);
+    await place(hider.socket, game.gameId, hider.id, northOf(5));
+
+    const gameOver = waitFor<GameOverEvent>(hider.socket, 'game_over');
+    const ack = (await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: hider.id,
+    })) as CatchAck;
+    expect(ack.ok).toBe(true);
+
+    const event = await gameOver;
+    expect(event.gameId).toBe(game.gameId);
+    expect(event.summary.winner).toBe('hunters');
+    expect(event.summary.reason).toBe('all_caught');
+    // The summary lists the catch and the hider's survival time.
+    expect(event.summary.catches).toHaveLength(1);
+    expect(event.summary.catches[0]).toMatchObject({ hunterId: game.hunterId, targetId: hider.id });
+    expect(event.summary.hiders).toHaveLength(1);
+    expect(event.summary.hiders[0]).toMatchObject({ playerId: hider.id, name: hider.name, caught: true });
+    expect(event.summary.hiders[0]?.survivalMs).toBeGreaterThanOrEqual(0);
+    expect(event.summary.hiders[0]?.caughtAt).toBeTruthy();
+
+    // The room is now 'ended' and its timers are cleared.
+    expect(handle.lobby.get(game.gameId)?.status).toBe('ended');
+    expect(handle.outcomeTracker.isTracking(game.gameId)).toBe(false);
+    expect(handle.pingScheduler.isRunning(game.gameId)).toBe(false);
+  });
+
+  it('ends the game when the timer runs out with a hider still free: hiders win', async () => {
+    const timers = fakeTimers();
+    const booted = await bootServer(timers, 15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url, 1);
+    const hider = game.hiders[0]!;
+
+    const gameOver = waitFor<GameOverEvent>(game.hunter, 'game_over');
+    // The survive-the-timer countdown elapses — the hider lasted the match.
+    timers.fire();
+
+    const event = await gameOver;
+    expect(event.summary.winner).toBe('hiders');
+    expect(event.summary.reason).toBe('timer');
+    expect(event.summary.hiders[0]).toMatchObject({ playerId: hider.id, caught: false });
+    // A survivor has no capture time.
+    expect(event.summary.hiders[0]?.caughtAt).toBeUndefined();
+    expect(handle.lobby.get(game.gameId)?.status).toBe('ended');
+  });
+
+  it('with two hiders, catching one leaves the game running until the timer', async () => {
+    const timers = fakeTimers();
+    const booted = await bootServer(timers, 15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url, 2);
+    const [first, second] = game.hiders as [
+      { socket: Socket; id: string; name: string },
+      { socket: Socket; id: string; name: string },
+    ];
+
+    // Catch only the first hider — the second is still free, so no game over yet.
+    await place(game.hunter, game.gameId, game.hunterId, BASE);
+    await place(first.socket, game.gameId, first.id, northOf(5));
+
+    let endedEarly = false;
+    game.hunter.on('game_over', () => {
+      endedEarly = true;
+    });
+    const caught = waitFor<CatchConfirmedEvent>(second.socket, 'catch_confirmed');
+    await game.hunter.emitWithAck('claim_catch', {
+      gameId: game.gameId,
+      hunterId: game.hunterId,
+      targetId: first.id,
+    });
+    await caught;
+    // Ordered barrier: once this round-trips the (non-)end has been handled.
+    await game.hunter.emitWithAck('join', { gameId: game.gameId });
+    expect(endedEarly).toBe(false);
+    expect(handle.lobby.get(game.gameId)?.status).toBe('active');
+
+    // Now the timer fires with the second hider still free — hiders win, and the
+    // summary distinguishes the caught hider from the survivor.
+    const gameOver = waitFor<GameOverEvent>(game.hunter, 'game_over');
+    timers.fire();
+    const event = await gameOver;
+    expect(event.summary.winner).toBe('hiders');
+    expect(event.summary.reason).toBe('timer');
+    const summaryFirst = event.summary.hiders.find((h) => h.playerId === first.id);
+    const summarySecond = event.summary.hiders.find((h) => h.playerId === second.id);
+    expect(summaryFirst).toMatchObject({ caught: true });
+    expect(summarySecond).toMatchObject({ caught: false });
+    expect(event.summary.catches).toHaveLength(1);
+  });
+
+  it('drops the survive timer when the room empties before it fires', async () => {
+    const timers = fakeTimers();
+    const booted = await bootServer(timers, 15);
+    handle = booted.handle;
+    const game = await activeGame(booted.url, 1);
+    const hider = game.hiders[0]!;
+
+    expect(handle.outcomeTracker.isTracking(game.gameId)).toBe(true);
+    await hider.socket.emitWithAck('leave_game', {});
+    await game.hunter.emitWithAck('leave_game', {});
+    expect(handle.outcomeTracker.isTracking(game.gameId)).toBe(false);
+
+    // Firing now must not throw or resurrect a game_over for the dead game.
+    expect(() => timers.fire()).not.toThrow();
+  });
+});

--- a/server/app.win.test.ts
+++ b/server/app.win.test.ts
@@ -290,7 +290,8 @@ describe('win conditions + end screen data over the socket', () => {
 
     // The second hider leaves mid-match — the tracker must forget them, or the
     // last-hider win would wait for the timer instead of firing on the catch.
-    await second.socket.emitWithAck('leave_game', {});
+    const left = (await second.socket.emitWithAck('leave_game', {})) as { ok: boolean };
+    expect(left.ok).toBe(true);
     expect(handle.outcomeTracker.remainingHiders(game.gameId)).toBe(1);
 
     await place(game.hunter, game.gameId, game.hunterId, BASE);

--- a/server/live/index.ts
+++ b/server/live/index.ts
@@ -22,6 +22,7 @@ export * from './tick.ts';
 export * from './boundary.ts';
 export * from './catch.ts';
 export * from './ping.ts';
+export * from './outcome.ts';
 
 /** The hot-state layer wired into the server. */
 export interface LiveState {

--- a/server/live/outcome.test.ts
+++ b/server/live/outcome.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSummary,
+  createOutcomeTracker,
+  DEFAULT_GAME_DURATION_MS,
+  winnerFor,
+  type CatchRecord,
+  type GameTimerApi,
+} from './outcome.ts';
+import type { Game, Player } from '../lobby/rooms.ts';
+
+/** A minimal player for building a test roster. */
+function player(id: string, name: string, role: 'hunter' | 'hider'): Player {
+  return { id, name, role, ready: true, isHost: false };
+}
+
+/** An active game with the given roster. */
+function game(id: string, players: Player[]): Game {
+  return {
+    id,
+    roomCode: 'ABCD',
+    status: 'active',
+    players,
+    createdAt: '2026-07-22T12:00:00.000Z',
+    startedAt: '2026-07-22T12:00:00.000Z',
+  };
+}
+
+/**
+ * A controllable one-shot timer stand-in. Records each registered handler so a
+ * test can fire the survive-the-timer timeout on demand — deterministic, no
+ * `setTimeout`.
+ */
+function fakeTimers(): GameTimerApi & { fireAll: () => void; active: () => number; lastMs: number | undefined } {
+  const handlers = new Map<number, () => void>();
+  let nextId = 1;
+  let lastMs: number | undefined;
+  return {
+    setTimeout(handler, ms) {
+      lastMs = ms;
+      const id = nextId++;
+      handlers.set(id, handler);
+      return id;
+    },
+    clearTimeout(handle) {
+      handlers.delete(handle as number);
+    },
+    fireAll() {
+      // Copy first: a handler that ends the game clears its own timer mid-iteration.
+      for (const handler of [...handlers.values()]) handler();
+    },
+    active() {
+      return handlers.size;
+    },
+    get lastMs() {
+      return lastMs;
+    },
+  };
+}
+
+const START = '2026-07-22T12:00:00.000Z';
+
+describe('winnerFor', () => {
+  it('gives the hunters the win when the last hider is caught', () => {
+    expect(winnerFor('all_caught')).toBe('hunters');
+  });
+
+  it('gives the hiders the win when the timer runs out', () => {
+    expect(winnerFor('timer')).toBe('hiders');
+  });
+});
+
+describe('buildSummary', () => {
+  it('summarizes an all-caught game: hunters win, per-hider survival, catches listed', () => {
+    const catches: CatchRecord[] = [
+      { hunterId: 'h1', targetId: 'a', at: '2026-07-22T12:01:00.000Z' }, // 60 s
+      { hunterId: 'h1', targetId: 'b', at: '2026-07-22T12:05:00.000Z' }, // 300 s
+    ];
+    const summary = buildSummary({
+      gameId: 'g1',
+      startedAt: START,
+      endedAt: '2026-07-22T12:05:00.000Z',
+      reason: 'all_caught',
+      initialHiders: [
+        { playerId: 'a', name: 'Ann' },
+        { playerId: 'b', name: 'Bo' },
+      ],
+      catches,
+    });
+
+    expect(summary.winner).toBe('hunters');
+    expect(summary.reason).toBe('all_caught');
+    expect(summary.durationMs).toBe(300_000);
+    expect(summary.catches).toEqual(catches);
+    // Longest survivor first: Bo lasted 300 s, Ann 60 s.
+    expect(summary.hiders).toEqual([
+      { playerId: 'b', name: 'Bo', caught: true, survivalMs: 300_000, caughtAt: '2026-07-22T12:05:00.000Z' },
+      { playerId: 'a', name: 'Ann', caught: true, survivalMs: 60_000, caughtAt: '2026-07-22T12:01:00.000Z' },
+    ]);
+  });
+
+  it('counts a survivor as lasting until the game ended', () => {
+    const summary = buildSummary({
+      gameId: 'g1',
+      startedAt: START,
+      endedAt: '2026-07-22T12:30:00.000Z',
+      reason: 'timer',
+      initialHiders: [
+        { playerId: 'a', name: 'Ann' },
+        { playerId: 'b', name: 'Bo' },
+      ],
+      catches: [{ hunterId: 'h1', targetId: 'a', at: '2026-07-22T12:10:00.000Z' }],
+    });
+
+    expect(summary.winner).toBe('hiders');
+    // Bo was never caught → survived the full 30 min; Ann caught at 10 min.
+    const bo = summary.hiders.find((h) => h.playerId === 'b');
+    expect(bo).toEqual({ playerId: 'b', name: 'Bo', caught: false, survivalMs: 1_800_000 });
+    const ann = summary.hiders.find((h) => h.playerId === 'a');
+    expect(ann).toMatchObject({ caught: true, survivalMs: 600_000 });
+    // The survivor sorts ahead of the caught hider.
+    expect(summary.hiders[0]?.playerId).toBe('b');
+  });
+
+  it('never reports a negative duration or survival time', () => {
+    const summary = buildSummary({
+      gameId: 'g1',
+      startedAt: START,
+      endedAt: START,
+      reason: 'all_caught',
+      initialHiders: [{ playerId: 'a', name: 'Ann' }],
+      // A catch stamped (impossibly) before the start clamps to 0, not negative.
+      catches: [{ hunterId: 'h1', targetId: 'a', at: '2026-07-22T11:59:00.000Z' }],
+    });
+    expect(summary.durationMs).toBe(0);
+    expect(summary.hiders[0]?.survivalMs).toBe(0);
+  });
+});
+
+describe('createOutcomeTracker', () => {
+  it('reports remaining hiders and reaches zero as they are caught', () => {
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
+    const g = game('g1', [
+      player('h1', 'Hunter', 'hunter'),
+      player('a', 'Ann', 'hider'),
+      player('b', 'Bo', 'hider'),
+    ]);
+    tracker.start({ game: g, startedAt: START });
+    expect(tracker.remainingHiders('g1')).toBe(2);
+
+    tracker.recordCatch('g1', { hunterId: 'h1', targetId: 'a', at: START });
+    expect(tracker.remainingHiders('g1')).toBe(1);
+    tracker.recordCatch('g1', { hunterId: 'h1', targetId: 'b', at: START });
+    expect(tracker.remainingHiders('g1')).toBe(0);
+  });
+
+  it('fires onExpire for a running game when the countdown elapses', () => {
+    const expired: string[] = [];
+    const timers = fakeTimers();
+    const tracker = createOutcomeTracker({ onExpire: (id) => expired.push(id), timers });
+    tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });
+    expect(timers.active()).toBe(1);
+
+    timers.fireAll();
+    expect(expired).toEqual(['g1']);
+  });
+
+  it('end() returns a summary once, then undefined (idempotent finalize)', () => {
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
+    tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });
+    tracker.recordCatch('g1', { hunterId: 'h1', targetId: 'a', at: '2026-07-22T12:02:00.000Z' });
+
+    const summary = tracker.end('g1', 'all_caught', '2026-07-22T12:02:00.000Z');
+    expect(summary?.winner).toBe('hunters');
+    expect(summary?.hiders[0]).toMatchObject({ playerId: 'a', caught: true, survivalMs: 120_000 });
+    // A second finalize (e.g. the timer racing the catch) yields nothing.
+    expect(tracker.end('g1', 'timer', '2026-07-22T12:30:00.000Z')).toBeUndefined();
+    expect(tracker.isTracking('g1')).toBe(false);
+  });
+
+  it('clears the countdown when a game ends so it cannot fire afterwards', () => {
+    const expired: string[] = [];
+    const timers = fakeTimers();
+    const tracker = createOutcomeTracker({ onExpire: (id) => expired.push(id), timers });
+    tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });
+    tracker.end('g1', 'all_caught', '2026-07-22T12:02:00.000Z');
+    expect(timers.active()).toBe(0);
+
+    timers.fireAll();
+    expect(expired).toEqual([]);
+  });
+
+  it('is idempotent on start: a second start does not stack timers or reset the snapshot', () => {
+    const timers = fakeTimers();
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers });
+    const g = game('g1', [player('a', 'Ann', 'hider')]);
+    tracker.start({ game: g, startedAt: START });
+    tracker.recordCatch('g1', { hunterId: 'h1', targetId: 'a', at: START });
+    // A double start_game must not wipe the recorded catch or add a timer.
+    tracker.start({ game: g, startedAt: START });
+    expect(timers.active()).toBe(1);
+    expect(tracker.remainingHiders('g1')).toBe(0);
+  });
+
+  it('treats an unknown game as having no hiders and finalizes to nothing', () => {
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
+    expect(tracker.remainingHiders('nope')).toBe(0);
+    expect(tracker.end('nope', 'timer', START)).toBeUndefined();
+    expect(() => tracker.recordCatch('nope', { hunterId: 'h', targetId: 't', at: START })).not.toThrow();
+  });
+
+  it('stop() drops tracking and clears the countdown without a summary', () => {
+    const expired: string[] = [];
+    const timers = fakeTimers();
+    const tracker = createOutcomeTracker({ onExpire: (id) => expired.push(id), timers });
+    tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });
+    tracker.stop('g1');
+    expect(tracker.isTracking('g1')).toBe(false);
+    expect(timers.active()).toBe(0);
+    timers.fireAll();
+    expect(expired).toEqual([]);
+  });
+
+  it('stopAll clears every tracked game', () => {
+    const timers = fakeTimers();
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers });
+    tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });
+    tracker.start({ game: game('g2', [player('b', 'Bo', 'hider')]), startedAt: START });
+    tracker.stopAll();
+    expect(tracker.isTracking('g1')).toBe(false);
+    expect(tracker.isTracking('g2')).toBe(false);
+    expect(timers.active()).toBe(0);
+  });
+
+  it('uses the default duration when none is configured and coerces a bad one', () => {
+    const timersA = fakeTimers();
+    createOutcomeTracker({ onExpire: () => {}, timers: timersA }).start({
+      game: game('g1', [player('a', 'Ann', 'hider')]),
+      startedAt: START,
+    });
+    expect(timersA.lastMs).toBe(DEFAULT_GAME_DURATION_MS);
+
+    const timersB = fakeTimers();
+    createOutcomeTracker({ onExpire: () => {}, durationMs: 0, timers: timersB }).start({
+      game: game('g2', [player('a', 'Ann', 'hider')]),
+      startedAt: START,
+    });
+    expect(timersB.lastMs).toBe(1);
+  });
+});

--- a/server/live/outcome.test.ts
+++ b/server/live/outcome.test.ts
@@ -165,6 +165,50 @@ describe('createOutcomeTracker', () => {
     expect(expired).toEqual(['g1']);
   });
 
+  it('dropPlayer removes a departed hider from the count and the summary', () => {
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
+    const g = game('g1', [
+      player('h1', 'Hunter', 'hunter'),
+      player('a', 'Ann', 'hider'),
+      player('b', 'Bo', 'hider'),
+    ]);
+    tracker.start({ game: g, startedAt: START });
+
+    // Bo leaves mid-match: the remaining-hider count drops, so catching Ann now
+    // takes the last present hider and the hunters win.
+    tracker.dropPlayer('g1', 'b');
+    expect(tracker.remainingHiders('g1')).toBe(1);
+    tracker.recordCatch('g1', { hunterId: 'h1', targetId: 'a', at: '2026-07-22T12:01:00.000Z' });
+    expect(tracker.remainingHiders('g1')).toBe(0);
+
+    const summary = tracker.end('g1', 'all_caught', '2026-07-22T12:01:00.000Z');
+    // The departed hider earns no survival line; only Ann remains.
+    expect(summary?.hiders.map((h) => h.playerId)).toEqual(['a']);
+  });
+
+  it('dropPlayer of an already-caught hider leaves the count unchanged', () => {
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
+    const g = game('g1', [
+      player('h1', 'Hunter', 'hunter'),
+      player('a', 'Ann', 'hider'),
+      player('b', 'Bo', 'hider'),
+    ]);
+    tracker.start({ game: g, startedAt: START });
+    tracker.recordCatch('g1', { hunterId: 'h1', targetId: 'a', at: START });
+    expect(tracker.remainingHiders('g1')).toBe(1);
+    // Ann (already caught, now a hunter) leaves: Bo is still the one free hider.
+    tracker.dropPlayer('g1', 'a');
+    expect(tracker.remainingHiders('g1')).toBe(1);
+  });
+
+  it('dropPlayer is a no-op for an unknown player or untracked game', () => {
+    const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
+    tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });
+    expect(() => tracker.dropPlayer('g1', 'nobody')).not.toThrow();
+    expect(() => tracker.dropPlayer('nope', 'a')).not.toThrow();
+    expect(tracker.remainingHiders('g1')).toBe(1);
+  });
+
   it('end() returns a summary once, then undefined (idempotent finalize)', () => {
     const tracker = createOutcomeTracker({ onExpire: () => {}, timers: fakeTimers() });
     tracker.start({ game: game('g1', [player('a', 'Ann', 'hider')]), startedAt: START });

--- a/server/live/outcome.ts
+++ b/server/live/outcome.ts
@@ -1,0 +1,305 @@
+/**
+ * Win conditions + end-screen data — the rules-engine end-of-game check
+ * (BACKLOG.md #15, docs/arc42.md §5 "Rules engine"). A match ends one of two
+ * ways:
+ *
+ * - **Last hider caught** — every hider has been converted to a hunter
+ *   (BACKLOG.md #12). There is no one left to find, so the **hunters win**
+ *   (`all_caught`). Detected the moment a confirmed catch flips the final hider.
+ * - **Survive the timer** — the game's duration elapses with at least one hider
+ *   still uncaught. The remaining hiders lasted the match, so the **hiders win**
+ *   (`timer`).
+ *
+ * Whichever fires first ends the game, and the server produces a summary payload
+ * for the end screen (BACKLOG.md #19): who won and why, how long the match ran,
+ * every catch that happened, and each hider's survival time. Like every
+ * game-affecting decision this is computed server-side and never trusted from the
+ * client (docs/arc42.md quality goal #1 "Fairness / authority").
+ *
+ * Two parts, mirroring the split elsewhere in `server/live/`: a pure summary
+ * builder ({@link buildSummary}) that turns recorded facts into the end payload,
+ * and a small stateful tracker ({@link createOutcomeTracker}) that remembers a
+ * game's start, its original hiders and its catches, and owns the one-shot
+ * survive-the-timer countdown. The timer primitives are injectable so tests can
+ * fire the timeout deterministically without leaning on real wall-clock time.
+ */
+import type { Game } from '../lobby/rooms.ts';
+
+/** Which side won the match. */
+export type Winner = 'hunters' | 'hiders';
+
+/**
+ * Why a match ended. `all_caught` — the last hider was caught (hunters win);
+ * `timer` — the duration elapsed with a hider still free (hiders win). Stable
+ * codes for the summary payload and the event log (`events.type = 'win'`).
+ */
+export type EndReason = 'all_caught' | 'timer';
+
+/**
+ * Default match duration, in milliseconds. Mirrors the `games.duration_s` column
+ * default (1800 s / 30 min) in `db/schema.sql`, so the same length is described
+ * everywhere. Tunable per game once game settings land (BACKLOG.md #27).
+ */
+export const DEFAULT_GAME_DURATION_MS = 1_800_000;
+
+/** The side that wins for a given end reason. */
+export function winnerFor(reason: EndReason): Winner {
+  return reason === 'all_caught' ? 'hunters' : 'hiders';
+}
+
+/**
+ * A catch that happened during the match: a hunter caught a hider at a moment in
+ * time. The same shape the transport layer broadcasts as `catch_confirmed` (minus
+ * the game id), recorded so the summary can list every catch and derive survival
+ * times.
+ */
+export interface CatchRecord {
+  hunterId: string;
+  targetId: string;
+  /** When the server confirmed the catch (ISO-8601). */
+  at: string;
+}
+
+/** One hider's line on the end screen: whether they were caught and for how long they lasted. */
+export interface HiderOutcome {
+  playerId: string;
+  name: string;
+  /** True if this hider was caught before the game ended; false if they survived. */
+  caught: boolean;
+  /** How long the hider lasted, in milliseconds — until caught, or until the game ended. */
+  survivalMs: number;
+  /** When this hider was caught (ISO-8601). Absent when they survived to the end. */
+  caughtAt?: string;
+}
+
+/**
+ * The end-of-game summary — the payload the end screen renders (BACKLOG.md #15
+ * "produce a summary", #19). Carries the winner and why, the match's span, every
+ * catch, and each original hider's survival time (longest-lasting first).
+ */
+export interface GameSummary {
+  gameId: string;
+  winner: Winner;
+  reason: EndReason;
+  /** When the match started (ISO-8601). */
+  startedAt: string;
+  /** When the match ended (ISO-8601). */
+  endedAt: string;
+  /** How long the match ran, in milliseconds. */
+  durationMs: number;
+  /** Every catch that happened, in the order they were confirmed. */
+  catches: CatchRecord[];
+  /** Each original hider's outcome, sorted by survival time descending. */
+  hiders: HiderOutcome[];
+}
+
+/** Milliseconds between two ISO-8601 stamps, never negative (a clock quirk can't make time run backwards here). */
+function elapsedMs(from: string, to: string): number {
+  return Math.max(0, Date.parse(to) - Date.parse(from));
+}
+
+/**
+ * Build the end-of-game summary from the recorded facts. Pure: the caller supplies
+ * the match's start/end, why it ended, the original hider roster, and the catches
+ * that happened. A hider's survival time runs from the start to the moment they
+ * were caught (or to the game's end if they were never caught); hiders are sorted
+ * by survival time descending so the end screen can lead with the longest survivor.
+ */
+export function buildSummary(input: {
+  gameId: string;
+  startedAt: string;
+  endedAt: string;
+  reason: EndReason;
+  initialHiders: { playerId: string; name: string }[];
+  catches: CatchRecord[];
+}): GameSummary {
+  const { gameId, startedAt, endedAt, reason, initialHiders, catches } = input;
+  // Index the catches by their target so each hider can find its own capture.
+  const caughtAtByPlayer = new Map<string, string>();
+  for (const c of catches) {
+    // Keep the first catch recorded for a player — a hider is caught once.
+    if (!caughtAtByPlayer.has(c.targetId)) caughtAtByPlayer.set(c.targetId, c.at);
+  }
+
+  const hiders: HiderOutcome[] = initialHiders
+    .map(({ playerId, name }) => {
+      const caughtAt = caughtAtByPlayer.get(playerId);
+      const survivalMs = elapsedMs(startedAt, caughtAt ?? endedAt);
+      return caughtAt
+        ? { playerId, name, caught: true, survivalMs, caughtAt }
+        : { playerId, name, caught: false, survivalMs };
+    })
+    // Longest survivor first; break ties by name for a stable order.
+    .sort((a, b) => b.survivalMs - a.survivalMs || a.name.localeCompare(b.name));
+
+  return {
+    gameId,
+    winner: winnerFor(reason),
+    reason,
+    startedAt,
+    endedAt,
+    durationMs: elapsedMs(startedAt, endedAt),
+    catches,
+    hiders,
+  };
+}
+
+/**
+ * The subset of the timer API the tracker needs for the survive-the-timer
+ * countdown: a one-shot `setTimeout` returning an opaque handle it later passes to
+ * `clearTimeout`. The handle type is hidden behind `unknown` so a fake (or the
+ * global timers) can supply whatever it likes. Defaults to the global timers,
+ * un-refed so a pending countdown never keeps the process alive on its own.
+ */
+export interface GameTimerApi {
+  setTimeout(handler: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+const defaultTimers: GameTimerApi = {
+  setTimeout: (handler, ms) => setTimeout(handler, ms).unref(),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/** Tunables for {@link createOutcomeTracker}. */
+export interface OutcomeTrackerOptions {
+  /**
+   * Called once when a game's survive-the-timer countdown elapses, with that
+   * game's id. The caller ends the game with reason `timer` (hiders win). Not
+   * awaited, mirroring the ping scheduler: a slow or throwing handler can't wedge
+   * the tracker, so the caller catches its own async failures.
+   */
+  onExpire: (gameId: string) => void;
+  /**
+   * Match duration in milliseconds — how long hiders must survive to win. Defaults
+   * to {@link DEFAULT_GAME_DURATION_MS}. Coerced to a positive integer so a
+   * zero/negative/fractional config can't make a nonsensical timer.
+   */
+  durationMs?: number;
+  /** Timer primitives; injected in tests for a deterministic timeout. */
+  timers?: GameTimerApi;
+}
+
+/** Per-game end-of-game tracker: remembers the facts a summary needs and owns the survive timer. */
+export interface OutcomeTracker {
+  /**
+   * Begin tracking a started match: snapshot its original hiders and start time,
+   * and arm the survive-the-timer countdown. Idempotent — starting an
+   * already-tracked game is a no-op, so a double `start_game` can't stack timers or
+   * reset the snapshot.
+   */
+  start(input: { game: Game; startedAt: string }): void;
+  /** Record a confirmed catch so it shows in the summary and counts against the hiders. */
+  recordCatch(gameId: string, record: CatchRecord): void;
+  /**
+   * How many original hiders are still uncaught. `0` means the last hider has been
+   * caught — the hunters have won. `0` too for an unknown/untracked game, so a
+   * stray check can't be misread as "hiders remain".
+   */
+  remainingHiders(gameId: string): number;
+  /**
+   * Finalize a tracked game exactly once: clear its countdown, drop its state, and
+   * return the summary. A second call (or a call for an untracked game) returns
+   * `undefined`, so the catch path and the timer path can race to end a game and
+   * only the first wins.
+   */
+  end(gameId: string, reason: EndReason, endedAt: string): GameSummary | undefined;
+  /** Stop tracking a game and clear its countdown without producing a summary (teardown). */
+  stop(gameId: string): void;
+  /** Whether a game is currently being tracked. */
+  isTracking(gameId: string): boolean;
+  /** Stop tracking every game — full teardown (server shutdown, test cleanup). */
+  stopAll(): void;
+}
+
+/** A tracked game's recorded facts plus its live countdown handle. */
+interface TrackedGame {
+  startedAt: string;
+  initialHiders: { playerId: string; name: string }[];
+  catches: CatchRecord[];
+  /** Ids of original hiders caught so far — the complement of "still free". */
+  caught: Set<string>;
+  timer: unknown;
+}
+
+/**
+ * Build an outcome tracker. State is one {@link TrackedGame} per active game,
+ * keyed by game id; {@link OutcomeTracker.end}/{@link OutcomeTracker.stop}/
+ * {@link OutcomeTracker.stopAll} clear the countdown so no timer outlives the game
+ * it ends.
+ */
+export function createOutcomeTracker({
+  onExpire,
+  durationMs = DEFAULT_GAME_DURATION_MS,
+  timers = defaultTimers,
+}: OutcomeTrackerOptions): OutcomeTracker {
+  const period = Math.max(1, Math.trunc(durationMs));
+  const games = new Map<string, TrackedGame>();
+
+  function clearTimer(game: TrackedGame): void {
+    timers.clearTimeout(game.timer);
+  }
+
+  return {
+    start({ game, startedAt }) {
+      if (games.has(game.id)) return;
+      const initialHiders = game.players
+        .filter((p) => p.role === 'hider')
+        .map((p) => ({ playerId: p.id, name: p.name }));
+      games.set(game.id, {
+        startedAt,
+        initialHiders,
+        catches: [],
+        caught: new Set(),
+        timer: timers.setTimeout(() => onExpire(game.id), period),
+      });
+    },
+
+    recordCatch(gameId, record) {
+      const game = games.get(gameId);
+      if (!game) return;
+      game.catches.push(record);
+      game.caught.add(record.targetId);
+    },
+
+    remainingHiders(gameId) {
+      const game = games.get(gameId);
+      if (!game) return 0;
+      return game.initialHiders.reduce(
+        (n, h) => (game.caught.has(h.playerId) ? n : n + 1),
+        0,
+      );
+    },
+
+    end(gameId, reason, endedAt) {
+      const game = games.get(gameId);
+      if (!game) return undefined;
+      clearTimer(game);
+      games.delete(gameId);
+      return buildSummary({
+        gameId,
+        startedAt: game.startedAt,
+        endedAt,
+        reason,
+        initialHiders: game.initialHiders,
+        catches: game.catches,
+      });
+    },
+
+    stop(gameId) {
+      const game = games.get(gameId);
+      if (!game) return;
+      clearTimer(game);
+      games.delete(gameId);
+    },
+
+    isTracking(gameId) {
+      return games.has(gameId);
+    },
+
+    stopAll() {
+      for (const game of games.values()) clearTimer(game);
+      games.clear();
+    },
+  };
+}

--- a/server/live/outcome.ts
+++ b/server/live/outcome.ts
@@ -192,6 +192,13 @@ export interface OutcomeTracker {
   /** Record a confirmed catch so it shows in the summary and counts against the hiders. */
   recordCatch(gameId: string, record: CatchRecord): void;
   /**
+   * Drop a player who left the game (disconnect / `leave_game`) from the tracker:
+   * remove them from the original-hider snapshot so they no longer count toward
+   * the last-hider win and are not credited with a survival time in the summary.
+   * A no-op for a player who was never a tracked hider, or an untracked game.
+   */
+  dropPlayer(gameId: string, playerId: string): void;
+  /**
    * How many original hiders are still uncaught. `0` means the last hider has been
    * caught — the hunters have won. `0` too for an unknown/untracked game, so a
    * stray check can't be misread as "hiders remain".
@@ -260,6 +267,16 @@ export function createOutcomeTracker({
       if (!game) return;
       game.catches.push(record);
       game.caught.add(record.targetId);
+    },
+
+    dropPlayer(gameId, playerId) {
+      const game = games.get(gameId);
+      if (!game) return;
+      // Leave the recorded catches intact — a catch that happened is history — but
+      // take the departed player out of the hider roster so they neither hold the
+      // game open past the last present hider nor earn a survival line at the end.
+      game.initialHiders = game.initialHiders.filter((h) => h.playerId !== playerId);
+      game.caught.delete(playerId);
     },
 
     remainingHiders(gameId) {

--- a/server/lobby/rooms.ts
+++ b/server/lobby/rooms.ts
@@ -140,6 +140,13 @@ export interface LobbyManager {
   /** Host-only: move the room from `lobby` to `active`. */
   startGame(gameId: string, playerId: string): Game;
   /**
+   * Move a game to `ended` — the terminal state a win condition triggers
+   * (BACKLOG.md #15). Unlike {@link LobbyManager.startGame} this is a rules-engine
+   * outcome (last hider caught, or the timer elapsed), not a host action, so it
+   * takes no player. Idempotent: ending an already-ended game is a no-op.
+   */
+  endGame(gameId: string): Game;
+  /**
    * Remove a player (e.g. on disconnect). Reassigns the host and deletes the
    * room once empty. Returns the updated game, or `undefined` if it's now gone.
    */
@@ -282,6 +289,12 @@ export function createMemoryLobby(): LobbyManager {
       }
       game.status = 'active';
       game.startedAt = new Date().toISOString();
+      return game;
+    },
+
+    endGame(gameId) {
+      const game = getGameOrThrow(gameId);
+      game.status = 'ended';
       return game;
     },
 

--- a/server/protocol/messages.ts
+++ b/server/protocol/messages.ts
@@ -18,7 +18,7 @@
  * (`server/lobby/rooms.ts`) and are named here so the contract lists every
  * event in one place.
  */
-import type { BoundaryCircle, PositionsByPlayer } from '../live/index.ts';
+import type { BoundaryCircle, GameSummary, PositionsByPlayer } from '../live/index.ts';
 import type { Game } from '../lobby/rooms.ts';
 
 /** Inbound events (client → server) that carry a validated game-loop payload. */
@@ -36,6 +36,7 @@ export const OUTBOUND_EVENTS = {
   lobbyUpdate: 'lobby_update',
   boundaryWarning: 'boundary_warning',
   playerEliminated: 'player_eliminated',
+  gameOver: 'game_over',
 } as const;
 
 // --- Inbound payloads (client → server) ------------------------------------
@@ -141,6 +142,17 @@ export interface PlayerEliminatedEvent {
   reason: 'boundary';
   /** When the server eliminated the player (ISO-8601). */
   at: string;
+}
+
+/**
+ * `game_over` — the server detected a win condition and ended the match
+ * (BACKLOG.md #15). Broadcast to the whole room so every client can switch to the
+ * end screen. The {@link GameSummary} payload carries who won and why, the match's
+ * span, every catch, and each hider's survival time (see `server/live/outcome.ts`).
+ */
+export interface GameOverEvent {
+  gameId: string;
+  summary: GameSummary;
 }
 
 // --- Validation ------------------------------------------------------------


### PR DESCRIPTION
Closes #15.

Detect the end of a match and produce the end-screen summary. A game ends one of two ways, whichever fires first:

- **Last hider caught** — every hider has been converted to a hunter, so there's no one left to find. The **hunters win** (`all_caught`). Detected the moment a confirmed catch flips the final hider.
- **Survive the timer** — the game's duration elapses with at least one hider still uncaught. The remaining hiders lasted the match, so the **hiders win** (`timer`).

Either way the server moves the game to `ended`, stops its timers, and broadcasts a new `game_over` event with a summary payload for the end screen: who won and why, the match span, every catch, and each hider's survival time (longest survivor first).

### Acceptance

- **Correct winner determination** — `all_caught` → hunters, `timer` → hiders, computed server-side.
- **Summary payload (survival times, catches)** — `GameSummary` carries `winner`, `reason`, `startedAt`/`endedAt`/`durationMs`, the ordered `catches`, and per-hider `survivalMs` / `caughtAt`.

### Changes

- **`server/live/outcome.ts`** (new) — a pure summary builder (`buildSummary`, `winnerFor`) plus a stateful `createOutcomeTracker` that snapshots a game's original hiders, records catches, tracks remaining hiders, and owns the survive-the-timer countdown. Timer primitives are injectable (unref'd by default), mirroring the ping scheduler.
- **`server/app.ts`** — start tracking on `start_game`; record each confirmed catch and end the game when no hider remains; end on timer expiry. A single `finishGame` finalizes exactly once (the catch and timer routes can safely race), stops the ping scheduler, moves the room to `ended`, and emits `game_over` then the final roster. Drops outcome tracking when a room empties. Adds `GAME_DURATION_S` support via `resolveGameDurationMs` (default 1800 s).
- **`server/lobby/rooms.ts`** — new `LobbyManager.endGame` (rules-engine terminal state).
- **`server/protocol/messages.ts`** — new `game_over` outbound event and `GameOverEvent`.
- **Docs / config** — README WebSocket contract + rules-engine notes, arc42 §6.5, and `.env.example`.

### Tests

- `server/live/outcome.test.ts` — pure summary logic + tracker (remaining-hider count, idempotent finalize, timer clear-on-end, teardown, duration coercion).
- `server/app.win.test.ts` — socket-level integration for both win routes, the two-hider "keep playing until the timer" case, and dropping the timer when the room empties.

Full server suite (185 tests) and lint/typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFWy1YXLqfDJsTBHAYMtbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFWy1YXLqfDJsTBHAYMtbh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matches now end when all hiders are caught or when the configured match timer expires.
  * Added a `game_over` end-screen event with winner, end reason, match duration, catch details, and per-hider survival times.
  * Added `GAME_DURATION_S` configuration (default: 1800s / 30 minutes).

* **Documentation**
  * Updated README and architecture docs to reflect the match-ending flow and the `game_over` payload contract.

* **Bug Fixes**
  * Improved end-of-match teardown to reliably stop timers and prevent duplicate end events.
  * Departed hiders are excluded from win evaluation after leaving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->