### PR TITLE
feat: reconnect handling + last-known position on signal loss

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ PING_INTERVAL_S=180
 POSITION_CADENCE_S=8
 # How long a match runs before the hiders win by surviving the timer (BACKLOG #15).
 GAME_DURATION_S=1800
+# How long a dropped player keeps their slot mid-match so an auto-reconnecting
+# client can `resume` the same identity (BACKLOG #24). Set 0 to drop immediately.
+DISCONNECT_GRACE_S=30

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | Event | Payload | Ack | Notes |
 | --- | --- | --- | --- |
 | `join` | `{ gameId }` | `{ ok }` | Subscribe the socket to a game's broadcasts. |
-| `resume` | `{ gameId, playerId }` | `{ ok, game, playerId }` / error | Reclaim a membership after a reconnect. A dropped socket auto-reconnects as a fresh socket; `resume` re-binds its authoritative identity (so its `position_update`/`claim_catch` are accepted again) if the player's slot is still held by the disconnect grace period, and re-seeds the live view. Rejected (`code: player_not_found`) once the grace has elapsed or the room is gone. |
+| `resume` | `{ gameId, playerId, resumeToken }` | `{ ok, game, playerId }` / error | Reclaim a membership after a reconnect. A dropped socket auto-reconnects as a fresh socket; `resume` re-binds its authoritative identity (so its `position_update`/`claim_catch` are accepted again) if the player's slot is still held by the disconnect grace period, and re-seeds the live view. The `resumeToken` is the per-session secret the server minted at create/join (returned in that ack) — since `playerId` is public in the roster, the token is what authenticates the claim. Rejected when the token is wrong or the player isn't mid-reconnect (`resume_denied`), once the grace has elapsed (`player_not_found`), or if the match already ended (`game_ended`). |
 | `position_update` | `{ gameId, playerId, lat, lng }` | — | One location tick. `lat`/`lng` are validated to WGS84 bounds; the server stamps the authoritative `recordedAt` and the tick engine drops fixes that imply an impossible speed (teleport/GPS spoof). Malformed or implausible ticks are dropped silently. |
 | `claim_catch` | `{ gameId, hunterId, targetId }` | `{ ok, catch }` / `{ ok:false, error, code }` | A hunter claims a catch (`targetId` must differ from `hunterId`). The server verifies the two are within the catch radius from its own positions; an out-of-range claim is rejected (`code: out_of_range`) and a confirmed one flips the caught hider to a hunter. |
 | `set_boundary` | `{ boundary: { center: { lat, lng }, radiusM } }` | `{ ok, game, playerId }` / error | Host-only: define the circular play area the rules engine geofences against. `radiusM` is bounded to a sane range. |
@@ -220,13 +220,18 @@ live map keeps every player's **last-known position** on screen — dimmed, behi
 "showing last-known positions" banner — rather than blanking. Because a reconnect
 arrives as a brand-new socket the server has dropped from the room, a bare
 re-`join` would restore broadcasts but not identity, so the client emits `resume`
-to re-bind its authoritative `playerId`. The server holds a mid-match player's
-slot for a grace period (`DISCONNECT_GRACE_S`, default 30 s): a `resume` inside
-that window cancels the pending removal, re-seeds the client's live view, and
-restores its ability to send ticks and claim catches; if the grace elapses first,
-the player is dropped as on any disconnect. In the lobby (before start) a
-disconnect still drops the player immediately — there's no in-flight match to
-preserve.
+to re-bind its authoritative `playerId` — proven with the per-session
+**resume token** the server minted at create/join (the roster exposes the
+`playerId` to every member, so the token, not the id, authenticates the claim).
+The server holds a mid-match player's slot for a grace period
+(`DISCONNECT_GRACE_S`, default 30 s): a `resume` inside that window — with a
+matching token, and only while a grace removal is actually pending, so a token
+can't seize a live session — cancels the pending removal, re-seeds the client's
+live view, and restores its ability to send ticks and claim catches. If the grace
+elapses first the player is dropped as on any disconnect, and a `resume` into an
+already-ended match is rejected so the client resets rather than showing a stale
+screen. In the lobby (before start) a disconnect still drops the player
+immediately — there's no in-flight match to preserve.
 
 ### Web Push notifications
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ is rejected (with an error ack where the event acks) and never mutates state.
 | Event | Payload | Ack | Notes |
 | --- | --- | --- | --- |
 | `join` | `{ gameId }` | `{ ok }` | Subscribe the socket to a game's broadcasts. |
+| `resume` | `{ gameId, playerId }` | `{ ok, game, playerId }` / error | Reclaim a membership after a reconnect. A dropped socket auto-reconnects as a fresh socket; `resume` re-binds its authoritative identity (so its `position_update`/`claim_catch` are accepted again) if the player's slot is still held by the disconnect grace period, and re-seeds the live view. Rejected (`code: player_not_found`) once the grace has elapsed or the room is gone. |
 | `position_update` | `{ gameId, playerId, lat, lng }` | — | One location tick. `lat`/`lng` are validated to WGS84 bounds; the server stamps the authoritative `recordedAt` and the tick engine drops fixes that imply an impossible speed (teleport/GPS spoof). Malformed or implausible ticks are dropped silently. |
 | `claim_catch` | `{ gameId, hunterId, targetId }` | `{ ok, catch }` / `{ ok:false, error, code }` | A hunter claims a catch (`targetId` must differ from `hunterId`). The server verifies the two are within the catch radius from its own positions; an out-of-range claim is rejected (`code: out_of_range`) and a confirmed one flips the caught hider to a hunter. |
 | `set_boundary` | `{ boundary: { center: { lat, lng }, radiusM } }` | `{ ok, game, playerId }` / error | Host-only: define the circular play area the rules engine geofences against. `radiusM` is bounded to a sane range. |
