### PR TITLE
feat(client): join screen from the mockup (#16)

### DIFF
--- a/client/e2e/gps.spec.ts
+++ b/client/e2e/gps.spec.ts
@@ -59,7 +59,7 @@ test('the browser client streams its GPS position to other players', async ({ pa
     await page.goto('/');
     await expect(page.getByRole('status')).toHaveText(/Connected to server/, { timeout: 15_000 });
     await page.getByLabel(/your name/i).fill('Host');
-    await page.getByRole('button', { name: /create new game/i }).click();
+    await page.getByRole('button', { name: /create game/i }).click();
 
     const codeChip = page.locator('.room-code__value');
     await expect(codeChip).toHaveText(/^[A-Z0-9]{4}$/, { timeout: 15_000 });

--- a/client/e2e/lobby.spec.ts
+++ b/client/e2e/lobby.spec.ts
@@ -86,7 +86,7 @@ test('creates a game from the UI and shows the room code', async ({ page }) => {
   await expect(page.getByRole('status')).toHaveText(/Connected to server/, { timeout: 15_000 });
 
   await page.getByLabel(/your name/i).fill('Ada');
-  await page.getByRole('button', { name: /create new game/i }).click();
+  await page.getByRole('button', { name: /create game/i }).click();
 
   // The room-code chip shows a 4-character unambiguous code.
   const code = page.locator('.room-code__value');

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -45,7 +45,7 @@ describe('<App />', () => {
   it('renders the Manhunt landing screen with the lobby entry', () => {
     render(<App />);
     expect(screen.getByRole('heading', { name: 'MANHUNT' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /create new game/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create game/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/room code/i)).toBeInTheDocument();
   });
 

--- a/client/src/lobby/CodeInput.test.tsx
+++ b/client/src/lobby/CodeInput.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import CodeInput, { CODE_LENGTH } from './CodeInput.tsx';
+
+afterEach(cleanup);
+
+/** A tiny controlled harness so typing flows through the parent, as in the app. */
+function Harness({ onChange }: { onChange?: (v: string) => void }) {
+  const [value, setValue] = useState('');
+  return (
+    <CodeInput
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe('<CodeInput />', () => {
+  it('renders one box per code character', () => {
+    render(<Harness />);
+    // The single accessible field plus CODE_LENGTH visual boxes.
+    expect(screen.getByLabelText(/room code/i)).toBeInTheDocument();
+  });
+
+  it('upper-cases input and drops disallowed characters', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    await user.type(screen.getByLabelText(/room code/i), 'a2-!z');
+    expect(onChange).toHaveBeenLastCalledWith('A2Z');
+    expect(screen.getByLabelText(/room code/i)).toHaveValue('A2Z');
+  });
+
+  it('caps the value at the code length', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.type(screen.getByLabelText(/room code/i), 'ABCDEFGH');
+    expect(screen.getByLabelText(/room code/i)).toHaveValue('ABCD'.slice(0, CODE_LENGTH));
+  });
+});

--- a/client/src/lobby/CodeInput.tsx
+++ b/client/src/lobby/CodeInput.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+/**
+ * Number of characters in a room code, mirroring the server's
+ * `ROOM_CODE_LENGTH` (see `server/lobby/rooms.ts`). The two workspaces don't
+ * share a package, so this is kept in sync by hand.
+ */
+export const CODE_LENGTH = 4;
+
+/** Keep only the characters a room code can contain (see `ROOM_CODE_ALPHABET`). */
+function sanitize(raw: string): string {
+  return raw
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+    .slice(0, CODE_LENGTH);
+}
+
+/**
+ * A segmented room-code entry, matching screen 01 of the mockup: one glowing
+ * box per character. A single transparent `<input>` overlays the boxes so the
+ * native (mobile) keyboard, paste, and assistive tech all work off one field —
+ * the boxes are a purely visual reflection of its value.
+ */
+export default function CodeInput({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+}) {
+  const [focused, setFocused] = useState(false);
+  const chars = value.split('');
+
+  return (
+    <div className="code-input">
+      <div className="code-input__boxes" aria-hidden="true">
+        {Array.from({ length: CODE_LENGTH }, (_, i) => {
+          const filled = i < value.length;
+          // Highlight the next empty box while the field has focus, so the
+          // caret's position is obvious even though the real caret is hidden.
+          const active = focused && !disabled && i === value.length && value.length < CODE_LENGTH;
+          const className = [
+            'code-box',
+            filled ? 'code-box--filled' : '',
+            active ? 'code-box--active' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <div key={i} className={className}>
+              {chars[i] ?? ''}
+            </div>
+          );
+        })}
+      </div>
+      <input
+        className="code-input__field"
+        value={value}
+        onChange={(e) => onChange(sanitize(e.target.value))}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        inputMode="text"
+        autoComplete="off"
+        autoCapitalize="characters"
+        autoCorrect="off"
+        spellCheck={false}
+        maxLength={CODE_LENGTH}
+        aria-label="Room code"
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/client/src/lobby/Lobby.css
+++ b/client/src/lobby/Lobby.css
@@ -37,25 +37,137 @@
   border-color: var(--teal);
 }
 
-.field__input--code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  letter-spacing: 0.35em;
-  text-transform: uppercase;
-}
-
-.lobby-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
+/*
+ * The join screen is card-less in the mockup — the create/join controls sit
+ * directly on the app background rather than in a bordered panel like the
+ * in-room screen. Strip the panel chrome the base .lobby-card carries.
+ */
+.lobby-card--join {
+  gap: 0.85rem;
+  padding: 0;
+  background: none;
+  border: none;
 }
 
 .btn {
-  padding: 0.8rem 1rem;
+  padding: 0.95rem 1rem;
   font-size: 1rem;
   font-weight: 600;
   border: 1px solid transparent;
-  border-radius: 12px;
+  border-radius: 16px;
   cursor: pointer;
+}
+
+.btn--create {
+  padding: 1.05rem 1rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  box-shadow: 0 8px 30px rgb(255 66 66 / 35%);
+}
+
+.lobby-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.15rem 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.lobby-divider::before,
+.lobby-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgb(255 255 255 / 10%);
+}
+
+.code-input {
+  position: relative;
+}
+
+.code-input__boxes {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.code-box {
+  flex: 1;
+  min-width: 0;
+  aspect-ratio: 0.85;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: clamp(1.25rem, 8vw, 1.6rem);
+  font-weight: 600;
+  color: var(--fg);
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 12px;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.code-box:not(.code-box--filled, .code-box--active) {
+  border-style: dashed;
+  border-color: rgb(255 255 255 / 16%);
+}
+
+/* A faint underscore marks the slots still waiting for a character, matching
+   the mockup's empty boxes. The active (next-up) box stays clean. */
+.code-box:not(.code-box--filled, .code-box--active)::after {
+  content: '_';
+  color: rgb(255 255 255 / 22%);
+}
+
+.code-box--active {
+  border-color: var(--teal);
+  box-shadow: 0 0 16px rgb(36 227 198 / 25%);
+}
+
+/*
+ * A single real input overlays the boxes: transparent text and caret so it's
+ * invisible, but it still captures taps, typing, paste, and focus for the
+ * segmented display above.
+ */
+.code-input__field {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: transparent;
+  caret-color: transparent;
+  text-align: center;
+  letter-spacing: 1em;
+  cursor: pointer;
+}
+
+.code-input__field:focus {
+  outline: none;
+}
+
+.code-input__field:disabled {
+  cursor: not-allowed;
+}
+
+.lobby-footnote {
+  margin: 0.25rem 0 0;
+  text-align: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
 }
 
 .btn:disabled {
@@ -71,7 +183,7 @@
 .btn--ghost {
   color: var(--fg);
   background: transparent;
-  border-color: rgb(255 255 255 / 18%);
+  border-color: #2a3543;
 }
 
 .btn--start {

--- a/client/src/lobby/Lobby.test.tsx
+++ b/client/src/lobby/Lobby.test.tsx
@@ -89,7 +89,7 @@ describe('<Lobby /> — join screen', () => {
     render(<Lobby />);
 
     await user.type(screen.getByLabelText(/your name/i), 'Ada');
-    await user.click(screen.getByRole('button', { name: /create new game/i }));
+    await user.click(screen.getByRole('button', { name: /create game/i }));
 
     expect(fake.emitWithAck).toHaveBeenCalledWith('create_game', { name: 'Ada' });
     expect(await screen.findByText('AB2C')).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe('<Lobby /> — join screen', () => {
 
     await user.type(screen.getByLabelText(/your name/i), 'Bo');
     await user.type(screen.getByLabelText(/room code/i), 'zzzz');
-    await user.click(screen.getByRole('button', { name: /join game/i }));
+    await user.click(screen.getByRole('button', { name: /^join$/i }));
 
     // Code is upper-cased before it leaves the client.
     expect(fake.emitWithAck).toHaveBeenCalledWith('join_game', { roomCode: 'ZZZZ', name: 'Bo' });
@@ -117,7 +117,7 @@ describe('<Lobby /> — join screen', () => {
   it('disables the create button until a name is entered', async () => {
     const user = userEvent.setup();
     render(<Lobby />);
-    const create = screen.getByRole('button', { name: /create new game/i });
+    const create = screen.getByRole('button', { name: /create game/i });
     expect(create).toBeDisabled();
     await user.type(screen.getByLabelText(/your name/i), 'Ada');
     expect(create).toBeEnabled();
@@ -130,7 +130,7 @@ describe('<Lobby /> — in the room', () => {
     fake.setResponder(() => ({ ok: true, game: initial, playerId: 'p1' }));
     render(<Lobby />);
     await user.type(screen.getByLabelText(/your name/i), 'Ada');
-    await user.click(screen.getByRole('button', { name: /create new game/i }));
+    await user.click(screen.getByRole('button', { name: /create game/i }));
     await screen.findByText(initial.roomCode);
     return user;
   }

--- a/client/src/lobby/Lobby.tsx
+++ b/client/src/lobby/Lobby.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { useLobby } from './useLobby.ts';
+import CodeInput, { CODE_LENGTH } from './CodeInput.tsx';
 import ActiveGame from '../game/ActiveGame.tsx';
 import type { Game, Player, Role } from './types.ts';
 import './Lobby.css';
@@ -31,6 +32,7 @@ function JoinScreen({
   const [code, setCode] = useState('');
 
   const trimmedName = name.trim();
+  const codeComplete = code.length === CODE_LENGTH;
 
   const handleCreate = (e: FormEvent) => {
     e.preventDefault();
@@ -39,11 +41,11 @@ function JoinScreen({
 
   const handleJoin = (e: FormEvent) => {
     e.preventDefault();
-    if (trimmedName && code.trim()) onJoin(code.trim(), trimmedName);
+    if (trimmedName && codeComplete) onJoin(code, trimmedName);
   };
 
   return (
-    <form className="lobby-card" onSubmit={handleJoin}>
+    <form className="lobby-card lobby-card--join" onSubmit={handleJoin}>
       <label className="field">
         <span className="field__label">Your name</span>
         <input
@@ -57,19 +59,20 @@ function JoinScreen({
         />
       </label>
 
-      <label className="field">
-        <span className="field__label">Room code</span>
-        <input
-          className="field__input field__input--code"
-          value={code}
-          onChange={(e) => setCode(e.target.value.toUpperCase())}
-          placeholder="ABCD"
-          maxLength={5}
-          autoComplete="off"
-          autoCapitalize="characters"
-          aria-label="Room code"
-        />
-      </label>
+      <button
+        className="btn btn--primary btn--create"
+        type="button"
+        onClick={handleCreate}
+        disabled={pending || !trimmedName}
+      >
+        Create game
+      </button>
+
+      <div className="lobby-divider">
+        <span>or join a room</span>
+      </div>
+
+      <CodeInput value={code} onChange={setCode} disabled={pending} />
 
       {error ? (
         <p className="lobby-error" role="alert">
@@ -77,23 +80,15 @@ function JoinScreen({
         </p>
       ) : null}
 
-      <div className="lobby-actions">
-        <button
-          className="btn btn--primary"
-          type="submit"
-          disabled={pending || !trimmedName || !code.trim()}
-        >
-          Join game
-        </button>
-        <button
-          className="btn btn--ghost"
-          type="button"
-          onClick={handleCreate}
-          disabled={pending || !trimmedName}
-        >
-          Create new game
-        </button>
-      </div>
+      <button
+        className="btn btn--ghost"
+        type="submit"
+        disabled={pending || !trimmedName || !codeComplete}
+      >
+        Join
+      </button>
+
+      <p className="lobby-footnote">No account needed to play</p>
     </form>
   );
 }


### PR DESCRIPTION
Closes #16.

Reworks the create/join entry screen to match screen **01 · Create / Join** of the design mockup.

## What changed
- **New `CodeInput`** — a segmented four-box room-code field. A single transparent `<input>` overlays the boxes so the native mobile keyboard, paste, and assistive tech all work off one accessible field (`aria-label="Room code"`), while the boxes are a visual reflection: filled boxes, a teal next-up highlight on focus, and dashed empty slots with underscore placeholders. `CODE_LENGTH` mirrors the server's `ROOM_CODE_LENGTH`.
- **Layout** — card-less/full-bleed on the app background, led by a prominent **CREATE GAME** button, an **"or join a room"** divider (monospace), the code input, a **Join** button (enabled only when the code is complete), and a **"No account needed to play"** footnote.
- **Buttons** — aligned with the mockup: 16px radius, bolder/chunkier CREATE GAME with a red glow, and a visible slate outline (`#2a3543`) on the ghost Join button.
- Kept the existing ringed logo and "Real-world GPS hide & seek" tagline per preference.

## Deliberate deviation
The mockup omits a name field, but the server requires a display name (`cleanName` throws `name_required`), so a **"Your name"** field is kept above the actions.

## Tests
- Added `CodeInput.test.tsx` (sanitizing, upper-casing, length cap); updated lobby/app unit + e2e specs for the renamed buttons.
- Client unit: **47 passed** · lobby e2e: **2 passed** · typecheck + ESLint + Stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a segmented room-code input with uppercase formatting, character validation, and length limits.
  * Updated the lobby screen with clearer Create game and Join actions.
  * Added visual focus states and a “No account needed to play” note.

* **Bug Fixes**
  * Improved join validation and button states for incomplete names or room codes.

* **Tests**
  * Added coverage for room-code input behavior and updated existing tests for the revised lobby labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->