### PR TITLE
feat(client): game over screen — winner, survival board, rematch (#19)

### DIFF
--- a/client/e2e/gameover.spec.ts
+++ b/client/e2e/gameover.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+import { io, type Socket } from 'socket.io-client';
+
+// Drives a full match to its end against the real production server the way a
+// client would: host a room, join as a hider, start, close in and catch the last
+// hider. Catching the final hider is a win condition (BACKLOG.md #15) — the
+// hunters win (`all_caught`) — so the server ends the game and broadcasts
+// `game_over` with the summary the end screen renders (BACKLOG.md #19).
+const PORT = process.env.E2E_PORT || 3000;
+const url = `http://127.0.0.1:${PORT}`;
+
+const BASE = { lat: 52.3731, lng: 4.8922 };
+function northOf(meters: number): { lat: number; lng: number } {
+  return { lat: BASE.lat + meters / 111_320, lng: BASE.lng };
+}
+
+interface Player {
+  id: string;
+  role: 'hunter' | 'hider';
+}
+interface Game {
+  id: string;
+  roomCode: string;
+  players: Player[];
+}
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+interface HiderOutcome {
+  playerId: string;
+  name: string;
+  caught: boolean;
+  survivalMs: number;
+}
+interface GameSummary {
+  gameId: string;
+  winner: 'hunters' | 'hiders';
+  reason: 'all_caught' | 'timer';
+  durationMs: number;
+  catches: { hunterId: string; targetId: string; at: string }[];
+  hiders: HiderOutcome[];
+}
+interface GameOver {
+  gameId: string;
+  summary: GameSummary;
+}
+interface GameState {
+  gameId: string;
+  positions: Record<string, { lat: number; lng: number }>;
+}
+
+function waitFor<T>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+function waitUntil<T>(socket: Socket, event: string, match: (payload: T) => boolean): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!match(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+test('ends the game and broadcasts the summary when the last hider is caught', async () => {
+  const hunter = io(url, { transports: ['websocket'], reconnection: false });
+  const hider = io(url, { transports: ['websocket'], reconnection: false });
+  const sockets = [hunter, hider];
+
+  try {
+    await Promise.all(sockets.map((s) => waitFor(s, 'connect')));
+
+    // Stand up an active game: host (hunter) + one hider, both ready, started.
+    const created = (await hunter.emitWithAck('create_game', { name: 'Hunter' })) as LobbyAck;
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('create failed');
+    const { roomCode, id: gameId } = created.game;
+    const hunterId = created.playerId;
+
+    const joined = (await hider.emitWithAck('join_game', { roomCode, name: 'Ana' })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+    const hiderId = joined.playerId;
+
+    await hunter.emitWithAck('set_ready', { ready: true });
+    await hider.emitWithAck('set_ready', { ready: true });
+    await hunter.emitWithAck('start_game', {});
+
+    // Both report a position within the catch radius (~5 m apart).
+    const stored = waitUntil<GameState>(
+      hider,
+      'game_state',
+      (p) => Boolean(p.positions[hunterId] && p.positions[hiderId]),
+    );
+    hunter.emit('position_update', { gameId, playerId: hunterId, ...BASE });
+    hider.emit('position_update', { gameId, playerId: hiderId, ...northOf(5) });
+    await stored;
+
+    // Catching the only hider is the last-hider win — the server ends the game.
+    const over = waitFor<GameOver>(hider, 'game_over');
+    const caught = await hunter.emitWithAck('claim_catch', { gameId, hunterId, targetId: hiderId });
+    expect((caught as { ok: boolean }).ok).toBe(true);
+
+    const event = await over;
+    expect(event.gameId).toBe(gameId);
+    expect(event.summary.winner).toBe('hunters');
+    expect(event.summary.reason).toBe('all_caught');
+    expect(event.summary.catches).toHaveLength(1);
+    expect(event.summary.hiders).toEqual([
+      expect.objectContaining({ playerId: hiderId, name: 'Ana', caught: true }),
+    ]);
+  } finally {
+    for (const s of sockets) s.close();
+  }
+});

--- a/client/src/game/GameOver.css
+++ b/client/src/game/GameOver.css
@@ -1,0 +1,224 @@
+.gameover {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+/* --- Win banner: eyebrow, big headline, subtitle, with a side-tinted glow --- */
+.gameover__banner {
+  position: relative;
+  overflow: hidden;
+  padding: 1.75rem 1.25rem 1.5rem;
+  border-radius: 20px;
+  border: 1px solid rgb(255 255 255 / 8%);
+}
+
+.gameover__banner--hiders {
+  background: radial-gradient(120% 90% at 50% 0%, rgb(36 227 198 / 22%), transparent 70%),
+    rgb(36 227 198 / 4%);
+  border-color: rgb(36 227 198 / 25%);
+}
+
+.gameover__banner--hunters {
+  background: radial-gradient(120% 90% at 50% 0%, rgb(255 66 66 / 22%), transparent 70%),
+    rgb(255 66 66 / 4%);
+  border-color: rgb(255 66 66 / 25%);
+}
+
+.gameover__eyebrow {
+  margin: 0 0 0.35rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-indent: 0.35em;
+  color: var(--teal);
+}
+
+.gameover--hunters .gameover__eyebrow {
+  color: var(--red);
+}
+
+.gameover__title {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: clamp(2.25rem, 11vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1;
+}
+
+.gameover--hiders .gameover__title {
+  color: var(--teal);
+  text-shadow: 0 0 28px rgb(36 227 198 / 45%);
+}
+
+.gameover--hunters .gameover__title {
+  color: var(--red);
+  text-shadow: 0 0 28px rgb(255 66 66 / 45%);
+}
+
+.gameover__subtitle {
+  margin: 0.6rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+/* --- Headline stat tiles --- */
+.gameover__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.6rem;
+}
+
+.endstat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.9rem 0.5rem;
+  border-radius: 14px;
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid rgb(255 255 255 / 8%);
+}
+
+.endstat__value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.endstat__label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+
+.endstat--teal .endstat__value {
+  color: var(--teal);
+}
+
+.endstat--alert .endstat__value {
+  color: var(--red);
+}
+
+/* --- Survival board: a bar per hider, on a faint grid --- */
+.board {
+  padding: 1rem 1.1rem 1.2rem;
+  border-radius: 16px;
+  text-align: left;
+  background:
+    linear-gradient(rgb(255 255 255 / 4%) 1px, transparent 1px) 0 0 / 100% 34px,
+    linear-gradient(90deg, rgb(255 255 255 / 4%) 1px, transparent 1px) 0 0 / 44px 100%,
+    rgb(255 255 255 / 3%);
+  border: 1px solid rgb(255 255 255 / 8%);
+}
+
+.board__heading {
+  margin: 0 0 0.85rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+
+.board__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.board__row {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.board__name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board__track {
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 6%);
+  overflow: hidden;
+}
+
+.board__bar {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  min-width: 3px;
+}
+
+.board__bar--survived {
+  background: var(--teal);
+  box-shadow: 0 0 10px rgb(36 227 198 / 45%);
+}
+
+.board__bar--caught {
+  background: var(--red);
+}
+
+.board__time {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+  min-width: 3.2rem;
+  text-align: right;
+}
+
+.board__time--survived {
+  color: var(--teal);
+}
+
+.board__time--caught {
+  color: var(--muted);
+}
+
+.board__empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+/* --- Closing actions --- */
+.gameover__actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.7rem;
+}
+
+.gameover__btn {
+  padding: 1rem;
+  font-size: 1rem;
+  font-weight: 700;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  cursor: pointer;
+}
+
+.gameover__btn--primary {
+  color: var(--bg);
+  background: var(--teal);
+  box-shadow: 0 0 24px rgb(36 227 198 / 35%);
+}
+
+.gameover__btn--ghost {
+  color: var(--fg);
+  background: transparent;
+  border-color: #2a3543;
+}

--- a/client/src/game/GameOver.test.tsx
+++ b/client/src/game/GameOver.test.tsx
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameOver from './GameOver.tsx';
+import type { GameSummary } from './summary.ts';
+
+function summary(overrides: Partial<GameSummary> = {}): GameSummary {
+  return {
+    gameId: 'g1',
+    winner: 'hiders',
+    reason: 'timer',
+    startedAt: '2026-07-22T10:00:00.000Z',
+    endedAt: '2026-07-22T10:25:00.000Z',
+    durationMs: 1_500_000, // 25:00
+    catches: [
+      { hunterId: 'h1', targetId: 'c', at: '2026-07-22T10:11:40.000Z' },
+    ],
+    hiders: [
+      { playerId: 'a', name: 'Ana', caught: false, survivalMs: 1_500_000 },
+      { playerId: 'b', name: 'Rui', caught: false, survivalMs: 1_500_000 },
+      { playerId: 'c', name: 'Leo', caught: true, survivalMs: 700_000, caughtAt: '2026-07-22T10:11:40.000Z' },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Reset the navigator patches the share/clipboard tests install.
+  Reflect.deleteProperty(navigator, 'share');
+  Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GameOver', () => {
+  it('shows the hiders-win banner and outcome line', () => {
+    render(<GameOver summary={summary()} onPlayAgain={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: 'HIDERS WIN' })).toBeInTheDocument();
+    expect(screen.getByText('2 survived the full 25:00')).toBeInTheDocument();
+  });
+
+  it('shows the hunters-win banner when everyone was caught', () => {
+    render(
+      <GameOver
+        summary={summary({
+          winner: 'hunters',
+          reason: 'all_caught',
+          durationMs: 754_000,
+          hiders: [
+            { playerId: 'a', name: 'Ana', caught: true, survivalMs: 754_000 },
+          ],
+        })}
+        onPlayAgain={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: 'HUNTERS WIN' })).toBeInTheDocument();
+    expect(screen.getByText('All hiders caught in 12:34')).toBeInTheDocument();
+  });
+
+  it('renders the headline stats: catches, survivors, top time', () => {
+    render(<GameOver summary={summary()} onPlayAgain={vi.fn()} />);
+    const stats = screen.getByText('CATCHES').closest('.gameover__stats');
+    expect(stats).not.toBeNull();
+    const s = within(stats as HTMLElement);
+    // CATCHES = 1
+    expect(s.getByText('CATCHES').previousSibling).toHaveTextContent('1');
+    // SURVIVORS = 2
+    expect(s.getByText('SURVIVORS').previousSibling).toHaveTextContent('2');
+    // TOP TIME = 25:00 (longest survival)
+    expect(s.getByText('TOP TIME').previousSibling).toHaveTextContent('25:00');
+  });
+
+  it('lists every hider on the survival board with their time', () => {
+    render(<GameOver summary={summary()} onPlayAgain={vi.fn()} />);
+    const board = screen.getByRole('region', { name: 'Survival' });
+    const b = within(board);
+    expect(b.getByText('Ana')).toBeInTheDocument();
+    expect(b.getByText('Rui')).toBeInTheDocument();
+    expect(b.getByText('Leo')).toBeInTheDocument();
+    // Caught hider's time (11:40) shows on the board.
+    expect(b.getByText('11:40')).toBeInTheDocument();
+  });
+
+  it('calls onPlayAgain when the primary button is pressed', async () => {
+    const onPlayAgain = vi.fn();
+    render(<GameOver summary={summary()} onPlayAgain={onPlayAgain} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Play again' }));
+    expect(onPlayAgain).toHaveBeenCalledOnce();
+  });
+
+  it('shares the result via the native share sheet where present', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { configurable: true, value: share });
+
+    render(<GameOver summary={summary()} onPlayAgain={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Share result/ }));
+
+    expect(share).toHaveBeenCalledOnce();
+    const arg = share.mock.calls[0]?.[0] as { text: string };
+    expect(arg.text).toContain('HIDERS WIN');
+    expect(arg.text).toContain('1 catch');
+  });
+
+  it('copies the result to the clipboard when there is no share sheet', async () => {
+    Object.defineProperty(navigator, 'share', { configurable: true, value: undefined });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+
+    render(<GameOver summary={summary()} onPlayAgain={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /Share result/ }));
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(await screen.findByRole('button', { name: /Copied/ })).toBeInTheDocument();
+  });
+});

