### PR TITLE
feat(client): lobby screen — hunters/hiders lists, room code chip, share (#17)

### DIFF
--- a/client/e2e/lobby.spec.ts
+++ b/client/e2e/lobby.spec.ts
@@ -92,4 +92,14 @@ test('creates a game from the UI and shows the room code', async ({ page }) => {
   const code = page.locator('.room-code__value');
   await expect(code).toHaveText(/^[A-Z0-9]{4}$/, { timeout: 15_000 });
   await expect(page.getByRole('button', { name: /start game/i })).toBeVisible();
+
+  // The creator lands in the Hunters list; both team lists are present.
+  const hunters = page.getByRole('list', { name: /hunters/i });
+  await expect(hunters).toBeVisible();
+  await expect(hunters.getByText('Ada')).toBeVisible();
+  await expect(page.getByRole('list', { name: /hiders/i })).toBeVisible();
+
+  // Switching sides moves the player to the Hiders list.
+  await page.getByRole('button', { name: 'hider' }).click();
+  await expect(page.getByRole('list', { name: /hiders/i }).getByText('Ada')).toBeVisible();
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,15 +29,6 @@ export default function App() {
 
   return (
     <main className="app">
-      <div className="logo" aria-hidden="true">
-        <span className="logo__ring logo__ring--teal" />
-        <span className="logo__ring logo__ring--red" />
-        <span className="logo__diamond" />
-      </div>
-
-      <h1 className="title">MANHUNT</h1>
-      <p className="tagline">Real-world GPS hide&nbsp;&amp;&nbsp;seek</p>
-
       <Lobby />
 
       <p className="status" role="status">

--- a/client/src/lobby/Lobby.css
+++ b/client/src/lobby/Lobby.css
@@ -49,6 +49,18 @@
   border: none;
 }
 
+/*
+ * The in-room screen (mockup 02) fills the frame rather than sitting in a
+ * bordered panel: drop the .lobby-card chrome so the roster and controls read
+ * as the whole screen, matching the join screen's card-less treatment.
+ */
+.lobby-card--room {
+  max-width: 24rem;
+  padding: 0;
+  background: none;
+  border: none;
+}
+
 .btn {
   padding: 0.95rem 1rem;
   font-size: 1rem;
@@ -197,13 +209,19 @@
   color: var(--red);
 }
 
-.room-code {
+.room-head {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.4rem;
+}
+
+.room-code {
+  display: flex;
   align-items: center;
-  padding: 0.75rem;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
   background: var(--bg);
+  border: 1px solid rgb(255 255 255 / 8%);
   border-radius: 12px;
 }
 
@@ -215,11 +233,66 @@
 }
 
 .room-code__value {
+  flex: 1;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 2rem;
+  font-size: 1.6rem;
+  font-weight: 600;
   letter-spacing: 0.3em;
   text-indent: 0.3em;
   color: var(--teal);
+}
+
+.room-code__share {
+  padding: 0.35rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--teal);
+  background: rgb(36 227 198 / 10%);
+  border: 1px solid rgb(36 227 198 / 30%);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.room-summary {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.teams {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.team__heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.team__title--hunter {
+  color: var(--red);
+}
+
+.team__title--hider {
+  color: var(--teal);
+}
+
+.team__count {
+  color: var(--muted);
 }
 
 .roster {
@@ -234,61 +307,114 @@
 .roster__row {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.5rem 0.65rem;
+  gap: 0.7rem;
+  padding: 0.55rem 0.65rem;
   background: rgb(255 255 255 / 4%);
+  border: 1px solid transparent;
+  border-radius: 14px;
+}
+
+.roster__row--hunter {
+  border-color: rgb(255 66 66 / 20%);
+}
+
+.roster__row--hider {
+  border-color: rgb(36 227 198 / 20%);
+}
+
+.avatar {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
   border-radius: 10px;
 }
 
-.roster__name {
+.avatar--hunter {
+  color: var(--red);
+  background: rgb(255 66 66 / 15%);
+}
+
+.avatar--hider {
+  color: var(--teal);
+  background: rgb(36 227 198 / 15%);
+}
+
+.roster__meta {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.roster__name {
   overflow: hidden;
+  font-weight: 600;
+  font-size: 0.95rem;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .roster__you {
   color: var(--muted);
-  font-size: 0.85rem;
+  font-weight: 400;
+  font-size: 0.8rem;
 }
 
 .roster__host {
-  color: #f5c451;
+  color: var(--muted);
+  font-weight: 400;
+  font-size: 0.8rem;
 }
 
-.role-chip {
-  padding: 0.15rem 0.5rem;
-  font-size: 0.7rem;
-  font-weight: 700;
+.role-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-radius: 999px;
+  letter-spacing: 0.08em;
 }
 
-.role-chip--hunter {
+.role-label--hunter {
   color: var(--red);
-  background: rgb(255 66 66 / 15%);
 }
 
-.role-chip--hider {
+.role-label--hider {
   color: var(--teal);
-  background: rgb(36 227 198 / 15%);
 }
 
-.ready-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+.roster__empty {
+  padding: 0.55rem 0.65rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  background: rgb(255 255 255 / 2%);
+  border: 1px dashed rgb(255 255 255 / 10%);
+  border-radius: 14px;
+}
+
+.ready-mark {
   flex: none;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border-radius: 50%;
 }
 
-.ready-dot--on {
-  background: var(--teal);
-  box-shadow: 0 0 8px var(--teal);
+.ready-mark--on {
+  color: var(--bg);
+  background: #1cc98d;
 }
 
-.ready-dot--off {
-  background: rgb(255 255 255 / 18%);
+.ready-mark--off {
+  border: 2px solid rgb(255 255 255 / 18%);
 }
 
 .my-controls {

--- a/client/src/lobby/Lobby.test.tsx
+++ b/client/src/lobby/Lobby.test.tsx
@@ -80,6 +80,9 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  // Drop any per-test navigator.share stub so it doesn't change another test's
+  // share path (jsdom has no native share sheet by default).
+  Reflect.deleteProperty(navigator, 'share');
 });
 
 describe('<Lobby /> — join screen', () => {
@@ -166,7 +169,7 @@ describe('<Lobby /> — in the room', () => {
     expect(fake.emitWithAck).toHaveBeenCalledWith('start_game', {});
   });
 
-  it('renders the roster from lobby_update broadcasts', async () => {
+  it('groups players into hunters and hiders lists from lobby_update broadcasts', async () => {
     await enterRoom(game());
     fake.push('lobby_update', {
       game: game({
@@ -177,9 +180,49 @@ describe('<Lobby /> — in the room', () => {
       }),
     });
 
-    const roster = await screen.findByRole('list', { name: /players/i });
-    expect(within(roster).getByText('Bo')).toBeInTheDocument();
-    expect(within(roster).getByText(/ada/i)).toBeInTheDocument();
+    const hunters = await screen.findByRole('list', { name: /hunters/i });
+    const hiders = screen.getByRole('list', { name: /hiders/i });
+    expect(within(hunters).getByText(/ada/i)).toBeInTheDocument();
+    expect(within(hunters).queryByText('Bo')).not.toBeInTheDocument();
+    expect(within(hiders).getByText('Bo')).toBeInTheDocument();
+    expect(within(hiders).queryByText(/ada/i)).not.toBeInTheDocument();
+
+    // Bo has readied up; Ada has not — the per-row ready mark reflects each.
+    expect(within(hunters).getByLabelText(/ada is not ready/i)).toBeInTheDocument();
+    expect(within(hiders).getByLabelText(/bo is ready/i)).toBeInTheDocument();
+  });
+
+  it('copies the room code to the clipboard from the share control', async () => {
+    const user = await enterRoom(game());
+    // Install the stub after enterRoom: userEvent.setup() replaces
+    // navigator.clipboard with its own, so override it once setup has run.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    await user.click(screen.getByRole('button', { name: /share/i }));
+    expect(writeText).toHaveBeenCalledWith('AB2C');
+    expect(await screen.findByRole('button', { name: /copied/i })).toBeInTheDocument();
+  });
+
+  it('uses the native share sheet on devices that support it', async () => {
+    const user = await enterRoom(game());
+    const share = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: share, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    await user.click(screen.getByRole('button', { name: /share/i }));
+    // The native sheet is used with the room code in the invite; no clipboard fallback.
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('AB2C') }),
+    );
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it('shows a waiting message to non-hosts and the game-on screen when active', async () => {

--- a/client/src/lobby/Lobby.tsx
+++ b/client/src/lobby/Lobby.tsx
@@ -45,74 +45,175 @@ function JoinScreen({
   };
 
   return (
-    <form className="lobby-card lobby-card--join" onSubmit={handleJoin}>
-      <label className="field">
-        <span className="field__label">Your name</span>
-        <input
-          className="field__input"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="e.g. Ada"
-          maxLength={24}
-          autoComplete="off"
-          aria-label="Your name"
-        />
-      </label>
-
-      <button
-        className="btn btn--primary btn--create"
-        type="button"
-        onClick={handleCreate}
-        disabled={pending || !trimmedName}
-      >
-        Create game
-      </button>
-
-      <div className="lobby-divider">
-        <span>or join a room</span>
+    <>
+      <div className="logo" aria-hidden="true">
+        <span className="logo__ring logo__ring--teal" />
+        <span className="logo__ring logo__ring--red" />
+        <span className="logo__diamond" />
       </div>
 
-      <CodeInput value={code} onChange={setCode} disabled={pending} />
+      <h1 className="title">MANHUNT</h1>
+      <p className="tagline">Real-world GPS hide&nbsp;&amp;&nbsp;seek</p>
 
-      {error ? (
-        <p className="lobby-error" role="alert">
-          {error}
-        </p>
-      ) : null}
+      <form className="lobby-card lobby-card--join" onSubmit={handleJoin}>
+        <label className="field">
+          <span className="field__label">Your name</span>
+          <input
+            className="field__input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Ada"
+            maxLength={24}
+            autoComplete="off"
+            aria-label="Your name"
+          />
+        </label>
 
-      <button
-        className="btn btn--ghost"
-        type="submit"
-        disabled={pending || !trimmedName || !codeComplete}
-      >
-        Join
-      </button>
+        <button
+          className="btn btn--primary btn--create"
+          type="button"
+          onClick={handleCreate}
+          disabled={pending || !trimmedName}
+        >
+          Create game
+        </button>
 
-      <p className="lobby-footnote">No account needed to play</p>
-    </form>
+        <div className="lobby-divider">
+          <span>or join a room</span>
+        </div>
+
+        <CodeInput value={code} onChange={setCode} disabled={pending} />
+
+        {error ? (
+          <p className="lobby-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <button
+          className="btn btn--ghost"
+          type="submit"
+          disabled={pending || !trimmedName || !codeComplete}
+        >
+          Join
+        </button>
+
+        <p className="lobby-footnote">No account needed to play</p>
+      </form>
+    </>
   );
 }
 
-/** A single row in the lobby roster. */
-function Roster({ players, playerId }: { players: Player[]; playerId: string | null }) {
+/** First letter of a name, for the row avatar. */
+function avatarInitial(name: string): string {
+  return name.trim().charAt(0).toUpperCase() || '?';
+}
+
+/** A single roster row: avatar, name (+ host/you tags), and ready mark. */
+function PlayerRow({ player, playerId }: { player: Player; playerId: string | null }) {
+  const { role, name, ready, isHost } = player;
   return (
-    <ul className="roster" aria-label="Players">
-      {players.map((p) => (
-        <li key={p.id} className="roster__row">
-          <span className={`role-chip role-chip--${p.role}`}>{p.role}</span>
-          <span className="roster__name">
-            {p.name}
-            {p.id === playerId ? <span className="roster__you"> (you)</span> : null}
-            {p.isHost ? <span className="roster__host" title="Host"> ★</span> : null}
-          </span>
-          <span
-            className={`ready-dot ${p.ready ? 'ready-dot--on' : 'ready-dot--off'}`}
-            aria-label={p.ready ? 'ready' : 'not ready'}
-          />
-        </li>
-      ))}
-    </ul>
+    <li className={`roster__row roster__row--${role}`}>
+      <span className={`avatar avatar--${role}`} aria-hidden="true">
+        {avatarInitial(name)}
+      </span>
+      <span className="roster__meta">
+        <span className="roster__name">
+          {name}
+          {player.id === playerId ? <span className="roster__you"> (you)</span> : null}
+          {isHost ? <span className="roster__host"> · host</span> : null}
+        </span>
+        <span className={`role-label role-label--${role}`}>{role}</span>
+      </span>
+      <span
+        className={`ready-mark ${ready ? 'ready-mark--on' : 'ready-mark--off'}`}
+        role="img"
+        aria-label={ready ? `${name} is ready` : `${name} is not ready`}
+      >
+        {ready ? '✓' : ''}
+      </span>
+    </li>
   );
+}
+
+/** One side's roster — a labelled list with a live count. */
+function TeamList({
+  role,
+  players,
+  playerId,
+}: {
+  role: Role;
+  players: Player[];
+  playerId: string | null;
+}) {
+  const title = role === 'hunter' ? 'Hunters' : 'Hiders';
+  return (
+    <section className="team">
+      <h2 className="team__heading">
+        <span className={`team__title team__title--${role}`}>{title}</span>
+        <span className="team__count">{players.length}</span>
+      </h2>
+      <ul className="roster" aria-label={title}>
+        {players.length === 0 ? (
+          <li className="roster__empty">No {role}s yet</li>
+        ) : (
+          players.map((p) => <PlayerRow key={p.id} player={p} playerId={playerId} />)
+        )}
+      </ul>
+    </section>
+  );
+}
+
+/** The room-code chip. Shares via the device's native share sheet where one
+ *  exists (mobile), and falls back to copying the code to the clipboard. */
+function RoomCode({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const share = async (): Promise<void> => {
+    const data = {
+      title: 'Manhunt',
+      text: `Join my Manhunt game — room code ${code}`,
+      url: window.location.origin,
+    };
+
+    // Prefer the platform share sheet (mobile) so people can send the invite
+    // through whatever messaging app they use.
+    if (navigator.share && (!navigator.canShare || navigator.canShare(data))) {
+      try {
+        await navigator.share(data);
+      } catch {
+        // The user dismissed the share sheet, or it failed — nothing to do.
+      }
+      return;
+    }
+
+    // No native share (typically desktop): copy the code to the clipboard.
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // Clipboard unavailable or denied — the code chip is still visible to read out.
+    }
+  };
+
+  return (
+    <div className="room-code">
+      <span className="room-code__label">Room</span>
+      <span className="room-code__value">{code}</span>
+      <button type="button" className="room-code__share" onClick={share}>
+        {copied ? 'Copied ✓' : 'Share'}
+      </button>
+    </div>
+  );
+}
+
+/** A one-line summary of the roster's readiness. */
+function readySummary(game: Game): string {
+  const total = game.players.length;
+  const notReady = game.players.filter((p) => !p.ready).length;
+  const players = `${total} ${total === 1 ? 'player' : 'players'}`;
+  return notReady === 0 ? `${players} · all ready` : `${players} · ${notReady} not ready`;
 }
 
 /** The in-lobby screen: roster, side picker, ready toggle, host start. */
@@ -135,15 +236,20 @@ function LobbyRoom({
 }) {
   const me = game.players.find((p) => p.id === playerId);
   const startable = canStart(game);
+  const hunters = game.players.filter((p) => p.role === 'hunter');
+  const hiders = game.players.filter((p) => p.role === 'hider');
 
   return (
-    <div className="lobby-card">
-      <div className="room-code">
-        <span className="room-code__label">Room code</span>
-        <span className="room-code__value">{game.roomCode}</span>
+    <div className="lobby-card lobby-card--room">
+      <div className="room-head">
+        <RoomCode code={game.roomCode} />
+        <p className="room-summary">{readySummary(game)}</p>
       </div>
 
-      <Roster players={game.players} playerId={playerId} />
+      <div className="teams">
+        <TeamList role="hunter" players={hunters} playerId={playerId} />
+        <TeamList role="hider" players={hiders} playerId={playerId} />
+      </div>
 
       {me ? (
         <div className="my-controls">


### PR DESCRIPTION
Closes #17.

Builds out the in-room lobby (mockup screen 02) with the three elements the issue calls for.

## What changed
- **Room code chip + share** — the code shown as a chip with a **Share** control that uses the device's **native share sheet** (Web Share API) on mobile, and falls back to copying the code to the clipboard (`Copied ✓`) on desktop. Adds a live `N players · M not ready / all ready` summary.
- **Hunters / hiders lists** — the roster is split into two labelled, counted lists, each row with a role-coloured avatar, name (+ `· host` / `(you)` tags), a role label, and a per-player ready mark (green check when ready, empty ring when not). Empty sides show a muted placeholder.
- **Ready control** — side toggle + ready button and host Start flow kept intact.
- **Chrome cleanup** — the app branding (logo / wordmark / tagline) now renders only on the join screen, not on every screen; and the in-room screen drops the bordered card so it fills the frame like the mockup.

## Testing
- Unit ([Lobby.test.tsx](client/src/lobby/Lobby.test.tsx)): team grouping + per-row ready marks, clipboard fallback, and native-share path.
- E2E ([lobby.spec.ts](client/e2e/lobby.spec.ts)): both team lists render and switching sides moves the player between them.
- `npm run typecheck`, `npm run lint`, full client unit suite (48), and lobby/app e2e all pass locally.

## Note
The invite shares the room code as text + the app origin; there's no code-in-URL auto-join yet (join is still by typing the code). A deep link that pre-fills the code would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the in-room lobby with separate Hunters and Hiders team lists.
  - Added player counts, empty-team states, avatars, host/player indicators, and readiness markers.
  - Added a readiness summary for the room.
  - Added room-code sharing through native device sharing, with clipboard fallback and “Copied” confirmation.

- **Improvements**
  - Streamlined the landing view to present the lobby experience more directly.
  - Updated room-code and roster layouts for clearer, more spacious presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->