@@ -211,6 +212,21 @@ duration elapses with a hider still free (the hiders win, `timer`, over
 with a summary — winner, reason, span, every catch, and each hider's survival
 time — the payload the end screen renders, per
 [`BACKLOG.md`](./BACKLOG.md) #15. See `docs/arc42.md` §6 for the runtime view.
+
+**Reconnect handling** ([`BACKLOG.md`](./BACKLOG.md) #24) keeps a match playable
+across the signal loss a phone in the field will hit. The client's socket
+auto-reconnects (capped, jittered backoff, never gives up); until it is back, the
+live map keeps every player's **last-known position** on screen — dimmed, behind a
+"showing last-known positions" banner — rather than blanking. Because a reconnect
+arrives as a brand-new socket the server has dropped from the room, a bare
+re-`join` would restore broadcasts but not identity, so the client emits `resume`
+to re-bind its authoritative `playerId`. The server holds a mid-match player's
+slot for a grace period (`DISCONNECT_GRACE_S`, default 30 s): a `resume` inside
+that window cancels the pending removal, re-seeds the client's live view, and
+restores its ability to send ticks and claim catches; if the grace elapses first,
+the player is dropped as on any disconnect. In the lobby (before start) a
+disconnect still drops the player immediately — there's no in-flight match to
+preserve.
 
 ### Web Push notifications
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -108,3 +108,7 @@
 .status__dot--off {
   background: #caa23a;
 }
+
+.status__dot--offline {
+  background: var(--red);
+}

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -4,25 +4,25 @@ import App from './App.tsx';
 
 // Fake Socket.IO client so the unit test never opens a real connection.
 const { fakeSocket, handlers } = vi.hoisted(() => {
-  const handlers: Record<string, Array<() => void>> = {};
+  const handlers: Record<string, Array<(arg?: unknown) => void>> = {};
   const fakeSocket = {
     connected: false,
-    on(event: string, cb: () => void) {
+    on(event: string, cb: (arg?: unknown) => void) {
       (handlers[event] ||= []).push(cb);
     },
-    off(event: string, cb: () => void) {
+    off(event: string, cb: (arg?: unknown) => void) {
       handlers[event] = (handlers[event] || []).filter((f) => f !== cb);
     },
-    emitLocal(event: string) {
-      (handlers[event] || []).forEach((f) => f());
+    emitLocal(event: string, arg?: unknown) {
+      (handlers[event] || []).forEach((f) => f(arg));
     },
     connect: vi.fn(() => {
       fakeSocket.connected = true;
       fakeSocket.emitLocal('connect');
     }),
-    disconnect: vi.fn(() => {
+    disconnect: vi.fn((reason?: unknown) => {
       fakeSocket.connected = false;
-      fakeSocket.emitLocal('disconnect');
+      fakeSocket.emitLocal('disconnect', reason);
     }),
   };
   return { fakeSocket, handlers };
@@ -56,13 +56,23 @@ describe('<App />', () => {
     expect(screen.getByTestId('status-dot')).toHaveClass('status__dot--on');
   });
 
-  it('reflects a dropped connection', () => {
+  it('reflects a recoverable drop as reconnecting', () => {
     render(<App />);
     act(() => {
-      fakeSocket.disconnect();
+      // A transport drop (no terminal reason) — the socket auto-reconnects.
+      fakeSocket.disconnect('transport close');
     });
-    expect(screen.getByRole('status')).toHaveTextContent('Connecting');
+    expect(screen.getByRole('status')).toHaveTextContent('Reconnecting');
     expect(screen.getByTestId('status-dot')).toHaveClass('status__dot--off');
+  });
+
+  it('reflects a server-forced close as offline', () => {
+    render(<App />);
+    act(() => {
+      fakeSocket.disconnect('io server disconnect');
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Offline');
+    expect(screen.getByTestId('status-dot')).toHaveClass('status__dot--offline');
   });
 
   it('disconnects on unmount', () => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,42 +1,48 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { socket } from './socket.ts';
+import { useConnection, type ConnectionStatus } from './useConnection.ts';
 import Lobby from './lobby/Lobby.tsx';
 import './App.css';
 
+/** The status dot's tone and label for each connection state. */
+function statusLabel(status: ConnectionStatus): { tone: 'on' | 'off' | 'offline'; text: string } {
+  switch (status) {
+    case 'connected':
+      return { tone: 'on', text: 'Connected to server' };
+    case 'reconnecting':
+      return { tone: 'off', text: 'Reconnecting…' };
+    default:
+      return { tone: 'offline', text: 'Offline' };
+  }
+}
+
 /**
  * Landing shell for the Manhunt PWA. It wires up the Socket.IO connection,
- * surfaces its live status, and hosts the {@link Lobby} (create/join a room,
- * pick a side, ready up, start). The in-game map screen is tracked in the
- * backlog.
+ * surfaces its live status — connected, auto-reconnecting after a signal loss,
+ * or offline (BACKLOG.md #24) — and hosts the {@link Lobby} (create/join a room,
+ * pick a side, ready up, start).
  */
 export default function App() {
-  const [connected, setConnected] = useState(socket.connected);
+  const status = useConnection(socket);
 
   useEffect(() => {
-    const onConnect = () => setConnected(true);
-    const onDisconnect = () => setConnected(false);
-
-    socket.on('connect', onConnect);
-    socket.on('disconnect', onDisconnect);
+    // The socket auto-reconnects on its own (see socket.ts); we just open it on
+    // mount and close it on unmount.
     socket.connect();
-
     return () => {
-      socket.off('connect', onConnect);
-      socket.off('disconnect', onDisconnect);
       socket.disconnect();
     };
   }, []);
+
+  const { tone, text } = statusLabel(status);
 
   return (
     <main className="app">
       <Lobby />
 
       <p className="status" role="status">
-        <span
-          className={`status__dot ${connected ? 'status__dot--on' : 'status__dot--off'}`}
-          data-testid="status-dot"
-        />
-        {connected ? 'Connected to server' : 'Connecting…'}
+        <span className={`status__dot status__dot--${tone}`} data-testid="status-dot" />
+        {text}
       </p>
     </main>
   );

--- a/client/src/game/ActiveGame.css
+++ b/client/src/game/ActiveGame.css
@@ -203,3 +203,44 @@
 .match .lobby-leave {
   align-self: center;
 }
+
+/* Signal-loss banner: a top strip that flags the map as last-known while the
+   socket is dropped (BACKLOG.md #24). */
+.match__signal {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  background: rgb(224 179 65 / 12%);
+  border: 1px solid rgb(224 179 65 / 35%);
+  color: #e0b341;
+  font-size: 0.82rem;
+}
+
+.match__signal-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: #e0b341;
+  animation: signal-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes signal-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .match__signal-dot {
+    animation: none;
+  }
+}

--- a/client/src/game/ActiveGame.test.tsx
+++ b/client/src/game/ActiveGame.test.tsx
@@ -4,10 +4,25 @@ import userEvent from '@testing-library/user-event';
 import ActiveGame from './ActiveGame.tsx';
 import type { Game } from '../lobby/types.ts';
 
-// Fake the shared socket so no real connection opens and we can assert emits.
-const { fakeSocket } = vi.hoisted(() => ({
-  fakeSocket: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
-}));
+// Fake the shared socket so no real connection opens and we can assert emits and
+// drive connection lifecycle events (connect/disconnect) by hand.
+const { fakeSocket, handlers } = vi.hoisted(() => {
+  const handlers: Record<string, Array<(arg?: unknown) => void>> = {};
+  const fakeSocket = {
+    connected: true,
+    emit: vi.fn(),
+    on(event: string, cb: (arg?: unknown) => void) {
+      (handlers[event] ||= []).push(cb);
+    },
+    off(event: string, cb: (arg?: unknown) => void) {
+      handlers[event] = (handlers[event] || []).filter((f) => f !== cb);
+    },
+    emitLocal(event: string, arg?: unknown) {
+      (handlers[event] || []).forEach((f) => f(arg));
+    },
+  };
+  return { fakeSocket, handlers };
+});
 vi.mock('../socket.ts', () => ({
   socket: fakeSocket,
   createSocket: () => fakeSocket,
@@ -62,6 +77,8 @@ function game(overrides: Partial<Game> = {}): Game {
 
 beforeEach(() => {
   fakeSocket.emit.mockClear();
+  fakeSocket.connected = true;
+  for (const key of Object.keys(handlers)) delete handlers[key];
   success = null;
   watchPosition.mockClear();
   clearWatch.mockClear();
@@ -122,5 +139,29 @@ describe('<ActiveGame />', () => {
     render(<ActiveGame game={game()} playerId="p1" onLeave={onLeave} />);
     await userEvent.click(screen.getByRole('button', { name: /leave/i }));
     expect(onLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a last-known-position banner and dims the map on signal loss', () => {
+    render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
+    // Connected: no banner, live map.
+    expect(screen.queryByText(/last-known positions/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('game-map')).not.toHaveClass('game-map--stale');
+
+    // A recoverable drop — the map freezes on the last-known fixes while the
+    // socket auto-reconnects.
+    act(() => {
+      fakeSocket.connected = false;
+      fakeSocket.emitLocal('disconnect', 'transport close');
+    });
+    expect(screen.getByText(/signal lost — showing last-known positions/i)).toBeInTheDocument();
+    expect(screen.getByTestId('game-map')).toHaveClass('game-map--stale');
+
+    // Reconnected: the banner clears and the map goes live again.
+    act(() => {
+      fakeSocket.connected = true;
+      fakeSocket.emitLocal('connect');
+    });
+    expect(screen.queryByText(/last-known positions/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('game-map')).not.toHaveClass('game-map--stale');
   });
 });

--- a/client/src/game/ActiveGame.test.tsx
+++ b/client/src/game/ActiveGame.test.tsx
@@ -164,4 +164,17 @@ describe('<ActiveGame />', () => {
     expect(screen.queryByText(/last-known positions/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('game-map')).not.toHaveClass('game-map--stale');
   });
+
+  it('shows the offline copy on a terminal disconnect and keeps the map stale', () => {
+    render(<ActiveGame game={game()} playerId="p1" onLeave={() => {}} />);
+
+    // A server-forced close won't auto-reconnect — the map stays stale behind the
+    // offline copy.
+    act(() => {
+      fakeSocket.connected = false;
+      fakeSocket.emitLocal('disconnect', 'io server disconnect');
+    });
+    expect(screen.getByText(/offline — showing last-known positions/i)).toBeInTheDocument();
+    expect(screen.getByTestId('game-map')).toHaveClass('game-map--stale');
+  });
 });

--- a/client/src/game/ActiveGame.tsx
+++ b/client/src/game/ActiveGame.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { socket } from '../socket.ts';
+import { useConnection, type ConnectionStatus } from '../useConnection.ts';
 import { useTracking } from '../gps/useTracking.ts';
 import type { GpsStatus } from '../gps/useGpsCapture.ts';
 import type { Game, Role } from '../lobby/types.ts';
@@ -93,6 +94,8 @@ export default function ActiveGame({
     socket,
   });
   const { positions, revealSeq } = useLivePositions(game.id, socket);
+  const connection = useConnection(socket);
+  const online = connection === 'connected';
   const now = useNow();
 
   const lat = tracking.last?.lat ?? null;
@@ -213,6 +216,8 @@ export default function ActiveGame({
 
   return (
     <div className="match">
+      <SignalBanner status={connection} />
+
       {myRole === 'hunter' ? (
         <MatchHud
           role="hunter"
@@ -236,6 +241,7 @@ export default function ActiveGame({
         boundary={boundary}
         alertRing={alertRing}
         revealRing={revealRing}
+        stale={!online}
       />
 
       <ProximityAlert role={myRole} near={alert} />
@@ -257,6 +263,26 @@ export default function ActiveGame({
         Leave
       </button>
     </div>
+  );
+}
+
+/**
+ * The connection banner shown across the top of a live match when the socket
+ * drops (BACKLOG.md #24). The map keeps every player's last-known position on
+ * screen — the live view is retained across a drop, it just stops updating — so
+ * the banner's job is to say the fixes are now stale and whether we're getting
+ * back. Renders nothing while connected.
+ */
+function SignalBanner({ status }: { status: ConnectionStatus }) {
+  if (status === 'connected') return null;
+  const reconnecting = status === 'reconnecting';
+  return (
+    <p className="match__signal" role="status">
+      <span className="match__signal-dot" aria-hidden="true" />
+      {reconnecting
+        ? 'Signal lost — showing last-known positions. Reconnecting…'
+        : 'Offline — showing last-known positions.'}
+    </p>
   );
 }
 

--- a/client/src/game/GameMap.css
+++ b/client/src/game/GameMap.css
@@ -80,3 +80,11 @@
 .game-map .maplibregl-ctrl-attrib {
   font-size: 0.65rem;
 }
+
+/* Signal lost: the pins are last-known, not live. Desaturate and dim the map so
+   a frozen position doesn't read as a fresh one (BACKLOG.md #24). */
+.game-map--stale .maplibregl-canvas,
+.game-map--stale .map-pin {
+  filter: grayscale(45%) brightness(0.8);
+  transition: filter 0.3s ease;
+}

--- a/client/src/game/GameMap.tsx
+++ b/client/src/game/GameMap.tsx
@@ -70,6 +70,12 @@ export interface GameMapProps {
   alertRing?: BoundaryCircle | null;
   /** A reveal-radius ring to draw around the player (hider view), or `null`. */
   revealRing?: BoundaryCircle | null;
+  /**
+   * Dim the map to signal the fixes are last-known, not live — set while the
+   * socket is dropped so a hunter/hider doesn't mistake a frozen position for a
+   * fresh one (BACKLOG.md #24).
+   */
+  stale?: boolean;
 }
 
 /** Build (or refresh) the DOM element MapLibre uses for a marker. */
@@ -110,6 +116,7 @@ export default function GameMap({
   boundary,
   alertRing = null,
   revealRing = null,
+  stale = false,
 }: GameMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
@@ -246,5 +253,11 @@ export default function GameMap({
     }
   }, [markers]);
 
-  return <div ref={containerRef} className="game-map" data-testid="game-map" />;
+  return (
+    <div
+      ref={containerRef}
+      className={`game-map${stale ? ' game-map--stale' : ''}`}
+      data-testid="game-map"
+    />
+  );
 }

--- a/client/src/lobby/types.ts
+++ b/client/src/lobby/types.ts
@@ -26,7 +26,7 @@ export interface Game {
 
 /** Ack returned by every lobby action. */
 export type LobbyAck =
-  | { ok: true; game: Game; playerId: string }
+  | { ok: true; game: Game; playerId: string; resumeToken?: string }
   | { ok: false; error: string; code?: string };
 
 /** Payload of the server's `lobby_update` broadcast. */

--- a/client/src/lobby/useLobby.test.ts
+++ b/client/src/lobby/useLobby.test.ts
@@ -54,9 +54,9 @@ describe('useLobby reconnect handling', () => {
     expect(fake.socket.emitWithAck).not.toHaveBeenCalledWith('resume', expect.anything());
   });
 
-  it('resumes the membership and refreshes the roster on reconnect', async () => {
+  it('resumes with the session token and refreshes the roster on reconnect', async () => {
     const fake = fakeSocket();
-    fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1' });
+    fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1', resumeToken: 'tok' });
     const { result } = renderHook(() => useLobby(fake.socket));
 
     await act(async () => {
@@ -80,6 +80,7 @@ describe('useLobby reconnect handling', () => {
       expect(fake.socket.emitWithAck).toHaveBeenCalledWith('resume', {
         gameId: 'g1',
         playerId: 'p1',
+        resumeToken: 'tok',
       });
     });
     await waitFor(() => {
@@ -87,9 +88,19 @@ describe('useLobby reconnect handling', () => {
     });
   });
 
-  it('keeps the last-known room when a resume is rejected', async () => {
+  it('does not resume without a session token', () => {
     const fake = fakeSocket();
+    // An ack without a resumeToken (e.g. a non-minting action) leaves nothing to
+    // authenticate a resume with, so we never attempt one.
     fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1' });
+    renderHook(() => useLobby(fake.socket));
+    fake.fire('connect');
+    expect(fake.socket.emitWithAck).not.toHaveBeenCalledWith('resume', expect.anything());
+  });
+
+  it('keeps the last-known room when a resume is rejected as already gone', async () => {
+    const fake = fakeSocket();
+    fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1', resumeToken: 'tok' });
     const { result } = renderHook(() => useLobby(fake.socket));
 
     await act(async () => {
@@ -105,8 +116,27 @@ describe('useLobby reconnect handling', () => {
       expect(fake.socket.emitWithAck).toHaveBeenCalledWith('resume', {
         gameId: 'g1',
         playerId: 'p1',
+        resumeToken: 'tok',
       });
     });
     expect(result.current.game?.id).toBe('g1');
+  });
+
+  it('resets to the join screen when the game ended while away', async () => {
+    const fake = fakeSocket();
+    fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1', resumeToken: 'tok' });
+    const { result } = renderHook(() => useLobby(fake.socket));
+
+    await act(async () => {
+      await result.current.createGame('Ada');
+    });
+
+    fake.setAck('resume', { ok: false, error: 'That game has ended', code: 'game_ended' });
+    fake.fire('connect');
+
+    await waitFor(() => {
+      expect(result.current.game).toBeNull();
+    });
+    expect(result.current.playerId).toBeNull();
   });
 });

--- a/client/src/lobby/useLobby.test.ts
+++ b/client/src/lobby/useLobby.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { useLobby } from './useLobby.ts';
+import type { Game } from './types.ts';
+
+function baseGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: 'g1',
+    roomCode: 'AB2C',
+    status: 'active',
+    players: [
+      { id: 'p1', name: 'Ada', role: 'hunter', ready: true, isHost: true },
+      { id: 'p2', name: 'Rui', role: 'hider', ready: true, isHost: false },
+    ],
+    createdAt: '2026-07-21T00:00:00.000Z',
+    startedAt: '2026-07-21T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** A fake socket with per-event acks and hand-driven lifecycle events. */
+function fakeSocket() {
+  const handlers = new Map<string, (arg?: unknown) => void>();
+  const acks = new Map<string, unknown>();
+  const socket = {
+    emit: vi.fn(),
+    emitWithAck: vi.fn((event: string) => Promise.resolve(acks.get(event))),
+    on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+      handlers.set(event, cb);
+    }),
+    off: vi.fn((event: string) => {
+      handlers.delete(event);
+    }),
+  };
+  return {
+    socket: socket as unknown as Socket & { emitWithAck: ReturnType<typeof vi.fn> },
+    setAck(event: string, value: unknown) {
+      acks.set(event, value);
+    },
+    fire(event: string, arg?: unknown) {
+      act(() => handlers.get(event)?.(arg));
+    },
+  };
+}
+
+afterEach(() => cleanup());
+
+describe('useLobby reconnect handling', () => {
+  it('does not resume before a room has been joined', () => {
+    const fake = fakeSocket();
+    renderHook(() => useLobby(fake.socket));
+    fake.fire('connect');
+    expect(fake.socket.emitWithAck).not.toHaveBeenCalledWith('resume', expect.anything());
+  });
+
+  it('resumes the membership and refreshes the roster on reconnect', async () => {
+    const fake = fakeSocket();
+    fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1' });
+    const { result } = renderHook(() => useLobby(fake.socket));
+
+    await act(async () => {
+      await result.current.createGame('Ada');
+    });
+    expect(result.current.game?.id).toBe('g1');
+
+    // While we were away the host reassigned — the resume ack carries the fresh
+    // roster the hook should adopt.
+    const refreshed = baseGame({
+      players: [
+        { id: 'p1', name: 'Ada', role: 'hunter', ready: true, isHost: true },
+        { id: 'p3', name: 'Mo', role: 'hider', ready: true, isHost: false },
+      ],
+    });
+    fake.setAck('resume', { ok: true, game: refreshed, playerId: 'p1' });
+
+    fake.fire('connect');
+
+    await waitFor(() => {
+      expect(fake.socket.emitWithAck).toHaveBeenCalledWith('resume', {
+        gameId: 'g1',
+        playerId: 'p1',
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.game?.players.map((p) => p.id)).toEqual(['p1', 'p3']);
+    });
+  });
+
+  it('keeps the last-known room when a resume is rejected', async () => {
+    const fake = fakeSocket();
+    fake.setAck('create_game', { ok: true, game: baseGame(), playerId: 'p1' });
+    const { result } = renderHook(() => useLobby(fake.socket));
+
+    await act(async () => {
+      await result.current.createGame('Ada');
+    });
+
+    // The slot was already released (grace elapsed): the resume fails, and we
+    // hold the last-known room rather than yanking the player to the join screen.
+    fake.setAck('resume', { ok: false, error: 'gone', code: 'player_not_found' });
+    fake.fire('connect');
+
+    await waitFor(() => {
+      expect(fake.socket.emitWithAck).toHaveBeenCalledWith('resume', {
+        gameId: 'g1',
+        playerId: 'p1',
+      });
+    });
+    expect(result.current.game?.id).toBe('g1');
+  });
+});

--- a/client/src/lobby/useLobby.ts
+++ b/client/src/lobby/useLobby.ts
@@ -31,6 +31,10 @@ export interface Lobby {
 export function useLobby(socket: Socket = defaultSocket): Lobby {
   const [game, setGame] = useState<Game | null>(null);
   const [playerId, setPlayerId] = useState<string | null>(null);
+  // The per-session secret the server minted at create/join; presented to
+  // `resume` after a reconnect so the server can prove we're the same player and
+  // not just a room member who has seen our (public) id (BACKLOG.md #24).
+  const [resumeToken, setResumeToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
@@ -56,22 +60,35 @@ export function useLobby(socket: Socket = defaultSocket): Lobby {
   // latest ids without re-subscribing the handler on every roster change.
   const gameRef = useRef(game);
   const playerIdRef = useRef(playerId);
+  const resumeTokenRef = useRef(resumeToken);
   useEffect(() => {
     gameRef.current = game;
     playerIdRef.current = playerId;
-  }, [game, playerId]);
+    resumeTokenRef.current = resumeToken;
+  }, [game, playerId, resumeToken]);
   useEffect(() => {
     const onConnect = (): void => {
       const current = gameRef.current;
       const id = playerIdRef.current;
-      if (!current || !id) return;
+      const token = resumeTokenRef.current;
+      if (!current || !id || !token) return;
       void socket
-        .emitWithAck('resume', { gameId: current.id, playerId: id })
+        .emitWithAck('resume', { gameId: current.id, playerId: id, resumeToken: token })
         .then((ack: LobbyAck) => {
-          // Only adopt the refreshed roster if we're still in the same game; if
-          // the slot was already gone (grace elapsed) the server rejects it and
-          // we keep the last-known state on screen for the player to leave from.
-          if (ack.ok) setGame((cur) => (cur && cur.id === ack.game.id ? ack.game : cur));
+          if (ack.ok) {
+            // Only adopt the refreshed roster if we're still in the same game.
+            setGame((cur) => (cur && cur.id === ack.game.id ? ack.game : cur));
+            return;
+          }
+          // The match ended while we were away (we missed `game_over`): reset to
+          // the join screen rather than sit on a stale, over match. Any other
+          // rejection (the slot was already released) leaves the last-known state
+          // on screen for the player to leave from.
+          if (ack.code === 'game_ended') {
+            setGame(null);
+            setPlayerId(null);
+            setResumeToken(null);
+          }
         })
         .catch(() => {
           // Transient — the socket will fire `connect` again on the next retry.
@@ -92,6 +109,7 @@ export function useLobby(socket: Socket = defaultSocket): Lobby {
         if (ack.ok) {
           setGame(ack.game);
           setPlayerId(ack.playerId);
+          setResumeToken(ack.resumeToken ?? null);
         } else {
           setError(ack.error);
         }
@@ -139,6 +157,7 @@ export function useLobby(socket: Socket = defaultSocket): Lobby {
     socket.emit('leave_game');
     setGame(null);
     setPlayerId(null);
+    setResumeToken(null);
     setError(null);
   }, [socket]);
 

--- a/client/src/lobby/useLobby.ts
+++ b/client/src/lobby/useLobby.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Socket } from 'socket.io-client';
 import { socket as defaultSocket } from '../socket.ts';
 import type { Game, LobbyAck, LobbyUpdate, Role } from './types.ts';
@@ -43,6 +43,43 @@ export function useLobby(socket: Socket = defaultSocket): Lobby {
     socket.on('lobby_update', onUpdate);
     return () => {
       socket.off('lobby_update', onUpdate);
+    };
+  }, [socket]);
+
+  // Reclaim our membership after a reconnect (BACKLOG.md #24). A dropped socket
+  // auto-reconnects as a fresh socket the server has dropped from the room, so
+  // its `position_update`/`claim_catch` would be ignored until we re-identify.
+  // On every `connect` after we've joined a room, `resume` re-binds our identity
+  // (the server held our slot through its grace period) and refreshes the roster
+  // — which may have changed while we were away (e.g. the host reassigned). The
+  // very first connect predates any membership, so it's a no-op. Refs keep the
+  // latest ids without re-subscribing the handler on every roster change.
+  const gameRef = useRef(game);
+  const playerIdRef = useRef(playerId);
+  useEffect(() => {
+    gameRef.current = game;
+    playerIdRef.current = playerId;
+  }, [game, playerId]);
+  useEffect(() => {
+    const onConnect = (): void => {
+      const current = gameRef.current;
+      const id = playerIdRef.current;
+      if (!current || !id) return;
+      void socket
+        .emitWithAck('resume', { gameId: current.id, playerId: id })
+        .then((ack: LobbyAck) => {
+          // Only adopt the refreshed roster if we're still in the same game; if
+          // the slot was already gone (grace elapsed) the server rejects it and
+          // we keep the last-known state on screen for the player to leave from.
+          if (ack.ok) setGame((cur) => (cur && cur.id === ack.game.id ? ack.game : cur));
+        })
+        .catch(() => {
+          // Transient — the socket will fire `connect` again on the next retry.
+        });
+    };
+    socket.on('connect', onConnect);
+    return () => {
+      socket.off('connect', onConnect);
     };
   }, [socket]);
 

--- a/client/src/socket.ts
+++ b/client/src/socket.ts
@@ -10,11 +10,27 @@ import {
 // `VITE_SERVER_URL` can override the target (e.g. a separate API host).
 const URL: string | undefined = import.meta.env.VITE_SERVER_URL || undefined;
 
+/**
+ * Auto-reconnect tuning for a phone on a flaky mobile signal (BACKLOG.md #24).
+ * Socket.IO reconnects by default; we make the intent explicit and never give up
+ * (`reconnectionAttempts: Infinity`) — a match can outlast a dead spot, and the
+ * server holds a dropped player's slot for a grace period so a late reconnect can
+ * still `resume`. The capped, jittered backoff keeps a herd of clients from all
+ * retrying in lockstep when a shared network flaps.
+ */
+export const RECONNECTION_OPTIONS = {
+  reconnection: true,
+  reconnectionAttempts: Infinity,
+  reconnectionDelay: 1_000,
+  reconnectionDelayMax: 5_000,
+  randomizationFactor: 0.5,
+} as const satisfies Partial<ManagerOptions>;
+
 export function createSocket(
   url: string | undefined = URL,
   opts: Partial<ManagerOptions & SocketOptions> = {},
 ): Socket {
-  return io(url, { autoConnect: false, ...opts });
+  return io(url, { autoConnect: false, ...RECONNECTION_OPTIONS, ...opts });
 }
 
 export const socket = createSocket();

--- a/client/src/useConnection.test.ts
+++ b/client/src/useConnection.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { useConnection } from './useConnection.ts';
+
+/** A fake socket that records handlers so a test can drive connect/disconnect. */
+function fakeSocket(connected = false) {
+  const handlers = new Map<string, (payload?: unknown) => void>();
+  const socket = {
+    connected,
+    on(event: string, cb: (payload?: unknown) => void) {
+      handlers.set(event, cb);
+    },
+    off(event: string) {
+      handlers.delete(event);
+    },
+  };
+  return {
+    socket: socket as unknown as Socket,
+    fire(event: string, payload?: unknown) {
+      act(() => handlers.get(event)?.(payload));
+    },
+    setConnected(value: boolean) {
+      socket.connected = value;
+    },
+  };
+}
+
+afterEach(() => cleanup());
+
+describe('useConnection', () => {
+  it('starts reconnecting before the first connect', () => {
+    const fake = fakeSocket(false);
+    const { result } = renderHook(() => useConnection(fake.socket));
+    expect(result.current).toBe('reconnecting');
+  });
+
+  it('starts connected when the socket is already up', () => {
+    const fake = fakeSocket(true);
+    const { result } = renderHook(() => useConnection(fake.socket));
+    expect(result.current).toBe('connected');
+  });
+
+  it('reports connected once the socket connects', () => {
+    const fake = fakeSocket(false);
+    const { result } = renderHook(() => useConnection(fake.socket));
+    fake.fire('connect');
+    expect(result.current).toBe('connected');
+  });
+
+  it('reports reconnecting on a recoverable transport drop', () => {
+    const fake = fakeSocket(true);
+    const { result } = renderHook(() => useConnection(fake.socket));
+    fake.fire('connect');
+    fake.fire('disconnect', 'transport close');
+    expect(result.current).toBe('reconnecting');
+  });
+
+  it('reports offline when the close will not auto-recover', () => {
+    const fake = fakeSocket(true);
+    const { result } = renderHook(() => useConnection(fake.socket));
+    fake.fire('connect');
+    fake.fire('disconnect', 'io server disconnect');
+    expect(result.current).toBe('offline');
+
+    fake.fire('disconnect', 'io client disconnect');
+    expect(result.current).toBe('offline');
+  });
+
+  it('recovers to connected after reconnecting', () => {
+    const fake = fakeSocket(true);
+    const { result } = renderHook(() => useConnection(fake.socket));
+    fake.fire('disconnect', 'ping timeout');
+    expect(result.current).toBe('reconnecting');
+    fake.fire('connect');
+    expect(result.current).toBe('connected');
+  });
+});

--- a/client/src/useConnection.ts
+++ b/client/src/useConnection.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+
+/**
+ * How the client is currently attached to the server:
+ *
+ * - `connected` — the socket is up; live play flows normally.
+ * - `reconnecting` — the transport dropped (a signal loss, a network flap) and
+ *   Socket.IO is auto-retrying. The last-known game state is still on screen; a
+ *   `resume` restores the session once the socket is back (BACKLOG.md #24).
+ * - `offline` — the connection was closed in a way that won't auto-recover: we
+ *   closed it deliberately, or the server forced it. No retry is in flight.
+ */
+export type ConnectionStatus = 'connected' | 'reconnecting' | 'offline';
+
+/**
+ * Socket.IO disconnect reasons that mean *no* automatic reconnect will follow:
+ * the client asked to close (`io client disconnect`) or the server closed the
+ * socket (`io server disconnect`). Every other reason — `transport close`,
+ * `ping timeout`, `transport error` — is a drop the manager retries, which is
+ * exactly the signal-loss case we want to show as "reconnecting".
+ */
+const TERMINAL_DISCONNECT_REASONS = new Set<string>([
+  'io client disconnect',
+  'io server disconnect',
+]);
+
+/**
+ * Track a socket's live connection status for the UI (BACKLOG.md #24). It follows
+ * `connect`/`disconnect`, mapping a recoverable drop to `reconnecting` (the
+ * manager is retrying under the hood) and a deliberate/forced close to `offline`.
+ * The consumer decides what to render — a status dot in the shell, a "showing
+ * last-known position" banner in a live match.
+ */
+export function useConnection(socket: Socket): ConnectionStatus {
+  const [status, setStatus] = useState<ConnectionStatus>(() =>
+    socket.connected ? 'connected' : 'reconnecting',
+  );
+
+  useEffect(() => {
+    const onConnect = (): void => setStatus('connected');
+    const onDisconnect = (reason: string): void => {
+      setStatus(TERMINAL_DISCONNECT_REASONS.has(reason) ? 'offline' : 'reconnecting');
+    };
+
+    socket.on('connect', onConnect);
+    socket.on('disconnect', onDisconnect);
+
+    return () => {
+      socket.off('connect', onConnect);
+      socket.off('disconnect', onDisconnect);
+    };
+  }, [socket]);
+
+  return status;
+}

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -144,6 +144,15 @@ Key game events also reach a player **out of band** through the browser's push s
 
 Web Push is **optional**: `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` are deployment-provided secrets (env / uncommitted `.env`). It is disabled unless **both** are configured — if either is missing the server advertises no key, the client never subscribes, and nothing is pushed. Subscriptions are in-process hot state, like the lobby — durable storage is a later concern.
 
+### 6.7 Reconnect + resume
+
+A phone in the field drops signal. The client's socket **auto-reconnects** on its own (capped, jittered backoff, never gives up), and while it is down the live map keeps every player's **last-known position** on screen — dimmed, behind a "showing last-known positions" banner — rather than blanking.
+
+1. On disconnect during an **active** match the server holds the player's slot for a grace period (`DISCONNECT_GRACE_S`) instead of removing them; a lobby disconnect (before start) still drops immediately.
+2. The transport hands a reconnect a **brand-new socket** the server has dropped from the room, so a bare `join` would restore broadcasts but not identity. The client emits **`resume`** carrying its `playerId` and the per-session **resume token** the server minted at create/join (the roster exposes the playerId to every member, so the token — not the id — authenticates the claim, upholding the "identity is server-authoritative, never from the payload" rule).
+3. The server re-binds identity only when the token matches and a grace removal is actually pending (so a token can't seize a live session), cancels the pending removal, and re-seeds the reconnecting client with the current per-role-filtered `game_state`. Ticks and catches flow again.
+4. If the grace elapsed first (`player_not_found`), or the match ended while the player was away (`game_ended`, they missed the one-shot `game_over`), `resume` is rejected and the client resets accordingly rather than showing a stale screen.
+
 ---
 
 ## 7. Deployment view

--- a/server/app.reconnect.test.ts
+++ b/server/app.reconnect.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { once } from 'node:events';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { io as ioClient, type Socket } from 'socket.io-client';
+import {
+  createServer,
+  type CreateServerOptions,
+  type DisconnectTimerApi,
+  type ServerHandle,
+} from './app.ts';
+import { createLocalBroadcaster, createMemoryPositionStore } from './live/index.ts';
+import { createMemoryLobby, type Game } from './lobby/rooms.ts';
+
+type LobbyAck =
+  | { ok: true; game: Game; playerId: string }
+  | { ok: false; error: string; code?: string };
+
+/**
+ * A controllable disconnect-grace timer: it records pending removals and fires
+ * them on demand, so a test can assert what happens before and after the grace
+ * elapses without waiting on the wall clock.
+ */
+function fakeGraceTimers(): DisconnectTimerApi & { fireAll: () => void; active: () => number } {
+  const handlers = new Set<() => void>();
+  return {
+    setTimeout(handler: () => void) {
+      handlers.add(handler);
+      return handler;
+    },
+    clearTimeout(handle: unknown) {
+      handlers.delete(handle as () => void);
+    },
+    fireAll() {
+      for (const handler of [...handlers]) {
+        handlers.delete(handler);
+        handler();
+      }
+    },
+    active() {
+      return handlers.size;
+    },
+  };
+}
+
+/** Boot the real server on an ephemeral port with in-memory hot state. */
+async function bootServer(
+  options: Partial<CreateServerOptions> = {},
+): Promise<{ handle: ServerHandle; url: string }> {
+  const handle = createServer({
+    staticDir: path.join(os.tmpdir(), 'nope'),
+    liveState: {
+      store: createMemoryPositionStore(),
+      broadcaster: createLocalBroadcaster(),
+      close: () => Promise.resolve(),
+    },
+    lobby: createMemoryLobby(),
+    ...options,
+  });
+  handle.httpServer.listen(0);
+  await once(handle.httpServer, 'listening');
+  const { port } = handle.httpServer.address() as AddressInfo;
+  return { handle, url: `http://127.0.0.1:${port}` };
+}
+
+function connect(url: string): Socket {
+  return ioClient(url, { transports: ['websocket'], reconnection: false });
+}
+
+function waitFor<T = unknown>(socket: Socket, event: string): Promise<T> {
+  return new Promise((resolve) => socket.once(event, (payload: T) => resolve(payload)));
+}
+
+function waitUntil<T = unknown>(
+  socket: Socket,
+  event: string,
+  match: (payload: T) => boolean,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const handler = (payload: T): void => {
+      if (!match(payload)) return;
+      socket.off(event, handler);
+      resolve(payload);
+    };
+    socket.on(event, handler);
+  });
+}
+
+describe('reconnect handling over the socket', () => {
+  let handle: ServerHandle;
+  const clients: Socket[] = [];
+
+  async function open(url: string): Promise<Socket> {
+    const c = connect(url);
+    clients.push(c);
+    await waitFor(c, 'connect');
+    return c;
+  }
+
+  /** Create a room, join a guest, and start the match; returns ids and sockets. */
+  async function startedGame(url: string): Promise<{
+    host: Socket;
+    guest: Socket;
+    gameId: string;
+    guestId: string;
+  }> {
+    const host = await open(url);
+    const guest = await open(url);
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    const joined = (await guest.emitWithAck('join_game', {
+      roomCode: created.game.roomCode,
+      name: 'Guest',
+    })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+    await host.emitWithAck('set_ready', { ready: true });
+    await guest.emitWithAck('set_ready', { ready: true });
+    const started = (await host.emitWithAck('start_game', {})) as LobbyAck;
+    if (!started.ok) throw new Error('start failed');
+    return { host, guest, gameId: created.game.id, guestId: joined.playerId };
+  }
+
+  afterEach(async () => {
+    for (const c of clients.splice(0)) c.close();
+    handle.io.close();
+    handle.httpServer.close();
+    await once(handle.httpServer, 'close');
+    await handle.liveState.close();
+  });
+
+  it('holds a dropped player mid-match through the grace period', async () => {
+    const timers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers });
+    handle = booted.handle;
+    const { guest, gameId, guestId } = await startedGame(booted.url);
+
+    guest.close();
+    // The socket close registers as a disconnect on the server; poll until its
+    // handler has armed the grace timer rather than removed the player outright.
+    await viFlush(() => timers.active() === 1);
+    expect(handle.lobby.get(gameId)?.players.map((p) => p.id)).toContain(guestId);
+
+    // The grace elapses with no resume — now the player is dropped.
+    timers.fireAll();
+    expect(handle.lobby.get(gameId)?.players.map((p) => p.id)).not.toContain(guestId);
+  });
+
+  it('lets a reconnecting client resume its identity within the grace', async () => {
+    const timers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers });
+    handle = booted.handle;
+    const { guest, gameId, guestId } = await startedGame(booted.url);
+
+    guest.close();
+    await viFlush(() => timers.active() === 1);
+
+    // A brand-new socket (as the transport gives a reconnect) reclaims the slot.
+    const reconnected = await open(booted.url);
+    const ack = (await reconnected.emitWithAck('resume', {
+      gameId,
+      playerId: guestId,
+    })) as LobbyAck;
+    expect(ack.ok).toBe(true);
+    if (!ack.ok) throw new Error('expected resume to succeed');
+    expect(ack.game.players.map((p) => p.id)).toContain(guestId);
+    // Resuming cancelled the pending removal, so the grace firing is now a no-op.
+    expect(timers.active()).toBe(0);
+    timers.fireAll();
+    expect(handle.lobby.get(gameId)?.players.map((p) => p.id)).toContain(guestId);
+  });
+
+  it('accepts position updates again once the socket has resumed', async () => {
+    const timers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers });
+    handle = booted.handle;
+    const { guest, gameId, guestId } = await startedGame(booted.url);
+
+    guest.close();
+    await viFlush(() => timers.active() === 1);
+
+    const reconnected = await open(booted.url);
+    const ack = (await reconnected.emitWithAck('resume', { gameId, playerId: guestId })) as LobbyAck;
+    if (!ack.ok) throw new Error('resume failed');
+
+    // A tick is only broadcast if the server accepted it against the socket's
+    // restored membership. The resumed guest is a hider, so its own game_state
+    // carries its position back (a hider sees everyone) — proof the tick landed.
+    const echoed = waitUntil<{ gameId: string; positions: Record<string, unknown> }>(
+      reconnected,
+      'game_state',
+      (p) => Boolean(p.positions[guestId]),
+    );
+    reconnected.emit('position_update', { gameId, playerId: guestId, lat: 52.1, lng: 4.3 });
+    const state = await echoed;
+    expect(state.positions[guestId]).toMatchObject({ lat: 52.1, lng: 4.3 });
+  });
+
+  it('rejects a resume for a player whose slot is already gone', async () => {
+    const timers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers });
+    handle = booted.handle;
+    const { guest, gameId, guestId } = await startedGame(booted.url);
+
+    guest.close();
+    await viFlush(() => timers.active() === 1);
+    // The grace elapses before the client ever reconnects — the slot is released.
+    timers.fireAll();
+
+    const reconnected = await open(booted.url);
+    const ack = (await reconnected.emitWithAck('resume', { gameId, playerId: guestId })) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected resume to fail');
+    expect(ack.code).toBe('player_not_found');
+  });
+
+  it('drops a lobby player immediately — grace only guards an active match', async () => {
+    const timers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers });
+    handle = booted.handle;
+    const host = await open(booted.url);
+    const guest = await open(booted.url);
+    const created = (await host.emitWithAck('create_game', { name: 'Host' })) as LobbyAck;
+    if (!created.ok) throw new Error('create failed');
+    const joined = (await guest.emitWithAck('join_game', {
+      roomCode: created.game.roomCode,
+      name: 'Guest',
+    })) as LobbyAck;
+    if (!joined.ok) throw new Error('join failed');
+
+    // Still in the lobby (not started): a disconnect drops the player at once and
+    // arms no grace timer, mirroring the pre-#24 behaviour.
+    const hostSawLeave = waitUntil<{ game: Game }>(
+      host,
+      'lobby_update',
+      (p) => p.game.players.length === 1,
+    );
+    guest.close();
+    await hostSawLeave;
+    expect(timers.active()).toBe(0);
+    expect(handle.lobby.get(created.game.id)?.players.map((p) => p.name)).toEqual(['Host']);
+  });
+});
+
+/** Poll `predicate` on the macrotask queue until it holds (bounded), for async
+ *  server-side effects a client can't directly await (like the disconnect
+ *  handler running after `socket.close()`). */
+async function viFlush(predicate: () => boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('condition not met in time');
+}

--- a/server/app.reconnect.test.ts
+++ b/server/app.reconnect.test.ts
@@ -14,7 +14,7 @@ import { createLocalBroadcaster, createMemoryPositionStore } from './live/index.
 import { createMemoryLobby, type Game } from './lobby/rooms.ts';
 
 type LobbyAck =
-  | { ok: true; game: Game; playerId: string }
+  | { ok: true; game: Game; playerId: string; resumeToken?: string }
   | { ok: false; error: string; code?: string };
 
 /**
@@ -104,6 +104,7 @@ describe('reconnect handling over the socket', () => {
     guest: Socket;
     gameId: string;
     guestId: string;
+    guestToken: string;
   }> {
     const host = await open(url);
     const guest = await open(url);
@@ -118,7 +119,13 @@ describe('reconnect handling over the socket', () => {
     await guest.emitWithAck('set_ready', { ready: true });
     const started = (await host.emitWithAck('start_game', {})) as LobbyAck;
     if (!started.ok) throw new Error('start failed');
-    return { host, guest, gameId: created.game.id, guestId: joined.playerId };
+    return {
+      host,
+      guest,
+      gameId: created.game.id,
+      guestId: joined.playerId,
+      guestToken: joined.resumeToken ?? '',
+    };
   }
 
   afterEach(async () => {
@@ -150,7 +157,7 @@ describe('reconnect handling over the socket', () => {
     const timers = fakeGraceTimers();
     const booted = await bootServer({ disconnectTimers: timers });
     handle = booted.handle;
-    const { guest, gameId, guestId } = await startedGame(booted.url);
+    const { guest, gameId, guestId, guestToken } = await startedGame(booted.url);
 
     guest.close();
     await viFlush(() => timers.active() === 1);
@@ -160,6 +167,7 @@ describe('reconnect handling over the socket', () => {
     const ack = (await reconnected.emitWithAck('resume', {
       gameId,
       playerId: guestId,
+      resumeToken: guestToken,
     })) as LobbyAck;
     expect(ack.ok).toBe(true);
     if (!ack.ok) throw new Error('expected resume to succeed');
@@ -170,7 +178,7 @@ describe('reconnect handling over the socket', () => {
     expect(handle.lobby.get(gameId)?.players.map((p) => p.id)).toContain(guestId);
   });
 
-  it('accepts position updates again once the socket has resumed', async () => {
+  it('rejects a resume with the wrong token — the playerId alone is not enough', async () => {
     const timers = fakeGraceTimers();
     const booted = await bootServer({ disconnectTimers: timers });
     handle = booted.handle;
@@ -179,8 +187,35 @@ describe('reconnect handling over the socket', () => {
     guest.close();
     await viFlush(() => timers.active() === 1);
 
+    // Another room member knows the (public) playerId but not the secret token.
+    const attacker = await open(booted.url);
+    const ack = (await attacker.emitWithAck('resume', {
+      gameId,
+      playerId: guestId,
+      resumeToken: 'not-the-real-token',
+    })) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected resume to be denied');
+    expect(ack.code).toBe('resume_denied');
+    // The slot is untouched — the legitimate owner can still resume.
+    expect(timers.active()).toBe(1);
+  });
+
+  it('accepts position updates again once the socket has resumed', async () => {
+    const timers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers });
+    handle = booted.handle;
+    const { guest, gameId, guestId, guestToken } = await startedGame(booted.url);
+
+    guest.close();
+    await viFlush(() => timers.active() === 1);
+
     const reconnected = await open(booted.url);
-    const ack = (await reconnected.emitWithAck('resume', { gameId, playerId: guestId })) as LobbyAck;
+    const ack = (await reconnected.emitWithAck('resume', {
+      gameId,
+      playerId: guestId,
+      resumeToken: guestToken,
+    })) as LobbyAck;
     if (!ack.ok) throw new Error('resume failed');
 
     // A tick is only broadcast if the server accepted it against the socket's
@@ -200,7 +235,7 @@ describe('reconnect handling over the socket', () => {
     const timers = fakeGraceTimers();
     const booted = await bootServer({ disconnectTimers: timers });
     handle = booted.handle;
-    const { guest, gameId, guestId } = await startedGame(booted.url);
+    const { guest, gameId, guestId, guestToken } = await startedGame(booted.url);
 
     guest.close();
     await viFlush(() => timers.active() === 1);
@@ -208,10 +243,40 @@ describe('reconnect handling over the socket', () => {
     timers.fireAll();
 
     const reconnected = await open(booted.url);
-    const ack = (await reconnected.emitWithAck('resume', { gameId, playerId: guestId })) as LobbyAck;
+    const ack = (await reconnected.emitWithAck('resume', {
+      gameId,
+      playerId: guestId,
+      resumeToken: guestToken,
+    })) as LobbyAck;
     expect(ack.ok).toBe(false);
     if (ack.ok) throw new Error('expected resume to fail');
     expect(ack.code).toBe('player_not_found');
+  });
+
+  it('rejects a resume into a game that ended during the grace window', async () => {
+    const timers = fakeGraceTimers();
+    // A controllable survive-the-timer so we can end the match on demand, while
+    // the guest is mid-reconnect.
+    const gameTimers = fakeGraceTimers();
+    const booted = await bootServer({ disconnectTimers: timers, gameTimers });
+    handle = booted.handle;
+    const { guest, gameId, guestId, guestToken } = await startedGame(booted.url);
+
+    guest.close();
+    await viFlush(() => timers.active() === 1);
+    // The match's survive-the-timer elapses (hiders win) while the guest is away.
+    gameTimers.fireAll();
+    await viFlush(() => handle.lobby.get(gameId)?.status === 'ended');
+
+    const reconnected = await open(booted.url);
+    const ack = (await reconnected.emitWithAck('resume', {
+      gameId,
+      playerId: guestId,
+      resumeToken: guestToken,
+    })) as LobbyAck;
+    expect(ack.ok).toBe(false);
+    if (ack.ok) throw new Error('expected resume to fail');
+    expect(ack.code).toBe('game_ended');
   });
 
   it('drops a lobby player immediately — grace only guards an active match', async () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -44,6 +44,7 @@ import {
   validateJoin,
   validatePositionUpdate,
   validatePushSubscription,
+  validateResume,
   validateSetBoundary,
   type BoundaryWarningEvent,
   type CatchConfirmedEvent,
@@ -142,6 +143,20 @@ export interface CreateServerOptions {
    * when the env is configured (tests).
    */
   vapidConfig?: VapidConfig | null;
+  /**
+   * Reconnect grace period in milliseconds (BACKLOG.md #24): how long a player
+   * who drops mid-match keeps their slot before the server removes them, so an
+   * auto-reconnecting client can `resume` the same identity. Defaults to
+   * {@link resolveDisconnectGraceMs} (from `DISCONNECT_GRACE_S`). `0` disables the
+   * grace — a dropped socket is removed immediately. Tests set it explicitly.
+   */
+  disconnectGraceMs?: number;
+  /**
+   * Timer primitives backing the reconnect grace. Defaults to the global timers;
+   * tests inject a controllable fake so they can fire the grace expiry on demand
+   * and assert the resulting removal, without waiting out the clock.
+   */
+  disconnectTimers?: DisconnectTimerApi;
   /**
    * The push-subscription store, keyed by game then player. Defaults to an
    * in-process store; tests inject one to assert on the registered subscriptions.
@@ -262,6 +277,47 @@ export function resolveGameDurationMs(
   return Math.trunc(seconds * 1000);
 }
 
+/**
+ * Default grace period, in milliseconds, before a player who dropped mid-match is
+ * removed from their game (BACKLOG.md #24). A transient signal loss on a phone is
+ * common, so the server holds the slot this long to let the auto-reconnecting
+ * client `resume` the same identity instead of vanishing from the roster. Tunable
+ * via `DISCONNECT_GRACE_S`.
+ */
+export const DEFAULT_DISCONNECT_GRACE_MS = 30_000;
+
+/**
+ * The subset of the timer API the disconnect-grace uses. `setTimeout` returns an
+ * opaque handle stored per pending removal and later passed to `clearTimeout`
+ * when the player resumes; the concrete type is hidden behind `unknown` so a fake
+ * (or the global timers) can supply whatever handle it likes. Defaults to the
+ * global timers, un-refed so a pending removal never keeps the process alive.
+ */
+export interface DisconnectTimerApi {
+  setTimeout(handler: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+const defaultDisconnectTimers: DisconnectTimerApi = {
+  setTimeout: (handler, ms) => setTimeout(handler, ms).unref(),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/**
+ * Resolve the reconnect grace period (ms) from `DISCONNECT_GRACE_S` (seconds).
+ * Falls back to {@link DEFAULT_DISCONNECT_GRACE_MS} when unset, empty, or not a
+ * finite non-negative number. `0` is honoured — it disables the grace, dropping a
+ * player the instant their socket closes (the pre-#24 behaviour).
+ */
+export function resolveDisconnectGraceMs(
+  raw: string | undefined = process.env.DISCONNECT_GRACE_S,
+): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_DISCONNECT_GRACE_MS;
+  const seconds = Number(raw.trim());
+  if (!Number.isFinite(seconds) || seconds < 0) return DEFAULT_DISCONNECT_GRACE_MS;
+  return Math.trunc(seconds * 1000);
+}
+
 /** What we remember about a socket that has created or joined a lobby. */
 interface LobbyMembership {
   gameId: string;
@@ -328,6 +384,8 @@ export function createServer({
   pingTimers,
   gameDurationMs = resolveGameDurationMs(),
   gameTimers,
+  disconnectGraceMs = resolveDisconnectGraceMs(),
+  disconnectTimers = defaultDisconnectTimers,
   vapidConfig: vapidConfigOption,
   subscriptions = createSubscriptionStore(),
   pushSender: pushSenderOption,
@@ -540,42 +598,92 @@ export function createServer({
     }
   };
 
-  // Remove a socket from whatever lobby it currently holds: drop the player
-  // server-side, leave the socket room, clear the membership, and broadcast the
-  // updated roster if the room survives. A no-op when the socket isn't in a room.
-  // Shared by leave_game, disconnect, and the create/join guard so a socket can
-  // never linger in two rooms (which would leave a ghost player behind).
-  const leaveCurrentLobby = (socket: Socket): void => {
-    const membership = membershipOf(socket);
-    if (!membership) return;
-    const game = lobby.removePlayer(membership.gameId, membership.playerId);
-    socket.leave(gameRoom(membership.gameId));
-    delete (socket.data as { lobby?: LobbyMembership }).lobby;
+  // Pending grace removals for players who dropped mid-match (BACKLOG.md #24),
+  // keyed by game+player. A `resume` within the grace cancels the timer; the
+  // grace expiring fires it and finally removes the player.
+  const pendingRemovals = new Map<string, unknown>();
+  const removalKey = (gameId: string, playerId: string): string => `${gameId}:${playerId}`;
+
+  // Drop a player from a game and sweep everything keyed to them: their geofence
+  // state, push subscription, and outcome snapshot; once the room itself empties,
+  // sweep the game's per-game timers and stores too. Broadcasts the updated roster
+  // when the room survives. Shared by an immediate leave and a grace-period expiry.
+  const forgetPlayer = (gameId: string, playerId: string): void => {
+    const game = lobby.removePlayer(gameId, playerId);
     // Drop the departing player's geofence state so a mid-game leaver doesn't
     // leave a stale warn/eliminate entry parked for the game's lifetime; once the
     // room itself is gone, sweep whatever remains for the (recyclable) game id.
-    boundaryMonitor.forget(membership.gameId, membership.playerId);
-    if (!game) boundaryMonitor.forget(membership.gameId);
+    boundaryMonitor.forget(gameId, playerId);
+    if (!game) boundaryMonitor.forget(gameId);
     // Drop the leaver's push subscription so no notification is routed to a
     // player who is no longer in the game; sweep the whole game once it's gone
     // (BACKLOG.md #23).
-    subscriptions.remove(membership.gameId, membership.playerId);
-    if (!game) subscriptions.removeGame(membership.gameId);
+    subscriptions.remove(gameId, playerId);
+    if (!game) subscriptions.removeGame(gameId);
     // Once the room empties (the game is gone), stop its ping-reveal timer so no
     // scheduler outlives the game it reveals (BACKLOG.md #13), and drop its
     // outcome tracking so the survive-the-timer countdown can't fire on a game
     // that no longer exists (BACKLOG.md #15).
     if (!game) {
-      pingScheduler.stop(membership.gameId);
-      outcomeTracker.stop(membership.gameId);
+      pingScheduler.stop(gameId);
+      outcomeTracker.stop(gameId);
     }
     if (game) {
       // The room lives on but this player is gone — drop them from the outcome
       // snapshot so a departed hider can't keep the last-hider win from firing or
       // be credited with a survival time (BACKLOG.md #15).
-      outcomeTracker.dropPlayer(membership.gameId, membership.playerId);
+      outcomeTracker.dropPlayer(gameId, playerId);
       emitLobby(game);
     }
+  };
+
+  // Cancel a player's pending grace removal (they came back, or left cleanly).
+  const cancelRemoval = (gameId: string, playerId: string): void => {
+    const key = removalKey(gameId, playerId);
+    const handle = pendingRemovals.get(key);
+    if (handle === undefined) return;
+    disconnectTimers.clearTimeout(handle);
+    pendingRemovals.delete(key);
+  };
+
+  // Hold a dropped player's slot for the grace period, then remove them if they
+  // never resumed. Re-arming an existing timer (a flapping connection) restarts
+  // the clock rather than stacking timers.
+  const scheduleRemoval = (gameId: string, playerId: string): void => {
+    const key = removalKey(gameId, playerId);
+    cancelRemoval(gameId, playerId);
+    const handle = disconnectTimers.setTimeout(() => {
+      pendingRemovals.delete(key);
+      forgetPlayer(gameId, playerId);
+    }, disconnectGraceMs);
+    pendingRemovals.set(key, handle);
+  };
+
+  // Remove a socket from whatever lobby it currently holds: leave the socket room,
+  // clear the membership, cancel any pending grace removal, and drop the player.
+  // A no-op when the socket isn't in a room. Shared by leave_game and the
+  // create/join/resume guard so a socket can never linger in two rooms (which
+  // would leave a ghost player behind).
+  const leaveCurrentLobby = (socket: Socket): void => {
+    const membership = membershipOf(socket);
+    if (!membership) return;
+    socket.leave(gameRoom(membership.gameId));
+    delete (socket.data as { lobby?: LobbyMembership }).lobby;
+    cancelRemoval(membership.gameId, membership.playerId);
+    forgetPlayer(membership.gameId, membership.playerId);
+  };
+
+  // Re-seed a (re)joining socket's live view with the game's current positions,
+  // filtered to what this player may see, so its map isn't blank until the next
+  // tick lands. Nothing reported yet is simply skipped.
+  const sendSnapshot = async (socket: Socket, gameId: string, playerId: string): Promise<void> => {
+    const positions = await tickEngine.latest(gameId);
+    if (Object.keys(positions).length === 0) return;
+    const message: GameStateEvent = {
+      gameId,
+      positions: visibleTo(roleOf(gameId, playerId), positions),
+    };
+    socket.emit('game_state', message);
   };
 
   // Authoritative game loop. The transport contract (join, position_update,
@@ -591,6 +699,45 @@ export function createServer({
       const result = validateJoin(payload);
       if (result.ok) socket.join(gameRoom(result.value.gameId));
       if (typeof ack === 'function') ack({ ok: result.ok });
+    });
+
+    // Reclaim a membership after a reconnect (BACKLOG.md #24). The transport gives
+    // a reconnecting client a brand-new socket the server has dropped from the
+    // room, so re-emitting `join` alone would restore broadcasts but not identity
+    // — its `position_update`/`claim_catch` would keep being ignored. `resume`
+    // re-binds the socket's authoritative lobby identity if the player is still in
+    // the roster (their slot held by the grace period), cancels the pending
+    // removal, and re-seeds the live view. Fails if the game or player is gone
+    // (the grace elapsed, or the room ended and emptied), so the client can fall
+    // back to the join screen.
+    socket.on('resume', (payload: unknown, ack?: (res: LobbyAck) => void) => {
+      const result = validateResume(payload);
+      if (!result.ok) {
+        ack?.({ ok: false, error: result.error, code: result.code });
+        return;
+      }
+      const { gameId, playerId } = result.value;
+      const game = lobby.get(gameId);
+      const player = game?.players.find((p) => p.id === playerId);
+      if (!game || !player) {
+        ack?.({ ok: false, error: 'That session is no longer available', code: 'player_not_found' });
+        return;
+      }
+      // Never let this socket hold two memberships — drop any prior one first,
+      // unless it's already bound to exactly this identity (nothing to do, and
+      // dropping it would evict the very player we're resuming).
+      const existing = membershipOf(socket);
+      if (existing && (existing.gameId !== gameId || existing.playerId !== playerId)) {
+        leaveCurrentLobby(socket);
+      }
+      cancelRemoval(gameId, playerId);
+      (socket.data as { lobby?: LobbyMembership }).lobby = { gameId, playerId };
+      socket.join(gameRoom(gameId));
+      ack?.({ ok: true, game, playerId });
+      void sendSnapshot(socket, gameId, playerId).catch((err: unknown) => {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.error('resume snapshot failed:', reason);
+      });
     });
 
     // --- Lobby: create/join a room, pick a side, ready up, host starts. ---
@@ -849,8 +996,22 @@ export function createServer({
 
     socket.on('disconnect', () => {
       console.log(`socket disconnected: ${socket.id}`);
-      // Drop the player from their lobby; if the room survives, tell the rest.
-      leaveCurrentLobby(socket);
+      const membership = membershipOf(socket);
+      if (!membership) return;
+      const game = lobby.get(membership.gameId);
+      // Signal loss mid-match: hold the player's slot for the grace period so an
+      // auto-reconnecting client can `resume` the same identity instead of being
+      // dropped and having to re-join fresh (BACKLOG.md #24). The socket is
+      // already gone (Socket.IO leaves its rooms on disconnect), so we only clear
+      // our own membership record and arm the removal timer. In the lobby (before
+      // start) or once the game has ended there's nothing to preserve — and with
+      // the grace disabled (`0`) we never defer — so drop immediately as before.
+      if (game?.status === 'active' && disconnectGraceMs > 0) {
+        delete (socket.data as { lobby?: LobbyMembership }).lobby;
+        scheduleRemoval(membership.gameId, membership.playerId);
+      } else {
+        leaveCurrentLobby(socket);
+      }
     });
   });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,7 @@
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import express, {
   type Express,
@@ -324,9 +325,15 @@ interface LobbyMembership {
   playerId: string;
 }
 
-/** Ack shape for lobby actions: the current game on success, an error code otherwise. */
+/**
+ * Ack shape for lobby actions: the current game on success, an error code
+ * otherwise. `create_game`/`join_game` (and `resume`) additionally return the
+ * `resumeToken` — the per-session secret the client stores and presents to
+ * `resume` after a reconnect (BACKLOG.md #24). It's absent on actions that don't
+ * mint one (set_role, set_ready, start_game).
+ */
 type LobbyAck =
-  | { ok: true; game: Game; playerId: string }
+  | { ok: true; game: Game; playerId: string; resumeToken?: string }
   | { ok: false; error: string; code?: string };
 
 /** Ack shape for `claim_catch`: the confirmed catch on success, an error otherwise. */
@@ -604,12 +611,25 @@ export function createServer({
   const pendingRemovals = new Map<string, unknown>();
   const removalKey = (gameId: string, playerId: string): string => `${gameId}:${playerId}`;
 
+  // Per-session resume tokens (BACKLOG.md #24), keyed by game+player. Minted at
+  // create/join and returned only to that client, so a `resume` can prove it is
+  // the same player rather than any room member who has merely seen the (public)
+  // playerId in the roster. Dropped with the player.
+  const resumeTokens = new Map<string, string>();
+  const mintResumeToken = (gameId: string, playerId: string): string => {
+    const token = randomUUID();
+    resumeTokens.set(removalKey(gameId, playerId), token);
+    return token;
+  };
+
   // Drop a player from a game and sweep everything keyed to them: their geofence
   // state, push subscription, and outcome snapshot; once the room itself empties,
   // sweep the game's per-game timers and stores too. Broadcasts the updated roster
   // when the room survives. Shared by an immediate leave and a grace-period expiry.
   const forgetPlayer = (gameId: string, playerId: string): void => {
     const game = lobby.removePlayer(gameId, playerId);
+    // The session is over — its resume token can never be redeemed again.
+    resumeTokens.delete(removalKey(gameId, playerId));
     // Drop the departing player's geofence state so a mid-game leaver doesn't
     // leave a stale warn/eliminate entry parked for the game's lifetime; once the
     // room itself is gone, sweep whatever remains for the (recyclable) game id.
@@ -705,22 +725,44 @@ export function createServer({
     // a reconnecting client a brand-new socket the server has dropped from the
     // room, so re-emitting `join` alone would restore broadcasts but not identity
     // — its `position_update`/`claim_catch` would keep being ignored. `resume`
-    // re-binds the socket's authoritative lobby identity if the player is still in
-    // the roster (their slot held by the grace period), cancels the pending
-    // removal, and re-seeds the live view. Fails if the game or player is gone
-    // (the grace elapsed, or the room ended and emptied), so the client can fall
-    // back to the join screen.
+    // re-binds the socket's authoritative lobby identity, cancels the pending
+    // removal, and re-seeds the live view.
+    //
+    // Identity is proven, never trusted from the payload: the caller must present
+    // the `resumeToken` minted for this player at create/join (the roster exposes
+    // the playerId to every member, so the token — not the id — is what
+    // authenticates the claim). And it only re-binds a player who is actually
+    // mid-reconnect (a pending grace removal exists), so a token can't be used to
+    // seize a live session. Fails when the game/player is gone (the grace
+    // elapsed), the game has ended, the token is wrong, or the player isn't
+    // disconnected — the client falls back accordingly.
     socket.on('resume', (payload: unknown, ack?: (res: LobbyAck) => void) => {
       const result = validateResume(payload);
       if (!result.ok) {
         ack?.({ ok: false, error: result.error, code: result.code });
         return;
       }
-      const { gameId, playerId } = result.value;
+      const { gameId, playerId, resumeToken } = result.value;
       const game = lobby.get(gameId);
       const player = game?.players.find((p) => p.id === playerId);
       if (!game || !player) {
         ack?.({ ok: false, error: 'That session is no longer available', code: 'player_not_found' });
+        return;
+      }
+      // The match ended while the grace timer was still pending: the one-shot
+      // `game_over` already fired and this socket missed it. Don't rebind into a
+      // stale, over game — tell the client so it can reset rather than show a
+      // frozen match/lobby screen.
+      if (game.status === 'ended') {
+        ack?.({ ok: false, error: 'That game has ended', code: 'game_ended' });
+        return;
+      }
+      const key = removalKey(gameId, playerId);
+      // Verify the session token, and that the player is genuinely mid-reconnect
+      // (a pending removal is armed). Either check failing means this isn't the
+      // legitimate owner resuming a dropped session.
+      if (resumeTokens.get(key) !== resumeToken || !pendingRemovals.has(key)) {
+        ack?.({ ok: false, error: 'That session cannot be resumed', code: 'resume_denied' });
         return;
       }
       // Never let this socket hold two memberships — drop any prior one first,
@@ -759,7 +801,8 @@ export function createServer({
           playerId: player.id,
         };
         socket.join(gameRoom(game.id));
-        ack?.({ ok: true, game, playerId: player.id });
+        const resumeToken = mintResumeToken(game.id, player.id);
+        ack?.({ ok: true, game, playerId: player.id, resumeToken });
         emitLobby(game);
       });
     });
@@ -777,7 +820,8 @@ export function createServer({
           playerId: player.id,
         };
         socket.join(gameRoom(game.id));
-        ack?.({ ok: true, game, playerId: player.id });
+        const resumeToken = mintResumeToken(game.id, player.id);
+        ack?.({ ok: true, game, playerId: player.id, resumeToken });
         emitLobby(game);
       });
     });

--- a/server/protocol/messages.test.ts
+++ b/server/protocol/messages.test.ts
@@ -30,10 +30,10 @@ describe('validateJoin', () => {
 });
 
 describe('validateResume', () => {
-  it('accepts a payload with a gameId and playerId', () => {
-    expect(validateResume({ gameId: 'g1', playerId: 'p1' })).toEqual({
+  it('accepts a payload with a gameId, playerId, and resumeToken', () => {
+    expect(validateResume({ gameId: 'g1', playerId: 'p1', resumeToken: 't1' })).toEqual({
       ok: true,
-      value: { gameId: 'g1', playerId: 'p1' },
+      value: { gameId: 'g1', playerId: 'p1', resumeToken: 't1' },
     });
   });
 
@@ -44,7 +44,7 @@ describe('validateResume', () => {
     expect(res.code).toBe('invalid_payload');
   });
 
-  it.each([{}, { gameId: '' }, { playerId: 'p1' }])(
+  it.each([{}, { gameId: '' }, { playerId: 'p1', resumeToken: 't1' }])(
     'rejects a missing/empty gameId: %o',
     (payload) => {
       const res = validateResume(payload);
@@ -54,15 +54,27 @@ describe('validateResume', () => {
     },
   );
 
-  it.each([{ gameId: 'g1' }, { gameId: 'g1', playerId: '' }, { gameId: 'g1', playerId: 3 }])(
-    'rejects a missing/empty playerId: %o',
-    (payload) => {
-      const res = validateResume(payload);
-      expect(res.ok).toBe(false);
-      if (res.ok) throw new Error('expected invalid');
-      expect(res.code).toBe('player_id_required');
-    },
-  );
+  it.each([
+    { gameId: 'g1' },
+    { gameId: 'g1', playerId: '' },
+    { gameId: 'g1', playerId: 3, resumeToken: 't1' },
+  ])('rejects a missing/empty playerId: %o', (payload) => {
+    const res = validateResume(payload);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected invalid');
+    expect(res.code).toBe('player_id_required');
+  });
+
+  it.each([
+    { gameId: 'g1', playerId: 'p1' },
+    { gameId: 'g1', playerId: 'p1', resumeToken: '' },
+    { gameId: 'g1', playerId: 'p1', resumeToken: 9 },
+  ])('rejects a missing/empty resumeToken: %o', (payload) => {
+    const res = validateResume(payload);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected invalid');
+    expect(res.code).toBe('resume_token_required');
+  });
 });
 
 describe('validatePositionUpdate', () => {

--- a/server/protocol/messages.test.ts
+++ b/server/protocol/messages.test.ts
@@ -5,6 +5,7 @@ import {
   validateJoin,
   validatePositionUpdate,
   validatePushSubscription,
+  validateResume,
   validateSetBoundary,
 } from './messages.ts';
 
@@ -26,6 +27,42 @@ describe('validateJoin', () => {
     if (res.ok) throw new Error('expected invalid');
     expect(res.code).toBe('game_id_required');
   });
+});
+
+describe('validateResume', () => {
+  it('accepts a payload with a gameId and playerId', () => {
+    expect(validateResume({ gameId: 'g1', playerId: 'p1' })).toEqual({
+      ok: true,
+      value: { gameId: 'g1', playerId: 'p1' },
+    });
+  });
+
+  it.each([undefined, null, 'g1', 42])('rejects non-objects: %s', (payload) => {
+    const res = validateResume(payload);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected invalid');
+    expect(res.code).toBe('invalid_payload');
+  });
+
+  it.each([{}, { gameId: '' }, { playerId: 'p1' }])(
+    'rejects a missing/empty gameId: %o',
+    (payload) => {
+      const res = validateResume(payload);
+      expect(res.ok).toBe(false);
+      if (res.ok) throw new Error('expected invalid');
+      expect(res.code).toBe('game_id_required');
+    },
+  );
+
+  it.each([{ gameId: 'g1' }, { gameId: 'g1', playerId: '' }, { gameId: 'g1', playerId: 3 }])(
+    'rejects a missing/empty playerId: %o',
+    (payload) => {
+      const res = validateResume(payload);
+      expect(res.ok).toBe(false);
+      if (res.ok) throw new Error('expected invalid');
+      expect(res.code).toBe('player_id_required');
+    },
+  );
 });
 
 describe('validatePositionUpdate', () => {

--- a/server/protocol/messages.ts
+++ b/server/protocol/messages.ts
@@ -26,6 +26,7 @@ import { isPrivateIp } from '../push/ssrf.ts';
 /** Inbound events (client → server) that carry a validated game-loop payload. */
 export const INBOUND_EVENTS = {
   join: 'join',
+  resume: 'resume',
   positionUpdate: 'position_update',
   claimCatch: 'claim_catch',
   setBoundary: 'set_boundary',
@@ -48,6 +49,20 @@ export const OUTBOUND_EVENTS = {
 /** `join` — subscribe this socket to a game's broadcasts. */
 export interface JoinPayload {
   gameId: string;
+}
+
+/**
+ * `resume` — a reconnecting client reclaims the game membership it held before a
+ * signal loss (BACKLOG.md #24). Unlike {@link JoinPayload} (which only subscribes
+ * a socket to a room's broadcasts) this re-binds the socket's authoritative lobby
+ * identity — the `playerId` recorded when it created or joined the room — so its
+ * `position_update`/`claim_catch` are accepted again after the transport dropped.
+ * The server holds a disconnected player's slot for a grace period; a `resume`
+ * within that window cancels the pending removal and restores the session.
+ */
+export interface ResumePayload {
+  gameId: string;
+  playerId: string;
 }
 
 /**
@@ -223,6 +238,19 @@ export function validateJoin(payload: unknown): Validation<JoinPayload> {
     return invalid('game_id_required', 'gameId is required');
   }
   return valid({ gameId: body.gameId });
+}
+
+/** Validate a `resume` payload: the game and the player identity to reclaim. */
+export function validateResume(payload: unknown): Validation<ResumePayload> {
+  const body = asRecord(payload);
+  if (!body) return invalid('invalid_payload', 'Expected an object');
+  if (!isNonEmptyString(body.gameId)) {
+    return invalid('game_id_required', 'gameId is required');
+  }
+  if (!isNonEmptyString(body.playerId)) {
+    return invalid('player_id_required', 'playerId is required');
+  }
+  return valid({ gameId: body.gameId, playerId: body.playerId });
 }
 
 /** Validate a `position_update` payload, including WGS84 coordinate bounds. */

--- a/server/protocol/messages.ts
+++ b/server/protocol/messages.ts
@@ -59,10 +59,19 @@ export interface JoinPayload {
  * `position_update`/`claim_catch` are accepted again after the transport dropped.
  * The server holds a disconnected player's slot for a grace period; a `resume`
  * within that window cancels the pending removal and restores the session.
+ *
+ * `gameId` and `playerId` are not secret — the roster broadcasts both to every
+ * room member — so re-binding on those alone would let any member hijack another
+ * player's identity. The payload therefore also carries the `resumeToken` the
+ * server minted for this player at create/join and returned only to them; the
+ * handler rebinds only when it matches, upholding the codebase invariant that a
+ * socket's identity is server-authoritative, never taken from an untrusted
+ * payload.
  */
 export interface ResumePayload {
   gameId: string;
   playerId: string;
+  resumeToken: string;
 }
 
 /**
@@ -240,7 +249,12 @@ export function validateJoin(payload: unknown): Validation<JoinPayload> {
   return valid({ gameId: body.gameId });
 }
 
-/** Validate a `resume` payload: the game and the player identity to reclaim. */
+/**
+ * Validate a `resume` payload: the game and player identity to reclaim, plus the
+ * server-issued `resumeToken` that authenticates the claim (see
+ * {@link ResumePayload}). Shape only — the handler verifies the token against the
+ * one it minted for this player.
+ */
 export function validateResume(payload: unknown): Validation<ResumePayload> {
   const body = asRecord(payload);
   if (!body) return invalid('invalid_payload', 'Expected an object');
@@ -250,7 +264,10 @@ export function validateResume(payload: unknown): Validation<ResumePayload> {
   if (!isNonEmptyString(body.playerId)) {
     return invalid('player_id_required', 'playerId is required');
   }
-  return valid({ gameId: body.gameId, playerId: body.playerId });
+  if (!isNonEmptyString(body.resumeToken)) {
+    return invalid('resume_token_required', 'resumeToken is required');
+  }
+  return valid({ gameId: body.gameId, playerId: body.playerId, resumeToken: body.resumeToken });
 }
 
 /** Validate a `position_update` payload, including WGS84 coordinate bounds. */


### PR DESCRIPTION
Closes #24.

Keeps a match playable across the transient signal loss a phone in the field will hit: the socket auto-reconnects, the server holds the player's slot while it does, and the live map shows last-known positions in the meantime.

## Server

- **Reconnect grace.** On a mid-match disconnect the server now holds the player's slot for a grace period instead of removing them the instant their socket closes. Lobby disconnects (before the match starts) still drop immediately — there's no in-flight game to preserve.
- **`resume` event.** A reconnect arrives as a brand-new socket the server has dropped from the room, so a bare re-`join` would restore broadcasts but not identity. `resume` re-binds the socket's authoritative `playerId` (if the slot is still held), cancels the pending removal, and re-seeds the client's live view — restoring its ability to send `position_update`/`claim_catch`. Rejected with `player_not_found` once the grace has elapsed or the room is gone.
- Grace is tunable via `DISCONNECT_GRACE_S` (default 30 s; `0` disables it), with injectable timers so tests drive expiry deterministically.
- Extracted the post-removal cleanup (`forgetPlayer`) shared by an immediate leave and a grace expiry; added `validateResume` to the message contract.

## Client

- **Auto-reconnect made explicit** in `socket.ts` — capped, jittered backoff that never gives up, matching a flaky mobile signal.
- **`useConnection` hook** maps the socket lifecycle to `connected` / `reconnecting` / `offline` (a recoverable transport drop vs. a deliberate/forced close), surfaced by the shell's status dot.
- **`resume` on reconnect** in `useLobby`: reclaims membership and adopts the refreshed roster (which may have changed while away). A rejected resume keeps the last-known room on screen rather than yanking the player to the join screen.
- **Last-known positions on signal loss** in `ActiveGame`: the live view is retained across a drop, so the map keeps every player's last position — dimmed, behind a "showing last-known positions" banner — instead of blanking.

## Docs & config

- README WebSocket contract gains the `resume` row and a "Reconnect handling" paragraph; `.env.example` documents `DISCONNECT_GRACE_S`.

## Tests

- New: `server/app.reconnect.test.ts` (grace hold, resume within grace, ticks accepted after resume, resume rejected after expiry, lobby drops immediately), `server/protocol` `validateResume` cases, `client/src/useConnection.test.ts`, `client/src/lobby/useLobby.test.ts` (resume-on-reconnect), and an `ActiveGame` banner/stale-map test.
- All green locally: lint + typecheck, **302** server + **125** client unit tests, and the **13** Playwright e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184nwGZ1et3ZYUhiPye6iem

---
_Generated by [Claude Code](https://claude.ai/code/session_0184nwGZ1et3ZYUhiPye6iem)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mid-match disconnect grace with automatic reconnect and session restoration via a server-minted resume token.
  * Updated connection UI with “Reconnecting…” and “Offline” statuses, plus a signal-loss banner.
  * When offline, the map now dims and shows last-known positions as stale.
* **Documentation**
  * Updated the WebSocket message contract and reconnection/resume flow, including lobby behavior (instant drop pre-start) and grace expiry.
  * Added configuration guidance for the disconnect grace period.
* **Bug Fixes**
  * Prevented recoverable disconnects from clearing match state; resuming now restores live state and cancels pending removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->