--- a/client/src/game/GameOver.tsx
+++ b/client/src/game/GameOver.tsx
@@ -1,0 +1,166 @@
+import { useState, type ReactNode } from 'react';
+import { formatClock } from './matchClock.ts';
+import {
+  outcomeLine,
+  survivorCount,
+  topSurvivalMs,
+  winTitle,
+  type GameSummary,
+  type HiderOutcome,
+} from './summary.ts';
+import './GameOver.css';
+
+/**
+ * The post-game / end screen shown once the server ends a match (BACKLOG.md #19,
+ * mockup screen 07). It renders the win banner ("HIDERS WIN" / "HUNTERS WIN"),
+ * the headline stats (catches, survivors, longest survival), a per-hider survival
+ * board, and the two closing actions — share the result and play again.
+ *
+ * Every value comes from the authoritative `game_over` summary (see
+ * {@link GameSummary}); the screen recomputes nothing. Full movement replay
+ * (BACKLOG.md #25) needs the position history the server doesn't stream yet, so
+ * the board visualises the one time-series we do have — how long each hider
+ * lasted — rather than fabricating a track.
+ */
+export default function GameOver({
+  summary,
+  onPlayAgain,
+}: {
+  summary: GameSummary;
+  onPlayAgain: () => void;
+}) {
+  const side = summary.winner; // 'hiders' | 'hunters'
+
+  return (
+    <div className={`gameover gameover--${side}`} data-testid="game-over">
+      <header className={`gameover__banner gameover__banner--${side}`}>
+        <p className="gameover__eyebrow">MATCH OVER</p>
+        <h1 className="gameover__title">{winTitle(summary.winner)}</h1>
+        <p className="gameover__subtitle">{outcomeLine(summary)}</p>
+      </header>
+
+      <div className="gameover__stats">
+        <EndStat label="CATCHES" value={summary.catches.length} tone="alert" />
+        <EndStat label="SURVIVORS" value={survivorCount(summary)} tone="teal" />
+        <EndStat label="TOP TIME" value={formatClock(topSurvivalMs(summary))} tone="teal" />
+      </div>
+
+      <SurvivalBoard hiders={summary.hiders} durationMs={summary.durationMs} />
+
+      <div className="gameover__actions">
+        <ShareButton summary={summary} />
+        <button
+          type="button"
+          className="gameover__btn gameover__btn--primary"
+          onClick={onPlayAgain}
+        >
+          Play again
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** One centred headline stat — a big value over a small caps label. */
+function EndStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: ReactNode;
+  tone: 'teal' | 'alert' | 'default';
+}) {
+  return (
+    <div className={`endstat endstat--${tone}`}>
+      <span className="endstat__value">{value}</span>
+      <span className="endstat__label">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * The survival board: each original hider as a bar proportional to how long they
+ * lasted, longest first (the server already sorts them). A caught hider's bar is
+ * red and tagged with the time they went down; a survivor's is teal and tagged
+ * "survived".
+ */
+function SurvivalBoard({
+  hiders,
+  durationMs,
+}: {
+  hiders: HiderOutcome[];
+  durationMs: number;
+}) {
+  // Scale bars against the longest survival so the leader fills the track — a
+  // more legible reference than the raw duration when the match ended early.
+  const longest = hiders.reduce((best, h) => Math.max(best, h.survivalMs), 0);
+  const scale = Math.max(longest, durationMs, 1);
+
+  return (
+    <section className="board" aria-label="Survival">
+      <h2 className="board__heading">SURVIVAL</h2>
+      {hiders.length === 0 ? (
+        <p className="board__empty">No hiders this match</p>
+      ) : (
+        <ul className="board__list">
+          {hiders.map((h) => (
+            <li key={h.playerId} className="board__row">
+              <span className="board__name">{h.name}</span>
+              <span className="board__track" aria-hidden="true">
+                <span
+                  className={`board__bar board__bar--${h.caught ? 'caught' : 'survived'}`}
+                  style={{ width: `${(h.survivalMs / scale) * 100}%` }}
+                />
+              </span>
+              <span className={`board__time board__time--${h.caught ? 'caught' : 'survived'}`}>
+                {formatClock(h.survivalMs)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Share the match result through the device's native share sheet where one exists
+ * (mobile), falling back to copying a short summary to the clipboard — the same
+ * pattern the lobby's room-code chip uses. Shares the outcome as text; the full
+ * movement replay it would ideally attach is future work (BACKLOG.md #25).
+ */
+function ShareButton({ summary }: { summary: GameSummary }) {
+  const [copied, setCopied] = useState(false);
+
+  const text = `Manhunt — ${winTitle(summary.winner)}. ${outcomeLine(summary)}, ${
+    summary.catches.length
+  } ${summary.catches.length === 1 ? 'catch' : 'catches'}.`;
+
+  const share = async (): Promise<void> => {
+    const data = { title: 'Manhunt', text, url: window.location.origin };
+
+    if (navigator.share && (!navigator.canShare || navigator.canShare(data))) {
+      try {
+        await navigator.share(data);
+      } catch {
+        // The user dismissed the share sheet, or it failed — nothing to do.
+      }
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // Clipboard unavailable or denied — nothing more we can do here.
+    }
+  };
+
+  return (
+    <button type="button" className="gameover__btn gameover__btn--ghost" onClick={share}>
+      {copied ? 'Copied ✓' : '↗ Share result'}
+    </button>
+  );
+}

--- a/client/src/game/summary.test.ts
+++ b/client/src/game/summary.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  outcomeLine,
+  survivorCount,
+  topSurvivalMs,
+  winTitle,
+  type GameSummary,
+} from './summary.ts';
+
+function summary(overrides: Partial<GameSummary> = {}): GameSummary {
+  return {
+    gameId: 'g1',
+    winner: 'hiders',
+    reason: 'timer',
+    startedAt: '2026-07-22T10:00:00.000Z',
+    endedAt: '2026-07-22T10:25:00.000Z',
+    durationMs: 1_500_000, // 25:00
+    catches: [],
+    hiders: [
+      { playerId: 'a', name: 'Ana', caught: false, survivalMs: 1_500_000 },
+      { playerId: 'b', name: 'Rui', caught: false, survivalMs: 1_500_000 },
+      { playerId: 'c', name: 'Leo', caught: true, survivalMs: 700_000, caughtAt: '2026-07-22T10:11:40.000Z' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('winTitle', () => {
+  it('names the winning side', () => {
+    expect(winTitle('hiders')).toBe('HIDERS WIN');
+    expect(winTitle('hunters')).toBe('HUNTERS WIN');
+  });
+});
+
+describe('survivorCount', () => {
+  it('counts hiders who were never caught', () => {
+    expect(survivorCount(summary())).toBe(2);
+  });
+
+  it('is zero when every hider was caught', () => {
+    expect(
+      survivorCount(
+        summary({
+          hiders: [
+            { playerId: 'a', name: 'Ana', caught: true, survivalMs: 60_000 },
+            { playerId: 'b', name: 'Rui', caught: true, survivalMs: 90_000 },
+          ],
+        }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe('topSurvivalMs', () => {
+  it('is the longest survival across the hiders', () => {
+    expect(topSurvivalMs(summary())).toBe(1_500_000);
+  });
+
+  it('is zero with no hiders', () => {
+    expect(topSurvivalMs(summary({ hiders: [] }))).toBe(0);
+  });
+});
+
+describe('outcomeLine', () => {
+  it('reports the survivors and full time when the hiders ran out the clock', () => {
+    expect(outcomeLine(summary())).toBe('2 survived the full 25:00');
+  });
+
+  it('uses the singular phrasing for a lone survivor', () => {
+    expect(
+      outcomeLine(
+        summary({
+          hiders: [
+            { playerId: 'a', name: 'Ana', caught: false, survivalMs: 1_500_000 },
+            { playerId: 'b', name: 'Rui', caught: true, survivalMs: 300_000 },
+          ],
+        }),
+      ),
+    ).toBe('1 hider survived the full 25:00');
+  });
+
+  it('reports the total time when the hunters caught everyone', () => {
+    expect(
+      outcomeLine(summary({ winner: 'hunters', reason: 'all_caught', durationMs: 754_000 })),
+    ).toBe('All hiders caught in 12:34');
+  });
+});

--- a/client/src/game/summary.ts
+++ b/client/src/game/summary.ts
@@ -1,0 +1,98 @@
+/**
+ * End-of-game summary wire types and the pure maths the end screen renders from
+ * them (BACKLOG.md #19). Mirrors the server's `server/live/outcome.ts` shapes by
+ * hand — the client and server workspaces don't share a package — so the payload
+ * of the `game_over` broadcast decodes to exactly these types.
+ *
+ * Everything here is pure and derived from the summary the server sends: who won
+ * and why, how long the match ran, every catch, and each hider's survival time.
+ * The screen shows the survival board and the headline stats straight from it —
+ * the client never recomputes the outcome (the server is authoritative).
+ */
+
+import { formatClock } from './matchClock.ts';
+
+/** Which side won the match. */
+export type Winner = 'hunters' | 'hiders';
+
+/**
+ * Why the match ended. `all_caught` — the last hider was caught (hunters win);
+ * `timer` — the duration elapsed with a hider still free (hiders win).
+ */
+export type EndReason = 'all_caught' | 'timer';
+
+/** A catch that happened during the match: a hunter caught a hider at a moment. */
+export interface CatchRecord {
+  hunterId: string;
+  targetId: string;
+  /** When the server confirmed the catch (ISO-8601). */
+  at: string;
+}
+
+/** One hider's line on the end screen: whether they were caught and how long they lasted. */
+export interface HiderOutcome {
+  playerId: string;
+  name: string;
+  /** True if this hider was caught before the game ended; false if they survived. */
+  caught: boolean;
+  /** How long the hider lasted, in milliseconds — until caught, or until the game ended. */
+  survivalMs: number;
+  /** When this hider was caught (ISO-8601). Absent when they survived to the end. */
+  caughtAt?: string;
+}
+
+/**
+ * The end-of-game summary — the payload the `game_over` broadcast carries and the
+ * end screen renders. Winner and why, the match's span, every catch, and each
+ * original hider's outcome (longest-lasting first, as the server sorts them).
+ */
+export interface GameSummary {
+  gameId: string;
+  winner: Winner;
+  reason: EndReason;
+  /** When the match started (ISO-8601). */
+  startedAt: string;
+  /** When the match ended (ISO-8601). */
+  endedAt: string;
+  /** How long the match ran, in milliseconds. */
+  durationMs: number;
+  /** Every catch that happened, in the order they were confirmed. */
+  catches: CatchRecord[];
+  /** Each original hider's outcome, sorted by survival time descending. */
+  hiders: HiderOutcome[];
+}
+
+/** Payload of the server's `game_over` broadcast. */
+export interface GameOverEvent {
+  gameId: string;
+  summary: GameSummary;
+}
+
+/** The headline for the winning side — "HIDERS WIN" / "HUNTERS WIN". */
+export function winTitle(winner: Winner): string {
+  return winner === 'hiders' ? 'HIDERS WIN' : 'HUNTERS WIN';
+}
+
+/** How many hiders lasted the whole match (never caught). */
+export function survivorCount(summary: GameSummary): number {
+  return summary.hiders.reduce((n, h) => (h.caught ? n : n + 1), 0);
+}
+
+/** The longest any hider lasted, in ms — 0 when there were no hiders. */
+export function topSurvivalMs(summary: GameSummary): number {
+  return summary.hiders.reduce((best, h) => Math.max(best, h.survivalMs), 0);
+}
+
+/**
+ * The one-line subtitle under the win headline, phrased for how the match ended:
+ * the hiders who ran out the clock, or the hunters who caught them all.
+ */
+export function outcomeLine(summary: GameSummary): string {
+  const clock = formatClock(summary.durationMs);
+  if (summary.reason === 'timer') {
+    const n = survivorCount(summary);
+    const who = n === 1 ? '1 hider survived' : `${n} survived`;
+    return `${who} the full ${clock}`;
+  }
+  return `All hiders caught in ${clock}`;
+}

--- a/client/src/game/useGameOver.test.ts
+++ b/client/src/game/useGameOver.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { useGameOver } from './useGameOver.ts';
+import type { GameSummary } from './summary.ts';
+
+/** A fake socket that records handlers so a test can drive `game_over`. */
+function fakeSocket() {
+  const handlers = new Map<string, (payload: unknown) => void>();
+  const socket = {
+    emit: vi.fn(),
+    on: vi.fn((event: string, cb: (payload: unknown) => void) => {
+      handlers.set(event, cb);
+    }),
+    off: vi.fn((event: string) => {
+      handlers.delete(event);
+    }),
+  };
+  return {
+    socket: socket as unknown as Socket,
+    emitOver(payload: unknown) {
+      act(() => handlers.get('game_over')?.(payload));
+    },
+    has(event: string) {
+      return handlers.has(event);
+    },
+  };
+}
+
+function summary(gameId = 'g1'): GameSummary {
+  return {
+    gameId,
+    winner: 'hunters',
+    reason: 'all_caught',
+    startedAt: '2026-07-22T10:00:00.000Z',
+    endedAt: '2026-07-22T10:12:00.000Z',
+    durationMs: 720_000,
+    catches: [{ hunterId: 'h', targetId: 'x', at: '2026-07-22T10:12:00.000Z' }],
+    hiders: [{ playerId: 'x', name: 'Ana', caught: true, survivalMs: 720_000, caughtAt: '2026-07-22T10:12:00.000Z' }],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useGameOver', () => {
+  it('latches the summary for the current game', () => {
+    const fake = fakeSocket();
+    const { result } = renderHook(() => useGameOver('g1', fake.socket));
+
+    expect(result.current).toBeNull();
+    fake.emitOver({ gameId: 'g1', summary: summary() });
+    expect(result.current).toEqual(summary());
+  });
+
+  it('ignores a summary for a different game', () => {
+    const fake = fakeSocket();
+    const { result } = renderHook(() => useGameOver('g1', fake.socket));
+
+    fake.emitOver({ gameId: 'other', summary: summary('other') });
+    expect(result.current).toBeNull();
+  });
+
+  it('does not subscribe without a game id', () => {
+    const fake = fakeSocket();
+    const { result } = renderHook(() => useGameOver(null, fake.socket));
+
+    expect(fake.has('game_over')).toBe(false);
+    expect(result.current).toBeNull();
+  });
+
+  it('clears the summary when the game changes', () => {
+    const fake = fakeSocket();
+    const { result, rerender } = renderHook(({ id }) => useGameOver(id, fake.socket), {
+      initialProps: { id: 'g1' as string | null },
+    });
+
+    fake.emitOver({ gameId: 'g1', summary: summary() });
+    expect(result.current).not.toBeNull();
+
+    rerender({ id: 'g2' });
+    expect(result.current).toBeNull();
+  });
+
+  it('unsubscribes on unmount', () => {
+    const fake = fakeSocket();
+    const { unmount } = renderHook(() => useGameOver('g1', fake.socket));
+    expect(fake.has('game_over')).toBe(true);
+    unmount();
+    expect(fake.has('game_over')).toBe(false);
+  });
+});

--- a/client/src/game/useGameOver.ts
+++ b/client/src/game/useGameOver.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+import { socket as defaultSocket } from '../socket.ts';
+import type { GameOverEvent, GameSummary } from './summary.ts';
+
+/** The socket event this hook speaks, mirrored from `server/protocol/messages.ts`. */
+const GAME_OVER = 'game_over';
+
+/**
+ * Listen for the server's `game_over` broadcast and hold the end-of-game summary
+ * for the current game (BACKLOG.md #15, #19). The server ends a match exactly
+ * once — when the last hider is caught or the timer runs out — and emits the
+ * summary the end screen renders; this hook latches it so the UI can switch from
+ * the live map to the game-over screen.
+ *
+ * Scoped to `gameId`: a summary for a different game is ignored, and changing
+ * (or clearing) the game resets the latch so a fresh match starts clean and a
+ * stale summary can't flash the end screen over a new game.
+ */
+export function useGameOver(gameId: string | null, socket: Socket = defaultSocket): GameSummary | null {
+  const [summary, setSummary] = useState<GameSummary | null>(null);
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    const onGameOver = (event: GameOverEvent): void => {
+      if (event.gameId !== gameId) return;
+      setSummary(event.summary);
+    };
+    socket.on(GAME_OVER, onGameOver);
+
+    return () => {
+      socket.off(GAME_OVER, onGameOver);
+      // Drop the latched summary so a changed/cleared game starts clean and this
+      // one's summary can't flash the end screen over the next match.
+      setSummary(null);
+    };
+  }, [gameId, socket]);
+
+  return summary;
+}

--- a/client/src/lobby/Lobby.tsx
+++ b/client/src/lobby/Lobby.tsx
@@ -2,6 +2,8 @@ import { useState, type FormEvent } from 'react';
 import { useLobby } from './useLobby.ts';
 import CodeInput, { CODE_LENGTH } from './CodeInput.tsx';
 import ActiveGame from '../game/ActiveGame.tsx';
+import GameOver from '../game/GameOver.tsx';
+import { useGameOver } from '../game/useGameOver.ts';
 import type { Game, Player, Role } from './types.ts';
 import './Lobby.css';
 
@@ -308,13 +310,21 @@ function LobbyRoom({
 }
 
 /**
- * The lobby feature: create or join a room, pick a side, ready up, and let the
- * host start. Once the game goes `active` the {@link ActiveGame} screen takes
- * over — it drives GPS capture now; the live map is tracked in the backlog.
+ * The lobby feature and the screen router for a session: create or join a room,
+ * pick a side, ready up, and let the host start. Once the game goes `active` the
+ * {@link ActiveGame} screen takes over; when the server ends the match it
+ * broadcasts a summary and the {@link GameOver} end screen takes over from there
+ * (BACKLOG.md #19), whose "play again" drops back to the join screen.
  */
 export default function Lobby() {
   const lobby = useLobby();
   const { game, playerId, error, pending } = lobby;
+
+  // Latch the server's end-of-game summary for the current room. When it lands
+  // (last hider caught, or the timer ran out) the game-over screen takes over —
+  // regardless of the roster's terminal status, since the `game_over` broadcast
+  // is what carries the summary the end screen renders.
+  const summary = useGameOver(game?.id ?? null);
 
   if (!game) {
     return (
@@ -325,6 +335,10 @@ export default function Lobby() {
         error={error}
       />
     );
+  }
+
+  if (summary && summary.gameId === game.id) {
+    return <GameOver summary={summary} onPlayAgain={lobby.leave} />;
   }
 
   if (game.status === 'active') {


### PR DESCRIPTION
Implements #19 — the post-game / end screen (mockup screen 07).

## What it does

When the server ends a match it broadcasts `game_over` with the summary payload (already wired server-side in #15). The client now listens for it: a new `useGameOver` hook latches the summary for the current room, and the `Lobby` screen-router hands off to the new `GameOver` screen once it arrives. **Play again** drops back to the join screen for a rematch.

The screen mirrors the mockup's language:

- **Win banner** — `MATCH OVER` eyebrow + big glowing headline, tinted teal for a hiders win / red for a hunters win, with a one-line outcome (e.g. *"2 survived the full 25:00"* / *"All hiders caught in 12:34"*).
- **Headline stats** — three tiles: **CATCHES**, **SURVIVORS**, **TOP TIME** (survival time + catches, per the issue).
- **Survival board** — a bar per hider (longest first), teal if they survived, red if caught, with their time.
- **Actions** — **Share result** (native share sheet → clipboard fallback, same pattern as the lobby room-code chip) and **Play again**.

## Deliberate divergences from the mockup

The mockup's third tile is DISTANCE and it has an animated replay scrubber. The server doesn't stream per-player distance or position history to the client — movement replay is separately tracked as #25 (M3). Rather than fabricate that data in the UI, I used **SURVIVORS** for the third tile and a **survival board** (real per-hider survival times) for the panel, in the mockup's grid-panel style. The share button shares a text result and is labelled "Share result" rather than "Share replay" for the same honesty reason.

## Screens

| Hiders win | Hunters win |
| --- | --- |
| teal banner, survivors + top time | red banner, 0 survivors |

(Rendered from the real component CSS at phone width; both match the mockup.)

## Tests

- **20 new client unit tests** — `summary` helpers, the `useGameOver` hook, and the `GameOver` component (banner variants, stats, board, play-again, share/clipboard paths).
- **New e2e** `gameover.spec.ts` drives a full match to `game_over` against the real server and asserts the summary payload.
- `typecheck`, `lint` (ESLint + Stylelint + markdownlint), full unit suite, and all 9 e2e specs pass.

No server changes — the `game_over` contract already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a post-match results screen showing the winning team, match statistics, player survival outcomes, and catch details.
  * Added options to share results or copy a summary, and to play again from the results screen.
  * Results now appear automatically when a match ends.

* **Tests**
  * Added coverage for results rendering, sharing, replay navigation, socket events, and end-to-end match completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->