### PR TITLE
feat(client): installable PWA with an offline app shell (#22)

### DIFF
--- a/client/e2e/pwa.spec.ts
+++ b/client/e2e/pwa.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+
+// These run against the production build served by the real server (see
+// playwright.config.ts), so the generated service worker and web app manifest
+// are live — the same artifacts a browser uses to offer "Install app".
+
+test('exposes an installable web app manifest', async ({ page, request }) => {
+  await page.goto('/');
+
+  const href = await page.getAttribute('link[rel="manifest"]', 'href');
+  expect(href).toBeTruthy();
+
+  const res = await request.get(href!);
+  expect(res.ok()).toBeTruthy();
+
+  const manifest = await res.json();
+  expect(manifest.name).toBe('Manhunt');
+  expect(manifest.display).toBe('standalone');
+  expect(manifest.start_url).toBeTruthy();
+
+  // Installability requires both a 192px and a 512px icon.
+  const sizes: string[] = manifest.icons.map((icon: { sizes: string }) => icon.sizes);
+  expect(sizes).toContain('192x192');
+  expect(sizes).toContain('512x512');
+});
+
+test('registers a service worker that controls the page', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'MANHUNT' })).toBeVisible();
+
+  // clientsClaim() in the generated worker takes control of the open page once
+  // it activates.
+  await page.waitForFunction(() => navigator.serviceWorker?.controller != null, null, {
+    timeout: 15_000,
+  });
+});
+
+test('boots the app shell offline once the worker is installed', async ({ page, context }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'MANHUNT' })).toBeVisible();
+
+  // Wait for the worker to precache the shell and take control.
+  await page.waitForFunction(() => navigator.serviceWorker?.controller != null, null, {
+    timeout: 15_000,
+  });
+
+  // Cut the network and reload: the shell must render from the precache alone.
+  await context.setOffline(true);
+  try {
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'MANHUNT' })).toBeVisible();
+  } finally {
+    await context.setOffline(false);
+  }
+});
+
+test('the offline fallback does not shadow server routes', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(() => navigator.serviceWorker?.controller != null, null, {
+    timeout: 15_000,
+  });
+
+  // A navigation to /health while the worker controls the page must reach the
+  // server (JSON), not be rewritten to the cached app shell by the SPA
+  // navigation fallback. Guards the navigateFallbackDenylist in vite.config.ts.
+  const res = await page.goto('/health');
+  expect(res?.ok()).toBeTruthy();
+  expect(await res?.json()).toEqual({ ok: true });
+});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -56,6 +56,16 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         registerType: 'autoUpdate',
         includeAssets: ['favicon.png', 'apple-touch-icon.png'],
+        workbox: {
+          // The service worker precaches the app shell (built JS/CSS/HTML, the
+          // manifest, and the icons) so the client boots offline, and serves the
+          // cached index.html for navigations (SPA deep links + offline
+          // reloads). Exclude the server's own routes so an installed client
+          // never shadows them with the app shell — mirrors the SPA fallback
+          // denylist in server/app.ts. `/socket.io` requests aren't navigations,
+          // but denylisting keeps the intent explicit.
+          navigateFallbackDenylist: [/^\/health/, /^\/api/, /^\/socket\.io/],
+        },
         manifest: {
           name: 'Manhunt',
           short_name: 'Manhunt',


### PR DESCRIPTION
Closes #22.

## What

Make the client installable with an offline shell.

The client already wired up `vite-plugin-pwa` (web app manifest + an auto-updating service worker registered in `main.tsx`). This PR hardens and verifies that setup so it behaves as a genuinely installable, offline-capable app shell.

## Changes

- **Service worker navigation fallback denylist** (`client/vite.config.ts`): the generated worker serves the cached `index.html` for navigations (SPA deep links + offline reloads). It now excludes the server's own routes — `/health`, `/api`, `/socket.io` — so an installed client never shadows them with the app shell. This mirrors the SPA fallback denylist already present in `server/app.ts`.
- **E2E coverage** (`client/e2e/pwa.spec.ts`), running against the production build served by the real server (the same path production uses):
  - a valid, installable web app manifest is linked and served (name, `display: standalone`, `start_url`, and both 192px + 512px icons);
  - the service worker registers and takes control of the page;
  - the app shell boots **offline** from the precache after the network is cut;
  - a navigation to `/health` while the worker controls the page still reaches the server (JSON), guarding the denylist.

## Verification

- `npm run build` → generateSW precaches 10 entries (app shell + manifest + icons); the emitted `sw.js` registers the navigation route with the `/health`, `/api`, `/socket.io` denylist.
- `npm run typecheck`, `npm run lint`, `npm run test:client` (100 passing), and the full Playwright e2e suite (13 passing, including the 4 new PWA specs) all green.

## Notes

No new dependencies — this builds on the existing `vite-plugin-pwa` and generated icons in `client/public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X15EKFC6cSdpbS5Kvg3pLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X15EKFC6cSdpbS5Kvg3pLB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved offline support so the app shell remains available when connectivity is lost.
  * Added PWA validation for installability, manifest metadata, icons, and service worker control.

* **Bug Fixes**
  * Preserved server responses for health checks, API requests, and real-time connection routes instead of applying offline page fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->