### PR TITLE
feat(client): in-game map screen — hunter + hider views (#18)

### DIFF
--- a/client/e2e/gps.spec.ts
+++ b/client/e2e/gps.spec.ts
@@ -85,7 +85,8 @@ test('the browser client streams its GPS position to other players', async ({ pa
       (state) => hostId != null && state.positions[hostId] != null,
     );
     await startButton.click();
-    await expect(page.getByRole('heading', { name: /game on/i })).toBeVisible();
+    // The host is a hunter, so the match screen shows the hunter HUD.
+    await expect(page.getByTestId('hunter-hud')).toBeVisible();
 
     const state = await hostPosition;
     expect(state.positions[hostId as string]).toMatchObject({

--- a/client/src/game/ActiveGame.css
+++ b/client/src/game/ActiveGame.css
@@ -1,3 +1,169 @@
+.match {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  text-align: left;
+}
+
+/* --- HUD: the row of stat tiles above the map --- */
+.hud {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 0.6rem;
+}
+
+.stat {
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid rgb(255 255 255 / 8%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.stat__label {
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.stat__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  line-height: 1.1;
+}
+
+.stat__sub {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.stat--teal .stat__value {
+  color: var(--teal);
+}
+
+.stat--alert {
+  background: rgb(255 66 66 / 10%);
+  border-color: rgb(255 66 66 / 30%);
+}
+
+.stat--alert .stat__value {
+  color: var(--red);
+}
+
+/* --- Hider reveal-countdown banner --- */
+.reveal-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  color: #e7cf8f;
+  background: rgb(224 179 65 / 8%);
+  border: 1px solid rgb(224 179 65 / 30%);
+}
+
+.reveal-banner__dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: #e0b341;
+  box-shadow: 0 0 8px #e0b341;
+}
+
+.reveal-banner--on {
+  color: #ffd7d7;
+  background: rgb(255 66 66 / 12%);
+  border-color: rgb(255 66 66 / 45%);
+}
+
+.reveal-banner--on .reveal-banner__dot {
+  background: var(--red);
+  box-shadow: 0 0 8px var(--red);
+}
+
+/* --- Proximity readout beneath the map --- */
+.proximity {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  font-size: 0.95rem;
+}
+
+.proximity--hunter {
+  color: #ffcaca;
+  background: rgb(255 66 66 / 10%);
+  border: 1px solid rgb(255 66 66 / 30%);
+}
+
+.proximity--hider {
+  color: #bff2e9;
+  background: rgb(36 227 198 / 10%);
+  border: 1px solid rgb(36 227 198 / 28%);
+}
+
+.proximity--quiet {
+  color: var(--muted);
+  background: rgb(255 255 255 / 3%);
+  border: 1px solid rgb(255 255 255 / 7%);
+}
+
+.proximity__icon {
+  color: var(--red);
+}
+
+.proximity--hider .proximity__icon {
+  color: #e0b341;
+}
+
+/* --- Hunter scan-to-catch action --- */
+.scan {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.scan__btn {
+  width: 100%;
+  padding: 1rem 1.25rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--red);
+  border: none;
+  border-radius: 14px;
+  cursor: pointer;
+  box-shadow: 0 0 24px rgb(255 66 66 / 45%);
+}
+
+.scan__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.scan__result {
+  margin: 0;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+/* --- GPS tracking status (shared with the previous screen) --- */
 .tracking {
   display: flex;
   align-items: center;
@@ -32,4 +198,8 @@
 
 .tracking__note {
   margin: 0;
+}
+
+.match .lobby-leave {
+  align-self: center;
 }

--- a/client/src/game/ActiveGame.test.tsx
+++ b/client/src/game/ActiveGame.test.tsx
@@ -50,8 +50,12 @@ function game(overrides: Partial<Game> = {}): Game {
     id: 'g1',
     roomCode: 'AB2C',
     status: 'active',
-    players: [{ id: 'p1', name: 'Ada', role: 'hunter', ready: true, isHost: true }],
+    players: [
+      { id: 'p1', name: 'Ada', role: 'hunter', ready: true, isHost: true },
+      { id: 'p2', name: 'Rui', role: 'hider', ready: true, isHost: false },
+    ],
     createdAt: new Date().toISOString(),
+    startedAt: new Date().toISOString(),
     ...overrides,
   };
 }
@@ -76,7 +80,6 @@ describe('<ActiveGame />', () => {
   it('starts GPS capture and streams position_update ticks', () => {
     render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
 
-    expect(screen.getByRole('heading', { name: /game on/i })).toBeInTheDocument();
     expect(screen.getByTestId('game-map')).toBeInTheDocument();
     expect(watchPosition).toHaveBeenCalledTimes(1);
 
@@ -90,6 +93,22 @@ describe('<ActiveGame />', () => {
     });
     expect(screen.getByText(/sharing your location/i)).toBeInTheDocument();
     expect(screen.getByTestId('tracking-dot')).toHaveClass('tracking__dot--on');
+  });
+
+  it('shows the hunter HUD and the scan-to-catch action for a hunter', () => {
+    render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
+    expect(screen.getByTestId('hunter-hud')).toBeInTheDocument();
+    expect(screen.getByText('TIME LEFT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /scan to catch/i })).toBeInTheDocument();
+    // No hider sighting yet, so the catch action has no target.
+    expect(screen.getByRole('button', { name: /scan to catch/i })).toBeDisabled();
+  });
+
+  it('shows the hider HUD and reveal countdown, and no scan action, for a hider', () => {
+    render(<ActiveGame game={game()} playerId="p2" onLeave={() => {}} />);
+    expect(screen.getByTestId('hider-hud')).toBeInTheDocument();
+    expect(screen.getByText(/revealed to hunters in/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /scan to catch/i })).not.toBeInTheDocument();
   });
 
   it('stops the watch when it leaves the match', () => {

--- a/client/src/game/ActiveGame.tsx
+++ b/client/src/game/ActiveGame.tsx
@@ -2,11 +2,24 @@ import { useMemo, useState } from 'react';
 import { socket } from '../socket.ts';
 import { useTracking } from '../gps/useTracking.ts';
 import type { GpsStatus } from '../gps/useGpsCapture.ts';
-import type { Game } from '../lobby/types.ts';
-import GameMap from './GameMap.tsx';
-import { useLivePositions } from './useLivePositions.ts';
+import type { Game, Role } from '../lobby/types.ts';
+import GameMap, { type MapMarker } from './GameMap.tsx';
+import MatchHud from './MatchHud.tsx';
+import { useLivePositions, type LivePositions } from './useLivePositions.ts';
+import { useNow } from './useNow.ts';
+import { elapsedMs, nextPingMs, timeLeftMs } from './matchClock.ts';
+import {
+  mergeSightings,
+  nearest,
+  PROXIMITY_ALERT_M,
+  REVEAL_RADIUS_M,
+  type Sightings,
+} from './proximity.ts';
 import { DEFAULT_BOUNDARY_RADIUS_M, type BoundaryCircle, type LngLat } from './geo.ts';
 import './ActiveGame.css';
+
+/** How long the hider HUD flags a reveal after a ping exposes them, in ms. */
+const REVEAL_FLASH_MS = 6_000;
 
 /** Map a GPS status to a user-facing message and an indicator state. */
 function gpsMessage(status: GpsStatus): { text: string; tone: 'on' | 'warn' | 'off' } {
@@ -26,12 +39,40 @@ function gpsMessage(status: GpsStatus): { text: string; tone: 'on' | 'warn' | 'o
   }
 }
 
+/** Keep only the positions whose owner currently holds `role` in the roster. */
+function positionsWithRole(
+  positions: LivePositions,
+  roleById: Map<string, Role>,
+  role: Role,
+): LivePositions {
+  const out: LivePositions = {};
+  for (const [id, pos] of Object.entries(positions)) {
+    if (roleById.get(id) === role) out[id] = pos;
+  }
+  return out;
+}
+
+/** "just now" / "3m" — how stale a hider sighting is, for the ghost caption. */
+function ageLabel(recordedAt: string, now: number): string {
+  const ageMs = Math.max(0, now - Date.parse(recordedAt));
+  const minutes = Math.floor(ageMs / 60_000);
+  return minutes < 1 ? 'just now' : `${minutes}m`;
+}
+
 /**
- * The in-match screen shown once a game goes `active`. It drives GPS capture —
- * mounting it starts `watchPosition` (throttled to the fixed cadence) and holds
- * a screen wake lock, streaming `position_update` ticks to the server — and
- * renders the live map: the player's own pin, every other permitted player from
- * the server's fan-out, and the play-area boundary overlaid (backlog #9).
+ * The in-match screen shown once a game goes `active`, rendered from the
+ * player's own perspective (BACKLOG.md #18). Mounting it drives GPS capture —
+ * `watchPosition` throttled to the fixed cadence plus a screen wake lock,
+ * streaming `position_update` ticks — and it composes the live view the mockup
+ * calls for: a role-specific HUD (a hunter's countdown, hider tally and next
+ * ping; a hider's survival time and reveal countdown), the map with role-coloured
+ * pins, and a proximity readout of the nearest opponent.
+ *
+ * The server is authoritative about visibility: a hunter only receives hider
+ * coordinates on a scheduled ping reveal (BACKLOG.md #14), so a hunter's map
+ * shows each hider's ageing *last-known* position (a "ghost") accumulated from
+ * those reveals, while a hider — who can see the hunters live — tracks them in
+ * real time.
  */
 export default function ActiveGame({
   game,
@@ -48,7 +89,8 @@ export default function ActiveGame({
     playerId,
     socket,
   });
-  const others = useLivePositions(game.id, socket);
+  const { positions, revealSeq } = useLivePositions(game.id, socket);
+  const now = useNow();
 
   const lat = tracking.last?.lat ?? null;
   const lng = tracking.last?.lng ?? null;
@@ -57,22 +99,147 @@ export default function ActiveGame({
     [lat, lng],
   );
 
+  // The authoritative role of every player, from the roster the lobby keeps in
+  // sync. Falls back to hider — the safe default (a hider sees everyone, so a
+  // momentarily-unknown role can't leak a hider's position to a hunter's view).
+  const myRole: Role = game.players.find((p) => p.id === playerId)?.role ?? 'hider';
+  const roleById = useMemo(() => {
+    const map = new Map<string, Role>();
+    for (const p of game.players) map.set(p.id, p.role);
+    return map;
+  }, [game.players]);
+
+  // Everyone but us, as the server permitted us to see them this tick.
+  const others = useMemo<LivePositions>(() => {
+    const rest: LivePositions = {};
+    for (const [id, pos] of Object.entries(positions)) {
+      if (id !== playerId) rest[id] = pos;
+    }
+    return rest;
+  }, [positions, playerId]);
+
+  // A hunter accumulates each hider's last-known position from the ping reveals
+  // (that's the only time hider coordinates arrive), so the map can keep showing
+  // where they were last seen between reveals. Latched during render — the merge
+  // returns the same reference when nothing new arrived, so this can't loop.
+  const [sightings, setSightings] = useState<Sightings>({});
+  if (myRole === 'hunter') {
+    const merged = mergeSightings(sightings, positionsWithRole(others, roleById, 'hider'));
+    if (merged !== sightings) setSightings(merged);
+  }
+
+  // The hider HUD flashes when a ping reveal exposes them. Latch the wall-clock
+  // time of the latest reveal during render, then derive "revealed" from how long
+  // ago that was — the once-a-second `now` tick clears it without a timer.
+  const [lastReveal, setLastReveal] = useState({ seq: 0, at: 0 });
+  if (revealSeq !== lastReveal.seq) setLastReveal({ seq: revealSeq, at: now });
+  const revealed = myRole === 'hider' && revealSeq > 0 && now - lastReveal.at < REVEAL_FLASH_MS;
+
   // Anchor a default play area to the first fix and hold it fixed for the match.
   // Set during render (React's endorsed pattern for latching a value the first
-  // time it's known) rather than in an effect. A server-configured per-game
-  // boundary replaces this later (BACKLOG.md #11).
+  // time it's known). A server-configured per-game boundary replaces this later
+  // (BACKLOG.md #11).
   const [boundary, setBoundary] = useState<BoundaryCircle | null>(null);
   if (!boundary && self) {
     setBoundary({ center: self, radiusM: DEFAULT_BOUNDARY_RADIUS_M });
   }
 
+  // Latch the starting hider count so the "3 / 5" tally has a stable denominator
+  // even as caught hiders convert to hunters and the numerator falls.
+  const [hidersTotal] = useState(() =>
+    Math.max(1, game.players.filter((p) => p.role === 'hider').length),
+  );
+  const hidersRemaining = game.players.filter((p) => p.role === 'hider').length;
+
+  // The nearest opponent: for a hunter, the closest hider we've a sighting for
+  // (still a hider — a caught one has flipped sides); for a hider, the closest
+  // live hunter. An alert only fires within the proximity radius.
+  const opponents = useMemo<LivePositions>(() => {
+    if (myRole === 'hunter') {
+      const stillHiders: LivePositions = {};
+      for (const [id, pos] of Object.entries(sightings)) {
+        if (roleById.get(id) === 'hider') stillHiders[id] = pos;
+      }
+      return stillHiders;
+    }
+    return positionsWithRole(others, roleById, 'hunter');
+  }, [myRole, sightings, others, roleById]);
+
+  const near = nearest(self, opponents);
+  const alert = near && near.distanceM <= PROXIMITY_ALERT_M ? near : null;
+
+  const markers = useMemo<MapMarker[]>(() => {
+    const list: MapMarker[] = [];
+    if (self) list.push({ id: 'self', lngLat: self, team: myRole, kind: 'self' });
+
+    if (myRole === 'hunter') {
+      // Fellow hunters, live; hiders as ageing ghosts from the reveals.
+      for (const [id, pos] of Object.entries(others)) {
+        if (roleById.get(id) === 'hunter') {
+          list.push({ id, lngLat: { lng: pos.lng, lat: pos.lat }, team: 'hunter', kind: 'player' });
+        }
+      }
+      for (const [id, pos] of Object.entries(sightings)) {
+        if (roleById.get(id) !== 'hider') continue;
+        list.push({
+          id: `ghost:${id}`,
+          lngLat: { lng: pos.lng, lat: pos.lat },
+          team: 'hider',
+          kind: 'ghost',
+          label: `last seen ${ageLabel(pos.recordedAt, now)}`,
+        });
+      }
+    } else {
+      // A hider sees everyone live, coloured by their side.
+      for (const [id, pos] of Object.entries(others)) {
+        list.push({
+          id,
+          lngLat: { lng: pos.lng, lat: pos.lat },
+          team: roleById.get(id) ?? 'hunter',
+          kind: 'player',
+        });
+      }
+    }
+    return list;
+  }, [self, myRole, others, sightings, roleById, now]);
+
+  const alertRing = myRole === 'hunter' && self ? { center: self, radiusM: PROXIMITY_ALERT_M } : null;
+  const revealRing = myRole === 'hider' && self ? { center: self, radiusM: REVEAL_RADIUS_M } : null;
+
   const gps = gpsMessage(tracking.gps);
 
   return (
-    <div className="lobby-card lobby-card--active">
-      <h2 className="active-title">Game on!</h2>
+    <div className="match">
+      {myRole === 'hunter' ? (
+        <MatchHud
+          role="hunter"
+          timeLeftMs={timeLeftMs(game.startedAt, now)}
+          hidersRemaining={hidersRemaining}
+          hidersTotal={hidersTotal}
+          nextPingMs={nextPingMs(game.startedAt, now)}
+        />
+      ) : (
+        <MatchHud
+          role="hider"
+          survivedMs={elapsedMs(game.startedAt, now)}
+          revealed={revealed}
+          nextPingMs={nextPingMs(game.startedAt, now)}
+        />
+      )}
 
-      <GameMap self={self} selfId={playerId} others={others} boundary={boundary} />
+      <GameMap
+        markers={markers}
+        focus={self}
+        boundary={boundary}
+        alertRing={alertRing}
+        revealRing={revealRing}
+      />
+
+      <ProximityAlert role={myRole} near={alert} />
+
+      {myRole === 'hunter' ? (
+        <CatchControl game={game} playerId={playerId} targetId={near?.id ?? null} />
+      ) : null}
 
       <p className="tracking" role="status">
         <span className={`tracking__dot tracking__dot--${gps.tone}`} data-testid="tracking-dot" />
@@ -80,14 +247,94 @@ export default function ActiveGame({
       </p>
 
       {tracking.wakeLock === 'denied' ? (
-        <p className="hint tracking__note">
-          Keep the screen on so tracking doesn&apos;t pause.
-        </p>
+        <p className="hint tracking__note">Keep the screen on so tracking doesn&apos;t pause.</p>
       ) : null}
 
       <button type="button" className="lobby-leave" onClick={onLeave}>
         Leave
       </button>
+    </div>
+  );
+}
+
+/** The nearest-opponent readout beneath the map — "Hider within 90 m — northeast". */
+function ProximityAlert({
+  role,
+  near,
+}: {
+  role: Role;
+  near: { distanceM: number; direction: string } | null;
+}) {
+  const quarry = role === 'hunter' ? 'Hider' : 'Hunter';
+  if (!near) {
+    return (
+      <p className={`proximity proximity--${role} proximity--quiet`} role="status">
+        No {quarry.toLowerCase()} nearby
+      </p>
+    );
+  }
+  return (
+    <p className={`proximity proximity--${role}`} role="status">
+      <span className="proximity__icon" aria-hidden="true">
+        ▲
+      </span>
+      {quarry} within <strong>{Math.round(near.distanceM)}m</strong> — {near.direction}
+    </p>
+  );
+}
+
+/**
+ * The hunter's "scan to catch" action. It claims a catch against the nearest
+ * known hider; the server verifies the catch-radius check authoritatively
+ * (BACKLOG.md #12) and rejects an out-of-range claim, whose reason we surface.
+ * A confirmed catch flips the hider to a hunter and the roster refresh does the
+ * rest, so there is nothing to do on success but clear the prompt.
+ */
+function CatchControl({
+  game,
+  playerId,
+  targetId,
+}: {
+  game: Game;
+  playerId: string | null;
+  targetId: string | null;
+}) {
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const scan = async (): Promise<void> => {
+    if (!playerId || !targetId) return;
+    setPending(true);
+    setMessage(null);
+    try {
+      const ack = (await socket.emitWithAck('claim_catch', {
+        gameId: game.id,
+        hunterId: playerId,
+        targetId,
+      })) as { ok: boolean; error?: string };
+      setMessage(ack.ok ? 'Caught!' : (ack.error ?? 'Catch failed'));
+    } catch {
+      setMessage('Could not reach the server.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="scan">
+      <button
+        type="button"
+        className="scan__btn"
+        onClick={scan}
+        disabled={pending || !targetId}
+      >
+        🚩 Scan to catch
+      </button>
+      {message ? (
+        <p className="scan__result" role="status">
+          {message}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/client/src/game/ActiveGame.tsx
+++ b/client/src/game/ActiveGame.tsx
@@ -21,6 +21,9 @@ import './ActiveGame.css';
 /** How long the hider HUD flags a reveal after a ping exposes them, in ms. */
 const REVEAL_FLASH_MS = 6_000;
 
+/** How long to wait for the server to ack a catch claim before giving up, in ms. */
+const CATCH_ACK_TIMEOUT_MS = 5_000;
+
 /** Map a GPS status to a user-facing message and an indicator state. */
 function gpsMessage(status: GpsStatus): { text: string; tone: 'on' | 'warn' | 'off' } {
   switch (status) {
@@ -307,7 +310,10 @@ function CatchControl({
     setPending(true);
     setMessage(null);
     try {
-      const ack = (await socket.emitWithAck('claim_catch', {
+      // Bound the wait: without a timeout a server that never acks would leave
+      // `pending` stuck and the button disabled for good. On timeout the ack
+      // rejects and the catch path recovers the UI.
+      const ack = (await socket.timeout(CATCH_ACK_TIMEOUT_MS).emitWithAck('claim_catch', {
         gameId: game.id,
         hunterId: playerId,
         targetId,

--- a/client/src/game/GameMap.css
+++ b/client/src/game/GameMap.css
@@ -7,8 +7,11 @@
   background: #0b0f16;
 }
 
-/* Player pins. The own pin is highlighted; everyone else is a plain marker. */
+/* Player pins. Colour marks the side (red hunters, teal hiders); shape marks the
+   kind — the own pin glows, a live opponent is a plain dot, a hider's stale
+   last-known position is a hollow dashed "ghost" with a caption. */
 .map-pin {
+  position: relative;
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
@@ -16,14 +19,61 @@
   box-sizing: border-box;
 }
 
-.map-pin--self {
-  background: var(--teal);
-  box-shadow: 0 0 0 4px rgb(36 227 198 / 25%);
+.map-pin--hunter {
+  background: var(--red);
 }
 
-.map-pin--other {
-  background: var(--red);
-  box-shadow: 0 0 0 4px rgb(255 66 66 / 25%);
+.map-pin--hider {
+  background: var(--teal);
+}
+
+/* The player's own position: bigger and glowing, so it reads as "you". */
+.map-pin--self {
+  width: 1.3rem;
+  height: 1.3rem;
+}
+
+.map-pin--self.map-pin--hunter {
+  box-shadow:
+    0 0 0 5px rgb(255 66 66 / 22%),
+    0 0 16px 2px rgb(255 66 66 / 55%);
+}
+
+.map-pin--self.map-pin--hider {
+  box-shadow:
+    0 0 0 5px rgb(36 227 198 / 22%),
+    0 0 16px 2px rgb(36 227 198 / 55%);
+}
+
+/* A live opponent/ally: a plain glowing dot. */
+.map-pin--player.map-pin--hunter {
+  box-shadow: 0 0 8px 1px rgb(255 66 66 / 55%);
+}
+
+.map-pin--player.map-pin--hider {
+  box-shadow: 0 0 8px 1px rgb(36 227 198 / 55%);
+}
+
+/* A ghost: a hider's ageing last-known spot — hollow, dashed, no glow. */
+.map-pin--ghost {
+  background: transparent;
+  border-style: dashed;
+  border-width: 2px;
+  border-color: var(--teal);
+  opacity: 0.75;
+}
+
+.map-pin__label {
+  position: absolute;
+  top: 120%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-size: 0.62rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--teal);
+  text-shadow: 0 1px 2px rgb(0 0 0 / 80%);
+  pointer-events: none;
 }
 
 /* Keep the MapLibre attribution legible on the dark shell. */

--- a/client/src/game/GameMap.test.tsx
+++ b/client/src/game/GameMap.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
-import GameMap from './GameMap.tsx';
-import type { LivePositions } from './useLivePositions.ts';
+import GameMap, { type MapMarker } from './GameMap.tsx';
 import type { BoundaryCircle } from './geo.ts';
 
 // Instrumented MapLibre stub: jsdom has no WebGL, so we record what the
@@ -36,6 +35,9 @@ vi.mock('maplibre-gl', () => {
     setLngLat(v: [number, number]) {
       this.lngLat = v;
       return this;
+    }
+    getElement() {
+      return this.element;
     }
     addTo() {
       return this;
@@ -90,41 +92,65 @@ function liveMarkers() {
 }
 
 describe('<GameMap />', () => {
-  it('creates a map and installs the boundary layers', () => {
-    render(<GameMap self={null} selfId={null} others={{}} boundary={null} />);
+  it('creates a map and installs the boundary + ring layers', () => {
+    render(<GameMap markers={[]} focus={null} boundary={null} />);
     expect(state.maps).toHaveLength(1);
     expect(state.maps[0]!.layers).toEqual(
-      expect.arrayContaining(['boundary-fill', 'boundary-line']),
+      expect.arrayContaining(['boundary-fill', 'boundary-line', 'alert-line', 'reveal-line']),
     );
   });
 
   it('overlays the play-area boundary as a polygon', () => {
-    render(<GameMap self={null} selfId={null} others={{}} boundary={boundary} />);
+    render(<GameMap markers={[]} focus={null} boundary={boundary} />);
     const data = state.maps[0]!.sourceData['boundary'] as {
       geometry?: { type?: string };
     };
     expect(data.geometry?.type).toBe('Polygon');
   });
 
-  it('draws the own pin and every other permitted player', () => {
-    const others: LivePositions = {
-      me: { lat: 52.37, lng: 4.9, recordedAt: '2026-07-21T00:00:00.000Z' },
-      p2: { lat: 52.38, lng: 4.91, recordedAt: '2026-07-21T00:00:00.000Z' },
-    };
+  it('draws the alert and reveal rings when supplied', () => {
     render(
-      <GameMap self={{ lng: 4.9, lat: 52.37 }} selfId="me" others={others} boundary={boundary} />,
+      <GameMap
+        markers={[]}
+        focus={{ lng: 4.9, lat: 52.37 }}
+        boundary={null}
+        alertRing={boundary}
+        revealRing={boundary}
+      />,
     );
-
-    const pins = liveMarkers();
-    // Own pin (from the live fix) + p2; the `me` entry in `others` is dropped so
-    // the player isn't drawn twice.
-    expect(pins).toHaveLength(2);
-    expect(pins.filter((p) => p.element.className.includes('map-pin--self'))).toHaveLength(1);
-    expect(pins.filter((p) => p.element.className.includes('map-pin--other'))).toHaveLength(1);
+    const map = state.maps[0]!;
+    expect((map.sourceData['alert'] as { geometry?: { type?: string } }).geometry?.type).toBe(
+      'Polygon',
+    );
+    expect((map.sourceData['reveal'] as { geometry?: { type?: string } }).geometry?.type).toBe(
+      'Polygon',
+    );
   });
 
-  it('renders without an own position yet', () => {
-    render(<GameMap self={null} selfId="me" others={{}} boundary={null} />);
+  it('draws a pin per marker, styled by kind and team', () => {
+    const markers: MapMarker[] = [
+      { id: 'me', lngLat: { lng: 4.9, lat: 52.37 }, team: 'hunter', kind: 'self' },
+      { id: 'p2', lngLat: { lng: 4.91, lat: 52.38 }, team: 'hunter', kind: 'player' },
+      {
+        id: 'h1',
+        lngLat: { lng: 4.92, lat: 52.39 },
+        team: 'hider',
+        kind: 'ghost',
+        label: 'last seen 2m',
+      },
+    ];
+    render(<GameMap markers={markers} focus={{ lng: 4.9, lat: 52.37 }} boundary={boundary} />);
+
+    const pins = liveMarkers();
+    expect(pins).toHaveLength(3);
+    expect(pins.filter((p) => p.element.className.includes('map-pin--self'))).toHaveLength(1);
+    expect(pins.filter((p) => p.element.className.includes('map-pin--player'))).toHaveLength(1);
+    const ghost = pins.find((p) => p.element.className.includes('map-pin--ghost'));
+    expect(ghost?.element.querySelector('.map-pin__label')?.textContent).toBe('last seen 2m');
+  });
+
+  it('renders with no markers yet', () => {
+    render(<GameMap markers={[]} focus={null} boundary={null} />);
     expect(liveMarkers()).toHaveLength(0);
     expect(state.maps).toHaveLength(1);
   });

--- a/client/src/game/GameMap.tsx
+++ b/client/src/game/GameMap.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import maplibregl, { type StyleSpecification } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { boundaryFeature, type BoundaryCircle, type LngLat } from './geo.ts';
-import type { LivePositions } from './useLivePositions.ts';
 import './GameMap.css';
 
 /**
@@ -27,6 +26,11 @@ const MAP_STYLE: StyleSpecification = {
 const BOUNDARY_SOURCE = 'boundary';
 const BOUNDARY_FILL = 'boundary-fill';
 const BOUNDARY_LINE = 'boundary-line';
+const ALERT_SOURCE = 'alert';
+const ALERT_FILL = 'alert-fill';
+const ALERT_LINE = 'alert-line';
+const REVEAL_SOURCE = 'reveal';
+const REVEAL_LINE = 'reveal-line';
 
 /** Zoom the map opens at once a position is known — street level for a chase. */
 const PLAY_ZOOM = 15;
@@ -34,32 +38,79 @@ const PLAY_ZOOM = 15;
 /** Empty feature collection used to clear a source. */
 const EMPTY_DATA = { type: 'FeatureCollection' as const, features: [] };
 
-export interface GameMapProps {
-  /** The caller's own live position, drawn as the highlighted pin. */
-  self: LngLat | null;
-  /** The caller's own player id, so it can be excluded from {@link others}. */
-  selfId: string | null;
-  /** Every other permitted player's latest position, keyed by player id. */
-  others: LivePositions;
-  /** The play-area boundary to overlay, or `null` before one is known. */
-  boundary: BoundaryCircle | null;
+/** Which side a marker belongs to — drives its colour (red hunters, teal hiders). */
+export type MarkerTeam = 'hunter' | 'hider';
+
+/**
+ * How a marker is drawn: the player's own glowing pin (`self`), another live
+ * player (`player`), or a hider's ageing last-known position on a hunter's map
+ * (`ghost` — dashed, with a "last seen" caption).
+ */
+export type MarkerKind = 'self' | 'player' | 'ghost';
+
+/** One pin to place on the map. */
+export interface MapMarker {
+  /** Stable id used to reconcile the marker across renders (usually a player id). */
+  id: string;
+  lngLat: LngLat;
+  team: MarkerTeam;
+  kind: MarkerKind;
+  /** Optional caption under the pin, e.g. `"last seen 2m"` for a ghost. */
+  label?: string;
 }
 
-/** Build the DOM element MapLibre uses for a player pin. */
-function makePin(kind: 'self' | 'other'): HTMLElement {
+export interface GameMapProps {
+  /** Every pin to draw this render — own position, live opponents, ghosts. */
+  markers: MapMarker[];
+  /** The point to recentre on the first time it's known (the player's own fix). */
+  focus: LngLat | null;
+  /** The play-area boundary to overlay, or `null` before one is known. */
+  boundary: BoundaryCircle | null;
+  /** A proximity-alert ring to draw around the player (hunter view), or `null`. */
+  alertRing?: BoundaryCircle | null;
+  /** A reveal-radius ring to draw around the player (hider view), or `null`. */
+  revealRing?: BoundaryCircle | null;
+}
+
+/** Build (or refresh) the DOM element MapLibre uses for a marker. */
+function syncPin(el: HTMLElement, marker: MapMarker): void {
+  el.className = `map-pin map-pin--${marker.kind} map-pin--${marker.team}`;
+  const label = marker.label ?? '';
+  let caption = el.querySelector<HTMLSpanElement>('.map-pin__label');
+  if (!label) {
+    caption?.remove();
+    return;
+  }
+  if (!caption) {
+    caption = document.createElement('span');
+    caption.className = 'map-pin__label';
+    el.appendChild(caption);
+  }
+  caption.textContent = label;
+}
+
+function makePin(marker: MapMarker): HTMLElement {
   const el = document.createElement('div');
-  el.className = `map-pin map-pin--${kind}`;
+  syncPin(el, marker);
   return el;
 }
 
 /**
- * The live match map: a MapLibre GL map that overlays the play-area boundary and
- * a pin for every player this client is permitted to see — the caller's own
- * position highlighted, everyone else from the server's fan-out. The map is
- * created once and then imperatively kept in sync as positions and the boundary
- * change; React only owns the container element.
+ * The live match map: a MapLibre GL map that overlays the play-area boundary,
+ * optional proximity/reveal rings, and one pin per {@link MapMarker} the caller
+ * decides to show — the player's own glowing position, live opponents, and (on a
+ * hunter's map) each hider's ageing last-known "ghost". The map is created once
+ * and then imperatively kept in sync as the props change; React only owns the
+ * container element. The caller (`ActiveGame`) resolves roles and visibility;
+ * this component just draws what it is handed.
  */
-export default function GameMap({ self, selfId, others, boundary }: GameMapProps) {
+export default function GameMap({
+  markers,
+  focus,
+  boundary,
+  alertRing = null,
+  revealRing = null,
+}: GameMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const markersRef = useRef<Map<string, maplibregl.Marker>>(new Map());
@@ -72,12 +123,12 @@ export default function GameMap({ self, selfId, others, boundary }: GameMapProps
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
 
-    const center = self ?? boundary?.center ?? { lng: 0, lat: 0 };
+    const center = focus ?? boundary?.center ?? { lng: 0, lat: 0 };
     const map = new maplibregl.Map({
       container: containerRef.current,
       style: MAP_STYLE,
       center: [center.lng, center.lat],
-      zoom: self || boundary ? PLAY_ZOOM : 1,
+      zoom: focus || boundary ? PLAY_ZOOM : 1,
       attributionControl: { compact: true },
     });
     mapRef.current = map;
@@ -96,13 +147,43 @@ export default function GameMap({ self, selfId, others, boundary }: GameMapProps
         source: BOUNDARY_SOURCE,
         paint: { 'line-color': '#24e3c6', 'line-width': 2, 'line-opacity': 0.7 },
       });
+
+      // Hunter proximity-alert ring: a faint red disc around the player.
+      map.addSource(ALERT_SOURCE, { type: 'geojson', data: EMPTY_DATA });
+      map.addLayer({
+        id: ALERT_FILL,
+        type: 'fill',
+        source: ALERT_SOURCE,
+        paint: { 'fill-color': '#ff4242', 'fill-opacity': 0.06 },
+      });
+      map.addLayer({
+        id: ALERT_LINE,
+        type: 'line',
+        source: ALERT_SOURCE,
+        paint: { 'line-color': '#ff4242', 'line-width': 1.5, 'line-opacity': 0.5 },
+      });
+
+      // Hider reveal ring: a dashed amber circle marking the exposure radius.
+      map.addSource(REVEAL_SOURCE, { type: 'geojson', data: EMPTY_DATA });
+      map.addLayer({
+        id: REVEAL_LINE,
+        type: 'line',
+        source: REVEAL_SOURCE,
+        paint: {
+          'line-color': '#e0b341',
+          'line-width': 1.5,
+          'line-opacity': 0.8,
+          'line-dasharray': [3, 3],
+        },
+      });
+
       setLoaded(true);
     });
 
-    const markers = markersRef.current;
+    const markerStore = markersRef.current;
     return () => {
-      for (const marker of markers.values()) marker.remove();
-      markers.clear();
+      for (const marker of markerStore.values()) marker.remove();
+      markerStore.clear();
       map.remove();
       mapRef.current = null;
       centeredRef.current = false;
@@ -117,54 +198,53 @@ export default function GameMap({ self, selfId, others, boundary }: GameMapProps
   useEffect(() => {
     const map = mapRef.current;
     if (!map || centeredRef.current) return;
-    const focus = self ?? boundary?.center;
-    if (!focus) return;
+    const target = focus ?? boundary?.center;
+    if (!target) return;
     centeredRef.current = true;
-    map.easeTo({ center: [focus.lng, focus.lat], zoom: PLAY_ZOOM, duration: 600 });
-  }, [self, boundary]);
+    map.easeTo({ center: [target.lng, target.lat], zoom: PLAY_ZOOM, duration: 600 });
+  }, [focus, boundary]);
 
-  // Keep the boundary overlay in sync with the source of truth.
+  // Keep each circular overlay in sync with its source of truth.
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !loaded) return;
-    const source = map.getSource(BOUNDARY_SOURCE) as maplibregl.GeoJSONSource | undefined;
-    if (!source) return;
-    source.setData(boundary ? boundaryFeature(boundary) : EMPTY_DATA);
-  }, [boundary, loaded]);
+    const apply = (id: string, circle: BoundaryCircle | null): void => {
+      const source = map.getSource(id) as maplibregl.GeoJSONSource | undefined;
+      source?.setData(circle ? boundaryFeature(circle) : EMPTY_DATA);
+    };
+    apply(BOUNDARY_SOURCE, boundary);
+    apply(ALERT_SOURCE, alertRing);
+    apply(REVEAL_SOURCE, revealRing);
+  }, [boundary, alertRing, revealRing, loaded]);
 
-  // Reconcile one marker per visible player: the caller's own pin plus every
-  // other permitted position. Markers absent from the latest set are removed.
+  // Reconcile one MapLibre marker per {@link MapMarker}: create newcomers, move
+  // and restyle survivors in place, and remove any that are gone this render.
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
-    const markers = markersRef.current;
+    const store = markersRef.current;
+    const desired = new Map(markers.map((m) => [m.id, m]));
 
-    const desired = new Map<string, { lngLat: LngLat; kind: 'self' | 'other' }>();
-    if (self) desired.set('self', { lngLat: self, kind: 'self' });
-    for (const [id, pos] of Object.entries(others)) {
-      if (id === selfId) continue; // own pin comes from the live GPS fix, not the fan-out
-      desired.set(id, { lngLat: { lng: pos.lng, lat: pos.lat }, kind: 'other' });
-    }
-
-    for (const [id, marker] of markers) {
+    for (const [id, marker] of store) {
       if (!desired.has(id)) {
         marker.remove();
-        markers.delete(id);
+        store.delete(id);
       }
     }
 
-    for (const [id, { lngLat, kind }] of desired) {
-      const existing = markers.get(id);
+    for (const [id, marker] of desired) {
+      const existing = store.get(id);
       if (existing) {
-        existing.setLngLat([lngLat.lng, lngLat.lat]);
+        existing.setLngLat([marker.lngLat.lng, marker.lngLat.lat]);
+        syncPin(existing.getElement(), marker);
       } else {
-        const marker = new maplibregl.Marker({ element: makePin(kind) })
-          .setLngLat([lngLat.lng, lngLat.lat])
+        const created = new maplibregl.Marker({ element: makePin(marker) })
+          .setLngLat([marker.lngLat.lng, marker.lngLat.lat])
           .addTo(map);
-        markers.set(id, marker);
+        store.set(id, created);
       }
     }
-  }, [self, selfId, others]);
+  }, [markers]);
 
   return <div ref={containerRef} className="game-map" data-testid="game-map" />;
 }

--- a/client/src/game/MatchHud.test.tsx
+++ b/client/src/game/MatchHud.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import MatchHud from './MatchHud.tsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('<MatchHud /> hunter', () => {
+  it('shows the countdown, hider tally, and next ping', () => {
+    render(
+      <MatchHud
+        role="hunter"
+        timeLeftMs={11 * 60_000 + 36_000}
+        hidersRemaining={3}
+        hidersTotal={5}
+        nextPingMs={72_000}
+      />,
+    );
+    const hud = screen.getByTestId('hunter-hud');
+    expect(within(hud).getByText('11:36')).toBeInTheDocument();
+    expect(within(hud).getByText('/ 5')).toBeInTheDocument();
+    expect(within(hud).getByText('01:12')).toBeInTheDocument();
+  });
+});
+
+describe('<MatchHud /> hider', () => {
+  it('shows survival time and the reveal countdown while hidden', () => {
+    render(<MatchHud role="hider" survivedMs={11 * 60_000 + 36_000} revealed={false} nextPingMs={42_000} />);
+    const hud = screen.getByTestId('hider-hud');
+    expect(within(hud).getByText('11:36')).toBeInTheDocument();
+    expect(within(hud).getByText('Hidden')).toBeInTheDocument();
+    expect(within(hud).getByText('00:42')).toBeInTheDocument();
+  });
+
+  it('flags the reveal while exposed', () => {
+    render(<MatchHud role="hider" survivedMs={0} revealed={true} nextPingMs={42_000} />);
+    const hud = screen.getByTestId('hider-hud');
+    expect(within(hud).getByText('Revealed')).toBeInTheDocument();
+    expect(within(hud).getByText(/just revealed to the hunters/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/game/MatchHud.tsx
+++ b/client/src/game/MatchHud.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react';
+import { formatClock } from './matchClock.ts';
+
+/**
+ * The in-game heads-up display: the row of stat tiles above the map, plus (for a
+ * hider) the "you'll be revealed soon" banner. Purely presentational — every
+ * value is computed by {@link ActiveGame} from the match clock and roster and
+ * passed in, so this component is trivial to render in isolation.
+ *
+ * The two roles read the same match differently, so the HUD is a discriminated
+ * union: a hunter watches the clock run down, how many hiders are left, and when
+ * the next ping will expose them; a hider watches how long they've survived and
+ * counts down to that same ping as a threat.
+ */
+export type MatchHudProps =
+  | {
+      role: 'hunter';
+      /** Time until the match's duration elapses, in ms. */
+      timeLeftMs: number;
+      /** Hiders still uncaught. */
+      hidersRemaining: number;
+      /** Hiders the match started with. */
+      hidersTotal: number;
+      /** Time until the next ping reveal, in ms. */
+      nextPingMs: number;
+    }
+  | {
+      role: 'hider';
+      /** How long this hider has lasted so far, in ms. */
+      survivedMs: number;
+      /** True for a few seconds after a ping reveal exposes this hider. */
+      revealed: boolean;
+      /** Time until the next ping reveal, in ms. */
+      nextPingMs: number;
+    };
+
+/** One labelled stat in the HUD row. `tone` tints the value. */
+function StatTile({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: ReactNode;
+  tone?: 'default' | 'teal' | 'alert';
+}) {
+  return (
+    <div className={`stat stat--${tone}`}>
+      <span className="stat__label">{label}</span>
+      <span className="stat__value">{value}</span>
+    </div>
+  );
+}
+
+export default function MatchHud(props: MatchHudProps) {
+  if (props.role === 'hunter') {
+    return (
+      <div className="hud" data-testid="hunter-hud">
+        <StatTile label="TIME LEFT" value={formatClock(props.timeLeftMs)} />
+        <StatTile
+          label="HIDERS"
+          tone="teal"
+          value={
+            <>
+              {props.hidersRemaining}
+              <span className="stat__sub"> / {props.hidersTotal}</span>
+            </>
+          }
+        />
+        <StatTile label="NEXT PING" tone="alert" value={formatClock(props.nextPingMs)} />
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="hider-hud">
+      <div className="hud">
+        <StatTile label="SURVIVED" tone="teal" value={formatClock(props.survivedMs)} />
+        <StatTile
+          label="STATUS"
+          tone={props.revealed ? 'alert' : 'teal'}
+          value={props.revealed ? 'Revealed' : 'Hidden'}
+        />
+      </div>
+      <p className={`reveal-banner ${props.revealed ? 'reveal-banner--on' : ''}`} role="status">
+        <span className="reveal-banner__dot" aria-hidden="true" />
+        {props.revealed ? (
+          <>Your location was just revealed to the hunters</>
+        ) : (
+          <>
+            Location revealed to hunters in <strong>{formatClock(props.nextPingMs)}</strong>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/client/src/game/geo.test.ts
+++ b/client/src/game/geo.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  bearingDegrees,
   boundaryFeature,
   circleRing,
+  compassDirection,
   DEFAULT_BOUNDARY_RADIUS_M,
+  distanceMeters,
   type BoundaryCircle,
 } from './geo.ts';
 
@@ -44,6 +47,51 @@ describe('circleRing', () => {
       expect(Number.isFinite(lng)).toBe(true);
       expect(Number.isFinite(latVal)).toBe(true);
     }
+  });
+});
+
+describe('distanceMeters', () => {
+  const amsterdam = { lng: 4.9, lat: 52.37 };
+
+  it('is zero for a point to itself', () => {
+    expect(distanceMeters(amsterdam, amsterdam)).toBe(0);
+  });
+
+  it('agrees with an independent haversine to within a metre', () => {
+    const other = { lng: 4.91, lat: 52.375 };
+    expect(distanceMeters(amsterdam, other)).toBeCloseTo(distanceM([4.9, 52.37], [4.91, 52.375]), 0);
+  });
+
+  it('is symmetric', () => {
+    const a = { lng: 4.9, lat: 52.37 };
+    const b = { lng: 5.1, lat: 52.4 };
+    expect(distanceMeters(a, b)).toBeCloseTo(distanceMeters(b, a), 6);
+  });
+});
+
+describe('bearingDegrees / compassDirection', () => {
+  const origin = { lng: 0, lat: 0 };
+
+  it('reads due north for a point directly above', () => {
+    const bearing = bearingDegrees(origin, { lng: 0, lat: 1 });
+    expect(bearing).toBeCloseTo(0, 1);
+    expect(compassDirection(bearing)).toBe('north');
+  });
+
+  it('reads due east for a point directly to the right', () => {
+    const bearing = bearingDegrees(origin, { lng: 1, lat: 0 });
+    expect(bearing).toBeCloseTo(90, 1);
+    expect(compassDirection(bearing)).toBe('east');
+  });
+
+  it('reads roughly northeast for a diagonal', () => {
+    const bearing = bearingDegrees(origin, { lng: 1, lat: 1 });
+    expect(compassDirection(bearing)).toBe('northeast');
+  });
+
+  it('snaps a wrapped bearing back to north', () => {
+    expect(compassDirection(359)).toBe('north');
+    expect(compassDirection(-90)).toBe('west');
   });
 });
 

--- a/client/src/game/geo.ts
+++ b/client/src/game/geo.ts
@@ -76,3 +76,56 @@ export function boundaryFeature(boundary: BoundaryCircle): PolygonFeature {
     },
   };
 }
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+const toDeg = (rad: number): number => (rad * 180) / Math.PI;
+
+/**
+ * Great-circle (haversine) distance between two points, in metres. This mirrors
+ * the server's `haversineMeters` so the client can size the "how close is the
+ * nearest player" readouts the same way the authoritative catch/boundary checks
+ * do — the client's number is advisory (the server re-measures), so it only has
+ * to agree to within GPS jitter.
+ */
+export function distanceMeters(a: LngLat, b: LngLat): number {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Initial compass bearing from `from` to `to`, in degrees clockwise from north
+ * (`[0, 360)`). Used to turn "the nearest hider is 90 m away" into a direction
+ * the player can act on ("…to the northeast").
+ */
+export function bearingDegrees(from: LngLat, to: LngLat): number {
+  const lat1 = toRad(from.lat);
+  const lat2 = toRad(to.lat);
+  const dLng = toRad(to.lng - from.lng);
+  const y = Math.sin(dLng) * Math.cos(lat2);
+  const x = Math.cos(lat1) * Math.sin(lat2) - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
+  return (toDeg(Math.atan2(y, x)) + 360) % 360;
+}
+
+/** The eight compass points, indexed clockwise from north in 45° steps. */
+const COMPASS_POINTS = [
+  'north',
+  'northeast',
+  'east',
+  'southeast',
+  'south',
+  'southwest',
+  'west',
+  'northwest',
+] as const;
+
+/** Round a bearing in degrees to the nearest of the eight named compass points. */
+export function compassDirection(bearing: number): string {
+  const normalized = ((bearing % 360) + 360) % 360;
+  const index = Math.round(normalized / 45) % 8;
+  return COMPASS_POINTS[index]!;
+}

--- a/client/src/game/matchClock.test.ts
+++ b/client/src/game/matchClock.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  elapsedMs,
+  formatClock,
+  GAME_DURATION_MS,
+  nextPingMs,
+  PING_INTERVAL_MS,
+  timeLeftMs,
+} from './matchClock.ts';
+
+const START = '2026-07-22T12:00:00.000Z';
+const startMs = Date.parse(START);
+
+describe('elapsedMs', () => {
+  it('measures time since the start', () => {
+    expect(elapsedMs(START, startMs + 90_000)).toBe(90_000);
+  });
+
+  it('never goes negative before the start', () => {
+    expect(elapsedMs(START, startMs - 5_000)).toBe(0);
+  });
+
+  it('reads zero without a valid start time', () => {
+    expect(elapsedMs(undefined, startMs)).toBe(0);
+    expect(elapsedMs('not-a-date', startMs)).toBe(0);
+  });
+});
+
+describe('timeLeftMs', () => {
+  it('counts down from the full duration', () => {
+    expect(timeLeftMs(START, startMs)).toBe(GAME_DURATION_MS);
+    expect(timeLeftMs(START, startMs + 60_000)).toBe(GAME_DURATION_MS - 60_000);
+  });
+
+  it('clamps at zero once the match runs out', () => {
+    expect(timeLeftMs(START, startMs + GAME_DURATION_MS + 10_000)).toBe(0);
+  });
+});
+
+describe('nextPingMs', () => {
+  it('is a full interval at the start and reset points', () => {
+    expect(nextPingMs(START, startMs)).toBe(PING_INTERVAL_MS);
+    expect(nextPingMs(START, startMs + PING_INTERVAL_MS)).toBe(PING_INTERVAL_MS);
+  });
+
+  it('counts down within an interval', () => {
+    expect(nextPingMs(START, startMs + 60_000)).toBe(PING_INTERVAL_MS - 60_000);
+    expect(nextPingMs(START, startMs + PING_INTERVAL_MS + 30_000)).toBe(PING_INTERVAL_MS - 30_000);
+  });
+});
+
+describe('formatClock', () => {
+  it('formats minutes and seconds zero-padded', () => {
+    expect(formatClock(0)).toBe('00:00');
+    expect(formatClock(72_000)).toBe('01:12');
+    expect(formatClock(11 * 60_000 + 36_000)).toBe('11:36');
+  });
+
+  it('clamps negative durations to zero', () => {
+    expect(formatClock(-5_000)).toBe('00:00');
+  });
+
+  it('does not cap the minute field past an hour', () => {
+    expect(formatClock(65 * 60_000)).toBe('65:00');
+  });
+});

--- a/client/src/game/matchClock.ts
+++ b/client/src/game/matchClock.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure match-timing maths for the in-game HUD: how long is left, how long a
+ * hider has survived, and how long until the next ping reveal. Everything is
+ * derived from the match's `startedAt` and two fixed cadences, so the client can
+ * render live countdowns without the server streaming a clock — it only needs to
+ * know when the match began.
+ *
+ * The two durations mirror the server's defaults by hand (the client and server
+ * workspaces don't share a package): `DEFAULT_GAME_DURATION_MS` and
+ * `DEFAULT_PING_INTERVAL_MS` in `server/live/`. They become per-game settings
+ * later (BACKLOG.md #27); until the server sends them, these constants keep the
+ * client's countdowns aligned with the server's timers.
+ */
+
+/** Match length, in milliseconds. Mirrors the server's `DEFAULT_GAME_DURATION_MS` (30 min). */
+export const GAME_DURATION_MS = 1_800_000;
+
+/** Ping-reveal cadence, in milliseconds. Mirrors the server's `DEFAULT_PING_INTERVAL_MS` (3 min). */
+export const PING_INTERVAL_MS = 180_000;
+
+/** Parse an ISO-8601 stamp to epoch ms, or `null` when it isn't a real time. */
+function parse(startedAt: string | undefined): number | null {
+  if (!startedAt) return null;
+  const ms = Date.parse(startedAt);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** How long the match has been running at `now`, in ms — never negative. */
+export function elapsedMs(startedAt: string | undefined, now: number): number {
+  const start = parse(startedAt);
+  if (start === null) return 0;
+  return Math.max(0, now - start);
+}
+
+/** Time remaining before the match's duration elapses, in ms — clamped at 0. */
+export function timeLeftMs(
+  startedAt: string | undefined,
+  now: number,
+  durationMs: number = GAME_DURATION_MS,
+): number {
+  return Math.max(0, durationMs - elapsedMs(startedAt, now));
+}
+
+/**
+ * Time until the next scheduled ping reveal, in ms. Reveals fire on a fixed
+ * cadence from the match start, so the countdown is the remainder of the elapsed
+ * time within one interval. Always in `(0, intervalMs]` — the moment a reveal
+ * fires the countdown resets to a full interval rather than reading zero.
+ */
+export function nextPingMs(
+  startedAt: string | undefined,
+  now: number,
+  intervalMs: number = PING_INTERVAL_MS,
+): number {
+  const period = Math.max(1, intervalMs);
+  const remainder = elapsedMs(startedAt, now) % period;
+  return period - remainder;
+}
+
+/**
+ * Format a duration in milliseconds as `MM:SS` (zero-padded, clamped at 0). The
+ * minute field is not capped, so a duration over an hour still reads correctly.
+ */
+export function formatClock(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}

--- a/client/src/game/proximity.test.ts
+++ b/client/src/game/proximity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { mergeSightings, nearest, type Sightings } from './proximity.ts';
+import type { LivePositions } from './useLivePositions.ts';
+
+const self = { lng: 4.9, lat: 52.37 };
+
+describe('nearest', () => {
+  it('returns null without an own fix', () => {
+    expect(nearest(null, { p2: { lng: 4.9, lat: 52.38, recordedAt: 'x' } })).toBeNull();
+  });
+
+  it('returns null when there is no one to measure against', () => {
+    expect(nearest(self, {})).toBeNull();
+  });
+
+  it('picks the closest of several and names the direction', () => {
+    const others: LivePositions = {
+      far: { lng: 4.95, lat: 52.37, recordedAt: 'x' },
+      near: { lng: 4.9, lat: 52.371, recordedAt: 'x' }, // just north
+    };
+    const result = nearest(self, others);
+    expect(result?.id).toBe('near');
+    expect(result?.direction).toBe('north');
+    expect(result?.distanceM).toBeLessThan(150);
+  });
+});
+
+describe('mergeSightings', () => {
+  it('records newly-visible hiders', () => {
+    const visible: LivePositions = { h1: { lng: 4.9, lat: 52.37, recordedAt: 't1' } };
+    const merged = mergeSightings({}, visible);
+    expect(merged.h1).toEqual(visible.h1);
+  });
+
+  it('keeps a hider that dropped out of the current set', () => {
+    const prev: Sightings = { h1: { lng: 4.9, lat: 52.37, recordedAt: 't1' } };
+    // A later non-reveal tick has no hiders visible; the last sighting persists.
+    expect(mergeSightings(prev, {})).toBe(prev);
+  });
+
+  it('updates a hider when a newer fix arrives', () => {
+    const prev: Sightings = { h1: { lng: 4.9, lat: 52.37, recordedAt: 't1' } };
+    const merged = mergeSightings(prev, { h1: { lng: 4.91, lat: 52.38, recordedAt: 't2' } });
+    expect(merged).not.toBe(prev);
+    expect(merged.h1?.recordedAt).toBe('t2');
+  });
+
+  it('returns the same reference when nothing changed', () => {
+    const prev: Sightings = { h1: { lng: 4.9, lat: 52.37, recordedAt: 't1' } };
+    expect(mergeSightings(prev, { h1: { lng: 4.9, lat: 52.37, recordedAt: 't1' } })).toBe(prev);
+  });
+});

--- a/client/src/game/proximity.ts
+++ b/client/src/game/proximity.ts
@@ -1,0 +1,79 @@
+/**
+ * Proximity read-model for the in-game HUD: turning the raw positions the server
+ * fans out into the "nearest opponent is 90 m to the northeast" cue each role
+ * gets, plus the accumulated hider *sightings* a hunter map shows.
+ *
+ * A hunter only ever receives a hider's coordinates on a scheduled ping reveal
+ * (the server withholds them otherwise, BACKLOG.md #14). So between reveals a
+ * hunter has nothing live to point at — the map instead shows each hider's *last
+ * known* position, ageing as a "last seen" ghost. {@link mergeSightings}
+ * accumulates those last-known fixes across ticks; a hider's own view needs no
+ * such memory because it can see the hunters live.
+ *
+ * All pure and side-effect free so the maths is unit-testable on its own.
+ */
+import { bearingDegrees, compassDirection, distanceMeters, type LngLat } from './geo.ts';
+import type { LivePosition, LivePositions } from './useLivePositions.ts';
+
+/**
+ * How close an opponent must be, in metres, for the HUD to raise a proximity
+ * alert. Loose enough to be a useful early warning at play-area scale, tight
+ * enough that it means "act now", and the radius the alert ring around the
+ * player draws.
+ */
+export const PROXIMITY_ALERT_M = 150;
+
+/** Radius, in metres, of the "you could be seen from here" ring a hider is shown on a reveal. */
+export const REVEAL_RADIUS_M = 200;
+
+/** The nearest opponent to the player: who, how far, and in which direction. */
+export interface Proximity {
+  /** The opponent's player id. */
+  id: string;
+  /** Great-circle distance to them, in metres. */
+  distanceM: number;
+  /** Initial compass bearing to them, in degrees clockwise from north. */
+  bearing: number;
+  /** That bearing as a named compass point (e.g. `"northeast"`). */
+  direction: string;
+}
+
+/**
+ * The nearest of `others` to `self`, or `null` when the player has no fix yet or
+ * there is no one to measure against. Distance and bearing are computed with the
+ * same great-circle maths the server uses, so the readout tracks reality within
+ * GPS jitter.
+ */
+export function nearest(self: LngLat | null, others: LivePositions): Proximity | null {
+  if (!self) return null;
+  let best: Proximity | null = null;
+  for (const [id, pos] of Object.entries(others)) {
+    const target = { lng: pos.lng, lat: pos.lat };
+    const distanceM = distanceMeters(self, target);
+    if (best && distanceM >= best.distanceM) continue;
+    const bearing = bearingDegrees(self, target);
+    best = { id, distanceM, bearing, direction: compassDirection(bearing) };
+  }
+  return best;
+}
+
+/** Accumulated last-known position per hider id — the hunter map's ghost markers. */
+export type Sightings = Record<string, LivePosition>;
+
+/**
+ * Fold whichever hider positions are currently visible into the accumulated
+ * sightings, keeping the newest fix per hider. `visible` is already role-filtered
+ * by the caller to hiders only. Returns the previous object unchanged (same
+ * reference) when nothing newer arrived, so a React state setter fed this can
+ * bail out of a re-render.
+ */
+export function mergeSightings(prev: Sightings, visible: LivePositions): Sightings {
+  let next: Sightings | null = null;
+  for (const [id, pos] of Object.entries(visible)) {
+    const existing = prev[id];
+    if (existing && existing.recordedAt === pos.recordedAt) continue;
+    next ??= { ...prev };
+    next[id] = pos;
+  }
+  return next ?? prev;
+}

--- a/client/src/game/useLivePositions.test.ts
+++ b/client/src/game/useLivePositions.test.ts
@@ -49,7 +49,19 @@ describe('useLivePositions', () => {
     };
     fake.emitState({ gameId: 'g1', positions });
 
-    expect(result.current).toEqual(positions);
+    expect(result.current.positions).toEqual(positions);
+  });
+
+  it('counts reveal broadcasts but leaves ordinary ticks flat', () => {
+    const fake = fakeSocket();
+    const { result } = renderHook(() => useLivePositions('g1', fake.socket));
+
+    fake.emitState({ gameId: 'g1', positions: {} });
+    expect(result.current.revealSeq).toBe(0);
+
+    fake.emitState({ gameId: 'g1', positions: {}, reveal: true });
+    fake.emitState({ gameId: 'g1', positions: {}, reveal: true });
+    expect(result.current.revealSeq).toBe(2);
   });
 
   it('re-joins the room when the socket reconnects', () => {
@@ -71,7 +83,7 @@ describe('useLivePositions', () => {
       positions: { p9: { lat: 1, lng: 2, recordedAt: '2026-07-21T00:00:00.000Z' } },
     });
 
-    expect(result.current).toEqual({});
+    expect(result.current.positions).toEqual({});
   });
 
   it('does not subscribe without a game id', () => {
@@ -89,7 +101,7 @@ describe('useLivePositions', () => {
       gameId: 'g1',
       positions: { p2: { lat: 52.1, lng: 4.3, recordedAt: '2026-07-21T00:00:00.000Z' } },
     });
-    expect(result.current).not.toEqual({});
+    expect(result.current.positions).not.toEqual({});
 
     unmount();
     expect(fake.socket.off).toHaveBeenCalledWith('game_state', expect.any(Function));

--- a/client/src/game/useLivePositions.ts
+++ b/client/src/game/useLivePositions.ts
@@ -25,6 +25,21 @@ export type LivePositions = Record<string, LivePosition>;
 interface GameStateEvent {
   gameId: string;
   positions: LivePositions;
+  /** True when this broadcast is a scheduled ping reveal (BACKLOG.md #13). */
+  reveal?: boolean;
+}
+
+/** The live view a client keeps for the current game. */
+export interface LiveView {
+  /** Latest position per player id, exactly what this player is permitted to see. */
+  positions: LivePositions;
+  /**
+   * Increments on every ping-reveal broadcast (BACKLOG.md #13), and stays flat
+   * on ordinary ticks. A component can watch it to react to a reveal — a hunter
+   * flashing the freshly-disclosed hiders, a hider flagging that they were seen —
+   * without diffing positions. `0` until the first reveal.
+   */
+  revealSeq: number;
 }
 
 /**
@@ -39,8 +54,9 @@ interface GameStateEvent {
  * a reconnect gets a fresh socket that the server has dropped from the room —
  * without re-joining, `game_state` would stop for the rest of the match.
  */
-export function useLivePositions(gameId: string | null, socket: Socket): LivePositions {
+export function useLivePositions(gameId: string | null, socket: Socket): LiveView {
   const [positions, setPositions] = useState<LivePositions>({});
+  const [revealSeq, setRevealSeq] = useState(0);
 
   useEffect(() => {
     if (!gameId) return;
@@ -53,6 +69,7 @@ export function useLivePositions(gameId: string | null, socket: Socket): LivePos
     const onState = (event: GameStateEvent): void => {
       if (event.gameId !== gameId) return;
       setPositions(event.positions ?? {});
+      if (event.reveal) setRevealSeq((n) => n + 1);
     };
     socket.on('connect', join);
     socket.on(GAME_STATE, onState);
@@ -60,10 +77,11 @@ export function useLivePositions(gameId: string | null, socket: Socket): LivePos
     return () => {
       socket.off('connect', join);
       socket.off(GAME_STATE, onState);
-      // Drop stale positions so a later game starts from a clean slate.
+      // Drop stale state so a later game starts from a clean slate.
       setPositions({});
+      setRevealSeq(0);
     };
   }, [gameId, socket]);
 
-  return positions;
+  return { positions, revealSeq };
 }

--- a/client/src/game/useNow.ts
+++ b/client/src/game/useNow.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * A wall-clock that re-renders on a fixed cadence. Returns the current epoch-ms
+ * time and ticks it every `intervalMs`, so a component can derive live
+ * countdowns (see `matchClock.ts`) without owning its own timer. One second is
+ * the natural cadence for a `MM:SS` HUD.
+ */
+export function useNow(intervalMs = 1000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/client/src/lobby/Lobby.test.tsx
+++ b/client/src/lobby/Lobby.test.tsx
@@ -225,7 +225,7 @@ describe('<Lobby /> — in the room', () => {
     expect(writeText).not.toHaveBeenCalled();
   });
 
-  it('shows a waiting message to non-hosts and the game-on screen when active', async () => {
+  it('shows a waiting message to non-hosts and the match screen when active', async () => {
     // Enter as a non-host guest.
     const guest = game({
       players: [
@@ -238,6 +238,7 @@ describe('<Lobby /> — in the room', () => {
     expect(screen.queryByRole('button', { name: /start game/i })).not.toBeInTheDocument();
 
     fake.push('lobby_update', { game: { ...guest, status: 'active' } });
-    expect(await screen.findByText(/game on/i)).toBeInTheDocument();
+    // The guest is a hider, so the hider HUD (with its reveal countdown) takes over.
+    expect(await screen.findByTestId('hider-hud')).toBeInTheDocument();
   });
 });

--- a/client/src/test/maplibreStub.ts
+++ b/client/src/test/maplibreStub.ts
@@ -33,8 +33,15 @@ class FakeMap {
 }
 
 class FakeMarker {
+  private element: HTMLElement;
+  constructor(opts?: { element?: HTMLElement }) {
+    this.element = opts?.element ?? document.createElement('div');
+  }
   setLngLat() {
     return this;
+  }
+  getElement() {
+    return this.element;
   }
   addTo() {
     return this;


### PR DESCRIPTION
Closes #18.

Renders the active match from each player's perspective, orienting on the mockup: a role-specific HUD, a role-aware map, and a nearest-opponent proximity readout.

## What's in it

**Hunter view**
- HUD: `TIME LEFT`, `HIDERS n / total` (latched denominator so the tally holds as caught hiders convert to hunters), `NEXT PING` countdown.
- Map: own red glowing pin, fellow hunters live, and each hider's ageing **"last seen Xm" ghost** — hunters only ever receive hider coordinates on a scheduled ping reveal (BACKLOG.md #14), so those last-known fixes are accumulated and shown between reveals. A faint red **proximity ring** rings the player.
- **Scan to catch** → the authoritative `claim_catch` contract; the server's range check gates it and the rejection reason is surfaced.

**Hider view**
- HUD: `SURVIVED` timer, `STATUS` (Hidden / Revealed), and the amber *"Location revealed to hunters in MM:SS"* banner that flips red for a few seconds when a ping exposes them.
- Map: own teal glowing pin and live hunters (a hider can see the hunters), with a dashed amber **reveal ring**.

**Proximity** — *"Hider within 90m — northeast"* / *"Hunter within …"*, from great-circle distance + compass bearing, only within the alert radius.

## New modules (pure, unit-tested)
- `matchClock` — time-left / survived / next-ping maths + `MM:SS` formatting, mirroring the server's duration (30 min) and ping (3 min) defaults by hand.
- `proximity` — nearest-opponent + last-known sighting accumulation.
- `geo` additions — `distanceMeters`, `bearingDegrees`, `compassDirection`.
- `useNow` — a once-a-second clock driving the live countdowns.
- The server's ping-`reveal` flag is threaded through `useLivePositions`.

`GameMap` was refactored from a fixed self/others split to a generic role-aware **markers + rings** API so the screen can decide colours, ghosts, and overlays.

## Out of scope (no server backing yet)
Safe zones / "Run to safe zone", "Ping team", and real QR scanning are left for their own issues; the catch button does a proximity-based claim instead.

## Verification
- `npm run typecheck` ✓
- `npm run lint` (js/css/md) ✓
- server tests 189 ✓ · client tests 80 ✓ (15 new) · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-specific in-match HUDs (hunter time remaining, hider survival/reveal messaging, and ping timing).
  * Added proximity alerts with directional distance readouts and proximity/reveal ring overlays.
  * Added hunter “scan to catch” action with visible result and connectivity feedback.
  * Revamped map markers with team styling, labels, and ghost last-known locations.
* **Bug Fixes**
  * Improved active match screen behavior so the correct HUD and reveal logic render for each role.
* **Tests**
  * Updated and expanded UI/logic coverage, including match HUD, map markers, GPS flow assertions, and timing/proximity helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->