### PR TITLE
feat(server): account auth, sessions, and root bootstrap (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,18 @@ RUN_MIGRATIONS=true
 REDIS_URL=redis://redis:6379
 
 # Sessions / auth
+# HMAC key the server signs session cookies with (BACKLOG #20). Rotating it
+# invalidates every outstanding session. Unset in dev → a random per-process
+# secret (sessions won't survive a restart); always set it in production.
 SESSION_SECRET=change-me
+
+# Root account bootstrap (BACKLOG #20). On boot (with DATABASE_URL set) the
+# server seeds a single root account — the trust anchor the vouch graph flows
+# out from — if one doesn't already exist. ROOT_PASSWORD is optional: leave it
+# empty and a strong password is generated and logged once at boot.
+ROOT_USERNAME=root
+ROOT_NAME=Root
+ROOT_PASSWORD=
 
 # Web Push (VAPID) — generate with: npx web-push generate-vapid-keys.
 # Leave the keys empty to disable Web Push (no key is advertised, nothing is

--- a/README.md
+++ b/README.md
@@ -151,6 +151,38 @@ no build step. Type-check the server and client with `npm run typecheck`.
 Evolve the schema by adding a new `NNNN_name.sql` migration (files are immutable
 once merged) and updating the snapshot to match.
 
+### Accounts, sessions & trust
+
+Accounts sign in over a small REST surface mounted at `/api/auth` (the only
+REST-ish routes on an otherwise Socket.IO server), backed by the durable
+`accounts`/`vouches` tables. Passwords are salted and hashed with **scrypt**
+(Node's built-in crypto — no third-party dependency); a successful register or
+login mints a **stateless, HMAC-signed session token** (keyed by
+`SESSION_SECRET`) and sets it as an **httpOnly** cookie. Identity on every
+authenticated route comes from that signed cookie — never from the request body —
+mirroring the socket layer's "identity is server-authoritative" rule.
+
+| Method & path | Body | Result |
+| --- | --- | --- |
+| `POST /api/auth/register` | `{ name, username, password }` | Creates an account and signs it in (sets the session cookie). `409` on a taken username, `400` on a blank field. |
+| `POST /api/auth/login` | `{ username, password }` | Verifies credentials, sets the session cookie. `401` on a bad pair. |
+| `POST /api/auth/logout` | — | Clears the session cookie. |
+| `GET /api/auth/me` | — | The signed-in account + its computed `trusted` flag. `401` when not signed in. |
+| `POST /api/auth/vouch` | `{ username }` or `{ accountId }` | The signed-in caller vouches for another account (see trust below). `404` unknown vouchee, `400` self-vouch. |
+
+**Trust (web of trust).** Trust flows out from a single **root account**, seeded
+idempotently on boot from `ROOT_USERNAME`/`ROOT_PASSWORD` (a strong password is
+generated and logged once if none is set). An account is *trusted* when it is
+reachable from a root by following `voucher → vouchee` edges: the root vouches
+for Alice, Alice vouches for Bob, and both become trusted. A vouch from an
+untrusted account records the edge but confers nothing until that account is
+itself reachable from the root — so the root is the sole anchor and the graph
+can't be bootstrapped from outside. (This is the app's own trust model, distinct
+from the repo-governance vouch list in `.github/VOUCHED.td`.)
+
+Without a `DATABASE_URL` a bare dev checkout falls back to an in-process account
+store so sign-in still works locally; accounts just aren't durable.
+
 ### WebSocket message contract
 
 All real-time play flows over a single Socket.IO connection. The contract — every

--- a/db/migrations/0002_accounts_auth.sql
+++ b/db/migrations/0002_accounts_auth.sql
@@ -1,0 +1,32 @@
+-- 0002_accounts_auth: account sign-in + the vouch (web-of-trust) graph
+-- (BACKLOG.md #20, docs/arc42.md §5 "Auth / accounts").
+--
+-- The initial schema (0001) gave `accounts` an id, name and `is_root` flag but
+-- no way to actually sign in. This adds the credentials a session is minted
+-- from, and the `vouches` edges that make trust flow out from the seeded root
+-- account: an account is trusted when it is reachable from a root by following
+-- voucher → vouchee edges.
+
+-- Credentials. `username` is the sign-in handle (stored already normalized —
+-- trimmed + lower-cased — by the server), unique across accounts; `password_hash`
+-- is a self-describing scrypt digest (see server/auth/password.ts). Both are
+-- nullable so a pre-existing/imported account row without credentials stays
+-- valid; an account can only sign in once both are set.
+alter table accounts add column if not exists username      text unique;
+alter table accounts add column if not exists password_hash text;
+
+-- The web of trust. One row per directed vouch: `voucher_id` vouches for
+-- `vouchee_id`. Self-vouches are meaningless (an account can't bootstrap its own
+-- trust) and are rejected. A pair is unique — vouching twice is idempotent — so
+-- the composite primary key doubles as the dedupe guard.
+create table if not exists vouches (
+  voucher_id uuid not null references accounts(id),
+  vouchee_id uuid not null references accounts(id),
+  created_at timestamptz not null default now(),
+  primary key (voucher_id, vouchee_id),
+  check (voucher_id <> vouchee_id)
+);
+
+-- Trust is computed by walking vouch edges out from the root(s), so the hot
+-- lookup is "who did X vouch for" — index the voucher side for that traversal.
+create index if not exists vouches_vouchee_id_idx on vouches (vouchee_id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,11 +4,28 @@
 -- (`npm run db:migrate`, or on boot with RUN_MIGRATIONS=true). Change the schema
 -- by adding a new migration, then update this snapshot to match.
 create table if not exists accounts (
-  id           uuid primary key default gen_random_uuid(),
-  name         text not null,
-  is_root      boolean not null default false,
-  created_at   timestamptz not null default now()
+  id            uuid primary key default gen_random_uuid(),
+  name          text not null,
+  -- Sign-in credentials (0002). `username` is normalized (trimmed + lower-cased)
+  -- by the server; `password_hash` is a self-describing scrypt digest. Nullable
+  -- so an imported/credential-less account row stays valid.
+  username      text unique,
+  password_hash text,
+  is_root       boolean not null default false,
+  created_at    timestamptz not null default now()
 );
+
+-- The vouch (web-of-trust) graph (0002): `voucher_id` vouches for `vouchee_id`.
+-- An account is trusted when it is reachable from a root by following these
+-- edges. Self-vouches are rejected; a pair is unique (vouching twice is a no-op).
+create table if not exists vouches (
+  voucher_id uuid not null references accounts(id),
+  vouchee_id uuid not null references accounts(id),
+  created_at timestamptz not null default now(),
+  primary key (voucher_id, vouchee_id),
+  check (voucher_id <> vouchee_id)
+);
+create index if not exists vouches_vouchee_id_idx on vouches (vouchee_id);
 
 create table if not exists games (
   id              uuid primary key default gen_random_uuid(),

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -155,6 +155,30 @@ A phone in the field drops signal. The client's socket **auto-reconnects** on it
 
 ---
 
+### 6.8 Accounts, sessions & trust
+
+Accounts are the durable identity layer (PostgreSQL `accounts`/`vouches`),
+exposed over a small REST surface at `/api/auth` — the only REST-ish routes on
+an otherwise Socket.IO server.
+
+1. **Sign-in.** A password is salted and hashed with scrypt (Node's built-in
+   crypto). Register/login mint a **stateless, HMAC-signed session token** keyed
+   by `SESSION_SECRET` and set it as an httpOnly cookie; every authenticated
+   route resolves identity from that signed cookie, never from the request body
+   — the same server-authoritative rule the socket layer follows.
+2. **Root bootstrap.** On boot (with a database configured) the server seeds a
+   single **root account** if none exists — idempotent, so it is safe on every
+   boot alongside the migrations. Its credentials come from the environment
+   (`ROOT_USERNAME`/`ROOT_PASSWORD`); when no password is supplied a strong one
+   is generated and logged **once**, so a fresh install never has a silent
+   default.
+3. **Trust (web of trust).** An account is *trusted* when it is reachable from a
+   root by following `voucher → vouchee` vouch edges. The root is the sole trust
+   anchor: a vouch from an untrusted account records an edge but confers nothing
+   until that account is itself reachable from the root, so the graph can't be
+   bootstrapped from outside. Trust is computed on demand (a recursive walk of
+   the edges in Postgres, or a BFS in the in-memory store) rather than cached.
+
 ## 7. Deployment view
 
 Single server running Docker containers:
@@ -244,3 +268,5 @@ stores to operate.
 | Boundary | Geofenced play area; leaving it triggers a warning or elimination. |
 | Tick | One position-update/broadcast cycle (every 5–10 s). |
 | PWA | Progressive Web App — installable, works offline-ish, no app store. |
+| Root account | The seeded trust anchor; every trusted account is reachable from it via vouches. |
+| Vouch | A directed trust edge (`voucher → vouchee`); trust flows out from the root along these. |

--- a/server/app.auth.test.ts
+++ b/server/app.auth.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import request from 'supertest';
+import type { Express } from 'express';
+import { createServer } from './app.ts';
+import {
+  createMemoryAccountStore,
+  createSessionCodec,
+  type Account,
+  type AccountStore,
+} from './auth/index.ts';
+
+describe('auth HTTP routes', () => {
+  let app: Express;
+  let accounts: AccountStore;
+  let staticDir: string;
+
+  beforeEach(() => {
+    // An empty static dir: no index.html, so there is no SPA fallback to shadow
+    // the API 404s we assert on.
+    staticDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manhunt-auth-'));
+    accounts = createMemoryAccountStore();
+    ({ app } = createServer({
+      staticDir,
+      accounts,
+      sessions: createSessionCodec({ secret: 'test-secret' }),
+    }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(staticDir, { recursive: true, force: true });
+  });
+
+  it('registers an account, sets a session cookie, and answers /me', async () => {
+    const agent = request.agent(app);
+    const res = await agent
+      .post('/api/auth/register')
+      .send({ name: 'Alice', username: 'Alice', password: 'hunter2' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.account).toMatchObject({ name: 'Alice', username: 'alice', trusted: false });
+    expect(res.body.account).not.toHaveProperty('passwordHash');
+    // httpOnly session cookie was set.
+    const cookie = res.headers['set-cookie']?.[0] ?? '';
+    expect(cookie).toMatch(/session=/);
+    expect(cookie.toLowerCase()).toContain('httponly');
+
+    const me = await agent.get('/api/auth/me');
+    expect(me.status).toBe(200);
+    expect(me.body.account).toMatchObject({ username: 'alice' });
+  });
+
+  it('rejects a duplicate username', async () => {
+    await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'A', username: 'dup', password: 'p' });
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'B', username: 'DUP', password: 'p' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('username_taken');
+  });
+
+  it('rejects blank registration fields', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ name: '', username: 'u', password: 'p' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('name_required');
+  });
+
+  it('signs in with correct credentials and rejects wrong ones', async () => {
+    await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'Alice', username: 'alice', password: 'hunter2' });
+
+    const bad = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'alice', password: 'nope' });
+    expect(bad.status).toBe(401);
+    expect(bad.body.code).toBe('invalid_credentials');
+
+    const ok = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'ALICE', password: 'hunter2' });
+    expect(ok.status).toBe(200);
+    expect(ok.body.account).toMatchObject({ username: 'alice' });
+  });
+
+  it('requires authentication for /me and clears the session on logout', async () => {
+    const anon = await request(app).get('/api/auth/me');
+    expect(anon.status).toBe(401);
+
+    const agent = request.agent(app);
+    await agent.post('/api/auth/register').send({ name: 'A', username: 'a', password: 'p' });
+    expect((await agent.get('/api/auth/me')).status).toBe(200);
+
+    await agent.post('/api/auth/logout');
+    expect((await agent.get('/api/auth/me')).status).toBe(401);
+  });
+
+  describe('vouch', () => {
+    // Seed a root with known credentials so a test can sign in as it.
+    let root: Account;
+    beforeEach(async () => {
+      root = await accounts.createAccount({
+        name: 'Root',
+        username: 'root',
+        password: 'rootpw',
+        isRoot: true,
+      });
+    });
+
+    it('lets the root vouch, making the vouchee trusted', async () => {
+      // A fresh, untrusted member.
+      const member = await request(app)
+        .post('/api/auth/register')
+        .send({ name: 'Mem', username: 'mem', password: 'p' });
+      expect(member.body.account.trusted).toBe(false);
+
+      // Sign in as root and vouch for the member by username.
+      const rootAgent = request.agent(app);
+      await rootAgent.post('/api/auth/login').send({ username: 'root', password: 'rootpw' });
+      const vouch = await rootAgent.post('/api/auth/vouch').send({ username: 'mem' });
+
+      expect(vouch.status).toBe(200);
+      expect(vouch.body.vouchee).toMatchObject({ username: 'mem', trusted: true });
+      expect(await accounts.isTrusted(root.id)).toBe(true);
+    });
+
+    it('requires authentication to vouch', async () => {
+      const res = await request(app).post('/api/auth/vouch').send({ username: 'root' });
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe('unauthenticated');
+    });
+
+    it('404s on an unknown vouchee', async () => {
+      const rootAgent = request.agent(app);
+      await rootAgent.post('/api/auth/login').send({ username: 'root', password: 'rootpw' });
+      const res = await rootAgent.post('/api/auth/vouch').send({ username: 'ghost' });
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe('account_not_found');
+    });
+
+    it('rejects a self-vouch', async () => {
+      const rootAgent = request.agent(app);
+      await rootAgent.post('/api/auth/login').send({ username: 'root', password: 'rootpw' });
+      const res = await rootAgent.post('/api/auth/vouch').send({ username: 'root' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('self_vouch');
+    });
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -64,6 +64,13 @@ import {
   type SubscriptionStore,
   type VapidConfig,
 } from './push/index.ts';
+import {
+  createAuthRouter,
+  createMemoryAccountStore,
+  createSessionCodec,
+  type AccountStore,
+  type SessionCodec,
+} from './auth/index.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -170,6 +177,18 @@ export interface CreateServerOptions {
    * push service.
    */
   pushSender?: PushSender;
+  /**
+   * The account + trust store backing the `/api/auth` routes (BACKLOG.md #20).
+   * Defaults to an in-process store so a bare dev checkout and the tests run
+   * without a database; production (`index.ts`) injects the PostgreSQL-backed
+   * store and seeds the root account.
+   */
+  accounts?: AccountStore;
+  /**
+   * The session-token codec that signs and verifies the auth cookie. Defaults to
+   * one keyed by `SESSION_SECRET`; tests inject one with an explicit secret/clock.
+   */
+  sessions?: SessionCodec;
 }
 
 export interface ServerHandle {
@@ -190,6 +209,8 @@ export interface ServerHandle {
   subscriptions: SubscriptionStore;
   /** The notifier that pushes key game events (caught, reveal, time) to subscribers. */
   notifier: Notifier;
+  /** The account + trust store backing `/api/auth` (BACKLOG.md #20). */
+  accounts: AccountStore;
 }
 
 /** Socket.IO room a game's broadcasts are emitted to. */
@@ -396,6 +417,8 @@ export function createServer({
   vapidConfig: vapidConfigOption,
   subscriptions = createSubscriptionStore(),
   pushSender: pushSenderOption,
+  accounts = createMemoryAccountStore(),
+  sessions = createSessionCodec(),
 }: CreateServerOptions = {}): ServerHandle {
   const app = express();
 
@@ -420,6 +443,11 @@ export function createServer({
   app.get('/api/push/vapid-public-key', (_req: Request, res: Response) => {
     res.json({ key: vapidConfig?.publicKey ?? null });
   });
+
+  // Account auth + sessions + vouch (BACKLOG.md #20). The only REST-ish routes on
+  // an otherwise Socket.IO server; mounted before the static/SPA fallback so
+  // `/api/auth/*` is handled here rather than served the app shell.
+  app.use('/api/auth', createAuthRouter({ store: accounts, sessions }));
 
   app.use(express.static(staticDir));
 
@@ -1071,5 +1099,6 @@ export function createServer({
     outcomeTracker,
     subscriptions,
     notifier,
+    accounts,
   };
 }

--- a/server/auth/bootstrap.test.ts
+++ b/server/auth/bootstrap.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { bootstrapRoot, bootstrapRootAndLog, resolveRootConfig } from './bootstrap.ts';
+import { createMemoryAccountStore } from './store.ts';
+
+describe('resolveRootConfig', () => {
+  it('defaults username/name and omits an unset password', () => {
+    expect(resolveRootConfig({})).toEqual({ username: 'root', name: 'Root' });
+  });
+
+  it('reads the environment', () => {
+    expect(
+      resolveRootConfig({ ROOT_USERNAME: 'admin', ROOT_NAME: 'Boss', ROOT_PASSWORD: 'pw' }),
+    ).toEqual({ username: 'admin', name: 'Boss', password: 'pw' });
+  });
+});
+
+describe('bootstrapRoot', () => {
+  it('seeds a root with a generated password when none is supplied', async () => {
+    const store = createMemoryAccountStore();
+    const result = await bootstrapRoot(store, { username: 'root', name: 'Root' });
+
+    expect(result.created).toBe(true);
+    expect(result.account?.isRoot).toBe(true);
+    expect(result.generatedPassword).toBeTruthy();
+    // The generated password actually works.
+    const login = await store.verifyCredentials('root', result.generatedPassword as string);
+    expect(login?.id).toBe(result.account?.id);
+    expect(await store.hasRoot()).toBe(true);
+  });
+
+  it('uses a supplied password and reports no generated one', async () => {
+    const store = createMemoryAccountStore();
+    const result = await bootstrapRoot(store, { username: 'root', name: 'Root', password: 'set-me' });
+    expect(result.created).toBe(true);
+    expect(result.generatedPassword).toBeUndefined();
+    expect(await store.verifyCredentials('root', 'set-me')).not.toBeNull();
+  });
+
+  it('is idempotent — a second call creates nothing', async () => {
+    const store = createMemoryAccountStore();
+    await bootstrapRoot(store, { username: 'root', name: 'Root', password: 'x' });
+    const again = await bootstrapRoot(store, { username: 'root', name: 'Root', password: 'x' });
+    expect(again).toEqual({ created: false });
+  });
+});
+
+describe('bootstrapRootAndLog', () => {
+  it('logs the generated password exactly once, on creation', async () => {
+    const store = createMemoryAccountStore();
+    const logger = { log: vi.fn(), warn: vi.fn() };
+    const result = await bootstrapRootAndLog(store, { username: 'root', name: 'Root' }, logger);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0]?.[0]).toContain(result.generatedPassword as string);
+  });
+
+  it('does not log a secret when the root already exists', async () => {
+    const store = createMemoryAccountStore();
+    await bootstrapRoot(store, { username: 'root', name: 'Root', password: 'x' });
+    const logger = { log: vi.fn(), warn: vi.fn() };
+    await bootstrapRootAndLog(store, { username: 'root', name: 'Root' }, logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith('root account "root" already exists');
+  });
+});

--- a/server/auth/bootstrap.ts
+++ b/server/auth/bootstrap.ts
@@ -1,0 +1,101 @@
+/**
+ * Root-account bootstrap (BACKLOG.md #20).
+ *
+ * Trust in the vouch graph flows out from a *root* account (see `./store.ts`), so
+ * the deployment needs exactly one to exist before anyone can be vouched for.
+ * {@link bootstrapRoot} seeds it idempotently: if a root already exists it does
+ * nothing, so it is safe to run on every boot alongside the DB migrations.
+ *
+ * The root's credentials come from the environment (`ROOT_USERNAME`,
+ * `ROOT_PASSWORD`, `ROOT_NAME`). When no `ROOT_PASSWORD` is configured a strong
+ * random one is generated and returned to the caller **once**, to be logged at
+ * boot — so a fresh self-hosted install always has a working, non-guessable root
+ * login even if the operator didn't set a password, and never a silent default.
+ */
+import { randomBytes } from 'node:crypto';
+import type { Account, AccountStore } from './store.ts';
+
+/** Resolved root credentials for {@link bootstrapRoot}. */
+export interface RootConfig {
+  username: string;
+  name: string;
+  /** Explicit password; when absent one is generated. */
+  password?: string;
+}
+
+/** The outcome of a bootstrap attempt. */
+export interface BootstrapResult {
+  /** Whether a root was created by this call (false if one already existed). */
+  created: boolean;
+  /** The created root account, present only when `created` is true. */
+  account?: Account;
+  /**
+   * The generated password, present only when a root was created *and* no
+   * `ROOT_PASSWORD` was supplied — surface it to the operator, then forget it.
+   */
+  generatedPassword?: string;
+}
+
+/**
+ * Read the root config from the environment. `ROOT_USERNAME` defaults to `root`
+ * and `ROOT_NAME` to `Root`; `ROOT_PASSWORD` is optional (generated when unset).
+ */
+export function resolveRootConfig(env: NodeJS.ProcessEnv = process.env): RootConfig {
+  const username = env.ROOT_USERNAME?.trim() || 'root';
+  const name = env.ROOT_NAME?.trim() || 'Root';
+  const password = env.ROOT_PASSWORD?.trim() || undefined;
+  return { username, name, ...(password ? { password } : {}) };
+}
+
+/** A URL-safe, high-entropy password for a generated root credential. */
+function generatePassword(): string {
+  return randomBytes(24).toString('base64url');
+}
+
+/**
+ * Ensure a root account exists. Idempotent: returns `{ created: false }` when one
+ * is already present. Otherwise creates the root from `config` (generating a
+ * password when none was supplied) and returns it.
+ */
+export async function bootstrapRoot(
+  store: AccountStore,
+  config: RootConfig = resolveRootConfig(),
+): Promise<BootstrapResult> {
+  if (await store.hasRoot()) return { created: false };
+
+  const generatedPassword = config.password ? undefined : generatePassword();
+  const account = await store.createAccount({
+    name: config.name,
+    username: config.username,
+    password: config.password ?? (generatedPassword as string),
+    isRoot: true,
+  });
+  return { created: true, account, ...(generatedPassword ? { generatedPassword } : {}) };
+}
+
+/**
+ * Bootstrap the root and log the outcome — the boot-time entry point. When a
+ * password was generated it is logged once (the only time it is ever available)
+ * so the operator can capture it; a supplied or pre-existing root logs nothing
+ * sensitive.
+ */
+export async function bootstrapRootAndLog(
+  store: AccountStore,
+  config: RootConfig = resolveRootConfig(),
+  logger: Pick<Console, 'log' | 'warn'> = console,
+): Promise<BootstrapResult> {
+  const result = await bootstrapRoot(store, config);
+  if (!result.created) {
+    logger.log(`root account "${config.username}" already exists`);
+  } else if (result.generatedPassword) {
+    logger.warn(
+      `seeded root account "${config.username}" with a generated password: ` +
+        `${result.generatedPassword}\n` +
+        'Save it now — it will not be shown again. ' +
+        'Set ROOT_PASSWORD to control the credential yourself.',
+    );
+  } else {
+    logger.log(`seeded root account "${config.username}" from ROOT_PASSWORD`);
+  }
+  return result;
+}

--- a/server/auth/index.ts
+++ b/server/auth/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Auth subsystem barrel (BACKLOG.md #20): password hashing, signed session
+ * tokens, the account + vouch (web-of-trust) store (in-memory + PostgreSQL),
+ * root bootstrap, and the `/api/auth` HTTP router. Mirrors `server/push/index.ts`.
+ */
+export * from './password.ts';
+export * from './session.ts';
+export * from './store.ts';
+export * from './postgres.ts';
+export * from './bootstrap.ts';
+export * from './routes.ts';

--- a/server/auth/password.test.ts
+++ b/server/auth/password.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { hashPassword, verifyPassword } from './password.ts';
+
+describe('password hashing', () => {
+  it('verifies a correct password', async () => {
+    const hash = await hashPassword('correct horse battery staple');
+    expect(await verifyPassword('correct horse battery staple', hash)).toBe(true);
+  });
+
+  it('rejects a wrong password', async () => {
+    const hash = await hashPassword('s3cret');
+    expect(await verifyPassword('S3cret', hash)).toBe(false);
+    expect(await verifyPassword('', hash)).toBe(false);
+  });
+
+  it('salts each hash, so identical passwords differ', async () => {
+    const a = await hashPassword('same');
+    const b = await hashPassword('same');
+    expect(a).not.toEqual(b);
+    // Both still verify against their own hash.
+    expect(await verifyPassword('same', a)).toBe(true);
+    expect(await verifyPassword('same', b)).toBe(true);
+  });
+
+  it('produces the self-describing scrypt format', async () => {
+    const hash = await hashPassword('x');
+    const parts = hash.split('$');
+    expect(parts).toHaveLength(6);
+    expect(parts[0]).toBe('scrypt');
+    // N, r, p are integers.
+    expect(Number.isInteger(Number(parts[1]))).toBe(true);
+  });
+
+  it('fails closed on a malformed stored hash instead of throwing', async () => {
+    expect(await verifyPassword('x', '')).toBe(false);
+    expect(await verifyPassword('x', 'not-a-hash')).toBe(false);
+    expect(await verifyPassword('x', 'scrypt$16384$8$1$onlyfiveparts')).toBe(false);
+    expect(await verifyPassword('x', 'bcrypt$16384$8$1$abc$def')).toBe(false);
+    expect(await verifyPassword('x', 'scrypt$x$8$1$c2FsdA$aGFzaA')).toBe(false);
+  });
+
+  it('re-derives with the parameters embedded in the hash', async () => {
+    // A hash written with a smaller N still verifies (params come from the string,
+    // not today's default), so cost can be tuned without invalidating old hashes.
+    const { scrypt } = await import('node:crypto');
+    const salt = Buffer.from('sixteenbytesalt!');
+    const key: Buffer = await new Promise((resolve, reject) =>
+      scrypt('legacy', salt, 32, { N: 1024, r: 8, p: 1 }, (e, k) =>
+        e ? reject(e) : resolve(k),
+      ),
+    );
+    const stored = ['scrypt', 1024, 8, 1, salt.toString('base64url'), key.toString('base64url')].join(
+      '$',
+    );
+    expect(await verifyPassword('legacy', stored)).toBe(true);
+    expect(await verifyPassword('wrong', stored)).toBe(false);
+  });
+});

--- a/server/auth/password.ts
+++ b/server/auth/password.ts
@@ -1,0 +1,116 @@
+/**
+ * Password hashing for account sign-in (BACKLOG.md #20).
+ *
+ * Passwords are never stored or compared in the clear. Each is salted and run
+ * through **scrypt** — a deliberately slow, memory-hard KDF from Node's built-in
+ * `crypto`, so no third-party dependency is pulled in for a security-critical
+ * primitive. The stored value is self-describing:
+ *
+ *     scrypt$<N>$<r>$<p>$<saltB64url>$<hashB64url>
+ *
+ * carrying the cost parameters used at hash time, so they can be tuned later
+ * without invalidating existing hashes — {@link verifyPassword} re-derives with
+ * the parameters embedded in the stored string, not today's defaults.
+ *
+ * Verification is constant-time (`timingSafeEqual`) and never throws on a
+ * malformed stored value: a hash it can't parse simply fails to verify, so a
+ * corrupt row can't crash a sign-in or, worse, be coerced into matching.
+ */
+import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
+
+/**
+ * scrypt cost parameters. `N` (CPU/memory cost) is the dominant knob; 2^15 with
+ * r=8, p=1 is a common interactive-login target that stays well under a phone's
+ * patience while being expensive to brute-force. `keylen` is the derived-key
+ * length in bytes.
+ */
+const N = 2 ** 15;
+const R = 8;
+const P = 1;
+const KEYLEN = 32;
+const SALT_BYTES = 16;
+
+/**
+ * scrypt needs a `maxmem` above its default 32 MiB once N·r·p·128 grows past it;
+ * derive a headroom-padded ceiling from the parameters so a higher cost doesn't
+ * trip `ERR_CRYPTO_INVALID_SCRYPT_PARAMS`.
+ */
+function maxmemFor(n: number, r: number, p: number): number {
+  return Math.max(32 * 1024 * 1024, 256 * n * r * p);
+}
+
+/** Promisified scrypt returning the derived key for the given parameters. */
+function derive(
+  password: string,
+  salt: Buffer,
+  n: number,
+  r: number,
+  p: number,
+  keylen: number,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(
+      password,
+      salt,
+      keylen,
+      { N: n, r, p, maxmem: maxmemFor(n, r, p) },
+      (err, derivedKey) => {
+        if (err) reject(err);
+        else resolve(derivedKey);
+      },
+    );
+  });
+}
+
+/**
+ * Hash a password into a self-describing, storable string. A fresh random salt
+ * is drawn per call, so identical passwords never yield identical hashes.
+ */
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(SALT_BYTES);
+  const key = await derive(password, salt, N, R, P, KEYLEN);
+  return [
+    'scrypt',
+    N,
+    R,
+    P,
+    salt.toString('base64url'),
+    key.toString('base64url'),
+  ].join('$');
+}
+
+/**
+ * Verify a password against a stored hash produced by {@link hashPassword}.
+ * Returns `false` — never throws — for a wrong password or a hash string this
+ * function can't parse, so a malformed row fails closed instead of crashing the
+ * caller or being tricked into a match.
+ */
+export async function verifyPassword(password: string, stored: string): Promise<boolean> {
+  const parts = stored.split('$');
+  if (parts.length !== 6 || parts[0] !== 'scrypt') return false;
+  const n = Number(parts[1]);
+  const r = Number(parts[2]);
+  const p = Number(parts[3]);
+  if (!Number.isInteger(n) || !Number.isInteger(r) || !Number.isInteger(p)) return false;
+
+  let salt: Buffer;
+  let expected: Buffer;
+  try {
+    salt = Buffer.from(parts[4] as string, 'base64url');
+    expected = Buffer.from(parts[5] as string, 'base64url');
+  } catch {
+    return false;
+  }
+  if (salt.length === 0 || expected.length === 0) return false;
+
+  let actual: Buffer;
+  try {
+    actual = await derive(password, salt, n, r, p, expected.length);
+  } catch {
+    return false;
+  }
+  // Equal lengths by construction (we derive `expected.length` bytes), but guard
+  // anyway — timingSafeEqual throws on a length mismatch.
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}

--- a/server/auth/postgres.test.ts
+++ b/server/auth/postgres.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { createPostgresAccountStore } from './postgres.ts';
+import { hashPassword } from './password.ts';
+import { AuthError } from './store.ts';
+import type { Queryable } from '../db/migrate.ts';
+
+/** A pg error carries a SQLSTATE `code`; fake one to exercise the translations. */
+function pgError(code: string): Error {
+  return Object.assign(new Error(`pg ${code}`), { code });
+}
+
+interface Call {
+  sql: string;
+  params?: unknown[];
+}
+
+/**
+ * A scriptable `Queryable` stand-in: match incoming SQL by substring to a handler
+ * that returns rows (or throws), recording every call for assertions.
+ */
+function fakeDb(
+  handlers: Array<{ match: string; rows?: Array<Record<string, unknown>>; throws?: Error }>,
+): Queryable & { calls: Call[] } {
+  const calls: Call[] = [];
+  return {
+    calls,
+    async query(sql: string, params?: unknown[]) {
+      calls.push({ sql, params });
+      const handler = handlers.find((h) => sql.includes(h.match));
+      if (!handler) throw new Error(`unexpected SQL: ${sql}`);
+      if (handler.throws) throw handler.throws;
+      return { rows: handler.rows ?? [] };
+    },
+  };
+}
+
+describe('postgres account store', () => {
+  const row = {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'Alice',
+    username: 'alice',
+    is_root: false,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  it('creates an account, normalizing input and mapping the row', async () => {
+    const db = fakeDb([{ match: 'insert into accounts', rows: [row] }]);
+    const store = createPostgresAccountStore(db);
+    const account = await store.createAccount({ name: '  Alice ', username: '  ALICE ', password: 'pw' });
+
+    expect(account).toEqual({
+      id: row.id,
+      name: 'Alice',
+      username: 'alice',
+      isRoot: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const insert = db.calls[0];
+    expect(insert?.params?.[0]).toBe('Alice'); // trimmed name
+    expect(insert?.params?.[1]).toBe('alice'); // normalized username
+    expect(typeof insert?.params?.[2]).toBe('string'); // a hash, not the raw password
+    expect(insert?.params?.[2]).not.toBe('pw');
+  });
+
+  it('translates a unique violation into username_taken', async () => {
+    const db = fakeDb([{ match: 'insert into accounts', throws: pgError('23505') }]);
+    const store = createPostgresAccountStore(db);
+    await expect(
+      store.createAccount({ name: 'A', username: 'dup', password: 'p' }),
+    ).rejects.toMatchObject({ code: 'username_taken' });
+  });
+
+  it('looks accounts up by id and username', async () => {
+    const db = fakeDb([{ match: 'where id = $1', rows: [row] }]);
+    const store = createPostgresAccountStore(db);
+    expect(await store.getById(row.id)).toMatchObject({ id: row.id });
+
+    const empty = fakeDb([{ match: 'where username = $1', rows: [] }]);
+    expect(await createPostgresAccountStore(empty).getByUsername('nobody')).toBeNull();
+    expect(empty.calls[0]?.params?.[0]).toBe('nobody');
+  });
+
+  it('verifies credentials against the stored hash', async () => {
+    const hash = await hashPassword('hunter2');
+    const db = fakeDb([
+      { match: 'password_hash from accounts', rows: [{ ...row, password_hash: hash }] },
+    ]);
+    const store = createPostgresAccountStore(db);
+    expect(await store.verifyCredentials('alice', 'hunter2')).toMatchObject({ id: row.id });
+    expect(await store.verifyCredentials('alice', 'wrong')).toBeNull();
+  });
+
+  it('returns null credentials when the account or hash is missing', async () => {
+    const noRow = createPostgresAccountStore(
+      fakeDb([{ match: 'password_hash from accounts', rows: [] }]),
+    );
+    expect(await noRow.verifyCredentials('ghost', 'x')).toBeNull();
+
+    const noHash = createPostgresAccountStore(
+      fakeDb([{ match: 'password_hash from accounts', rows: [{ ...row, password_hash: null }] }]),
+    );
+    expect(await noHash.verifyCredentials('alice', 'x')).toBeNull();
+  });
+
+  it('records a vouch and rejects self / unknown accounts', async () => {
+    const ok = fakeDb([{ match: 'insert into vouches', rows: [] }]);
+    const store = createPostgresAccountStore(ok);
+    await store.vouch('a', 'b');
+    expect(ok.calls[0]?.params).toEqual(['a', 'b']);
+
+    // Self-vouch is caught before any query.
+    const untouched = fakeDb([]);
+    await expect(createPostgresAccountStore(untouched).vouch('a', 'a')).rejects.toBeInstanceOf(
+      AuthError,
+    );
+    expect(untouched.calls).toHaveLength(0);
+
+    const fk = createPostgresAccountStore(
+      fakeDb([{ match: 'insert into vouches', throws: pgError('23503') }]),
+    );
+    await expect(fk.vouch('a', 'ghost')).rejects.toMatchObject({ code: 'account_not_found' });
+  });
+
+  it('reads trust and root existence as booleans', async () => {
+    const trusted = createPostgresAccountStore(
+      fakeDb([{ match: 'recursive trusted', rows: [{ trusted: true }] }]),
+    );
+    expect(await trusted.isTrusted('a')).toBe(true);
+
+    const untrusted = createPostgresAccountStore(
+      fakeDb([{ match: 'recursive trusted', rows: [{ trusted: false }] }]),
+    );
+    expect(await untrusted.isTrusted('a')).toBe(false);
+
+    const hasRoot = createPostgresAccountStore(
+      fakeDb([{ match: 'where is_root', rows: [{ has: true }] }]),
+    );
+    expect(await hasRoot.hasRoot()).toBe(true);
+  });
+});

--- a/server/auth/postgres.ts
+++ b/server/auth/postgres.ts
@@ -1,0 +1,141 @@
+/**
+ * The PostgreSQL-backed {@link AccountStore} (BACKLOG.md #20) — the production
+ * account + trust store, over the `accounts` and `vouches` tables from migration
+ * 0002. It shares the input validation and hashing with the in-memory store so
+ * both reject the same bad input and store the same self-describing scrypt
+ * digests; only persistence differs.
+ *
+ * Trust is resolved in the database with a recursive CTE that walks vouch edges
+ * out from the root(s), so a single round-trip answers "is this account
+ * reachable from a root" without pulling the whole graph into the process.
+ */
+import { hashPassword, verifyPassword } from './password.ts';
+import {
+  AuthError,
+  normalizeNewAccount,
+  normalizeUsername,
+  type Account,
+  type AccountStore,
+  type NewAccount,
+} from './store.ts';
+import type { Queryable } from '../db/migrate.ts';
+
+/** PostgreSQL SQLSTATE codes we translate into {@link AuthError}s. */
+const UNIQUE_VIOLATION = '23505';
+const FOREIGN_KEY_VIOLATION = '23503';
+
+/** The columns selected for a public {@link Account}, in a stable order. */
+const ACCOUNT_COLUMNS = 'id, name, username, is_root, created_at';
+
+/** Map a selected `accounts` row to a public {@link Account}. */
+function toAccount(row: Record<string, unknown>): Account {
+  const createdAt = row.created_at;
+  return {
+    id: String(row.id),
+    name: String(row.name),
+    username: row.username == null ? null : String(row.username),
+    isRoot: Boolean(row.is_root),
+    createdAt:
+      createdAt instanceof Date ? createdAt.toISOString() : String(createdAt),
+  };
+}
+
+/** The SQLSTATE code of a `pg` error, if it carries one. */
+function sqlState(err: unknown): string | undefined {
+  return (err as { code?: string })?.code;
+}
+
+/**
+ * Build a PostgreSQL-backed {@link AccountStore} over a `Queryable` — a `pg.Pool`,
+ * a pooled client, or a fake in tests. The store issues plain parameterized
+ * queries and never holds a transaction across calls, so a shared pool is fine.
+ */
+export function createPostgresAccountStore(db: Queryable): AccountStore {
+  return {
+    async createAccount(input: NewAccount): Promise<Account> {
+      const { name, username, password, isRoot } = normalizeNewAccount(input);
+      const passwordHash = await hashPassword(password);
+      try {
+        const { rows } = await db.query(
+          `insert into accounts (name, username, password_hash, is_root)
+             values ($1, $2, $3, $4)
+             returning ${ACCOUNT_COLUMNS}`,
+          [name, username, passwordHash, isRoot],
+        );
+        return toAccount(rows[0] as Record<string, unknown>);
+      } catch (err) {
+        if (sqlState(err) === UNIQUE_VIOLATION) {
+          throw new AuthError('username_taken', 'That username is taken');
+        }
+        throw err;
+      }
+    },
+
+    async getById(id) {
+      const { rows } = await db.query(
+        `select ${ACCOUNT_COLUMNS} from accounts where id = $1`,
+        [id],
+      );
+      return rows[0] ? toAccount(rows[0]) : null;
+    },
+
+    async getByUsername(username) {
+      const { rows } = await db.query(
+        `select ${ACCOUNT_COLUMNS} from accounts where username = $1`,
+        [normalizeUsername(username)],
+      );
+      return rows[0] ? toAccount(rows[0]) : null;
+    },
+
+    async verifyCredentials(username, password) {
+      const { rows } = await db.query(
+        `select ${ACCOUNT_COLUMNS}, password_hash from accounts where username = $1`,
+        [normalizeUsername(username)],
+      );
+      const row = rows[0];
+      const hash = row?.password_hash;
+      if (!row || typeof hash !== 'string' || hash === '') return null;
+      const ok = await verifyPassword(password, hash);
+      return ok ? toAccount(row) : null;
+    },
+
+    async vouch(voucherId, voucheeId) {
+      if (voucherId === voucheeId) {
+        throw new AuthError('self_vouch', 'An account cannot vouch for itself');
+      }
+      try {
+        await db.query(
+          `insert into vouches (voucher_id, vouchee_id) values ($1, $2)
+             on conflict do nothing`,
+          [voucherId, voucheeId],
+        );
+      } catch (err) {
+        if (sqlState(err) === FOREIGN_KEY_VIOLATION) {
+          throw new AuthError('account_not_found', 'No such account');
+        }
+        throw err;
+      }
+    },
+
+    async isTrusted(accountId) {
+      const { rows } = await db.query(
+        `with recursive trusted as (
+           select id from accounts where is_root
+           union
+           select v.vouchee_id from vouches v
+             join trusted t on v.voucher_id = t.id
+         )
+         select exists(select 1 from trusted where id = $1) as trusted`,
+        [accountId],
+      );
+      return Boolean(rows[0]?.trusted);
+    },
+
+    async hasRoot() {
+      const { rows } = await db.query(
+        'select exists(select 1 from accounts where is_root) as has',
+      );
+      return Boolean(rows[0]?.has);
+    },
+  };
+}

--- a/server/auth/routes.ts
+++ b/server/auth/routes.ts
@@ -1,0 +1,197 @@
+/**
+ * The auth HTTP surface (BACKLOG.md #20): register, sign in/out, "who am I", and
+ * vouch — mounted at `/api/auth` by `createServer`. This is the only REST-ish
+ * corner of an otherwise Socket.IO server (docs/arc42.md §3), so it keeps its own
+ * `express.json()` body parsing and cookie handling scoped to the router rather
+ * than adding global middleware.
+ *
+ * A successful register/login mints a {@link SessionCodec} token and sets it as an
+ * **httpOnly** cookie, so client JavaScript can't read the session and it rides
+ * along automatically on later requests. Identity on every authenticated route is
+ * taken from that signed cookie — never from the request body — mirroring the
+ * socket layer's "identity is server-authoritative" rule.
+ */
+import express, { type Request, type Response, type Router } from 'express';
+import { AuthError, type Account, type AccountStore } from './store.ts';
+import type { SessionCodec } from './session.ts';
+
+/** The session cookie name. */
+export const SESSION_COOKIE = 'session';
+
+interface AuthRouterOptions {
+  store: AccountStore;
+  sessions: SessionCodec;
+  /**
+   * Whether to mark the session cookie `Secure`. Defaults to following the
+   * request (`req.secure`) so it is set behind Caddy's HTTPS but omitted over
+   * plain HTTP in dev/tests, where a `Secure` cookie would be dropped.
+   */
+  secureCookie?: boolean;
+}
+
+/** HTTP status for each recoverable {@link AuthError}. */
+const STATUS_BY_CODE: Record<AuthError['code'], number> = {
+  name_required: 400,
+  username_required: 400,
+  password_required: 400,
+  username_taken: 409,
+  account_not_found: 404,
+  self_vouch: 400,
+};
+
+/** An account plus its computed trust, the shape every auth route returns. */
+async function present(
+  store: AccountStore,
+  account: Account,
+): Promise<Account & { trusted: boolean }> {
+  return { ...account, trusted: await store.isTrusted(account.id) };
+}
+
+/** Parse a `Cookie` header into a name→value map. Tolerant of odd whitespace. */
+function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name === '') continue;
+    out[name] = decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+/**
+ * Resolve the caller's session token from the request: the session cookie first,
+ * then a `Authorization: Bearer <token>` header (handy for API clients and
+ * tests). Returns the account id if the token verifies, else `null`.
+ */
+function sessionAccountId(req: Request, sessions: SessionCodec): string | null {
+  const cookies = parseCookies(req.headers.cookie);
+  const bearer = /^Bearer (.+)$/i.exec(req.headers.authorization ?? '');
+  const token = cookies[SESSION_COOKIE] ?? bearer?.[1];
+  return sessions.verify(token)?.accountId ?? null;
+}
+
+/** Send an {@link AuthError} as a JSON error with its mapped status. */
+function sendAuthError(res: Response, err: unknown): boolean {
+  if (err instanceof AuthError) {
+    res.status(STATUS_BY_CODE[err.code]).json({ error: err.message, code: err.code });
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Build the `/api/auth` router. `store` persists accounts + trust; `sessions`
+ * mints and verifies the cookie token.
+ */
+export function createAuthRouter({
+  store,
+  sessions,
+  secureCookie,
+}: AuthRouterOptions): Router {
+  const router = express.Router();
+  router.use(express.json());
+
+  // Set the httpOnly session cookie for a freshly authenticated account.
+  const setSession = (req: Request, res: Response, account: Account): void => {
+    res.cookie(SESSION_COOKIE, sessions.sign(account.id), {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: secureCookie ?? req.secure,
+      path: '/',
+      maxAge: sessions.ttlSeconds * 1000,
+    });
+  };
+
+  // The signed-in account, or null. Shared by /me and /vouch.
+  const requireAccount = async (
+    req: Request,
+    res: Response,
+  ): Promise<Account | null> => {
+    const id = sessionAccountId(req, sessions);
+    const account = id ? await store.getById(id) : null;
+    if (!account) {
+      res.status(401).json({ error: 'Not signed in', code: 'unauthenticated' });
+      return null;
+    }
+    return account;
+  };
+
+  // Create an account and sign it in.
+  router.post('/register', async (req: Request, res: Response) => {
+    const { name, username, password } = (req.body ?? {}) as Record<string, unknown>;
+    try {
+      const account = await store.createAccount({
+        name: typeof name === 'string' ? name : '',
+        username: typeof username === 'string' ? username : '',
+        password: typeof password === 'string' ? password : '',
+      });
+      setSession(req, res, account);
+      res.status(201).json({ account: await present(store, account) });
+    } catch (err) {
+      if (sendAuthError(res, err)) return;
+      throw err;
+    }
+  });
+
+  // Sign in with username + password.
+  router.post('/login', async (req: Request, res: Response) => {
+    const { username, password } = (req.body ?? {}) as Record<string, unknown>;
+    const account =
+      typeof username === 'string' && typeof password === 'string'
+        ? await store.verifyCredentials(username, password)
+        : null;
+    if (!account) {
+      res.status(401).json({ error: 'Invalid username or password', code: 'invalid_credentials' });
+      return;
+    }
+    setSession(req, res, account);
+    res.json({ account: await present(store, account) });
+  });
+
+  // Sign out: clear the cookie. Always succeeds (idempotent).
+  router.post('/logout', (req: Request, res: Response) => {
+    res.clearCookie(SESSION_COOKIE, { path: '/' });
+    res.json({ ok: true });
+  });
+
+  // The current account, from the session cookie.
+  router.get('/me', async (req: Request, res: Response) => {
+    const account = await requireAccount(req, res);
+    if (!account) return;
+    res.json({ account: await present(store, account) });
+  });
+
+  // Vouch for another account. The voucher is always the signed-in caller — the
+  // body only names the vouchee (by id or username), never the voucher — so a
+  // root (or any trusted account) extends trust outward but no one can forge a
+  // vouch *from* someone else. Root's ability to vouch is the acceptance
+  // criterion; the same path serves any account.
+  router.post('/vouch', async (req: Request, res: Response) => {
+    const voucher = await requireAccount(req, res);
+    if (!voucher) return;
+    const { accountId, username } = (req.body ?? {}) as Record<string, unknown>;
+
+    const vouchee =
+      typeof accountId === 'string'
+        ? await store.getById(accountId)
+        : typeof username === 'string'
+          ? await store.getByUsername(username)
+          : null;
+    if (!vouchee) {
+      res.status(404).json({ error: 'No such account', code: 'account_not_found' });
+      return;
+    }
+    try {
+      await store.vouch(voucher.id, vouchee.id);
+      res.json({ ok: true, vouchee: await present(store, vouchee) });
+    } catch (err) {
+      if (sendAuthError(res, err)) return;
+      throw err;
+    }
+  });
+
+  return router;
+}

--- a/server/auth/session.test.ts
+++ b/server/auth/session.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionCodec, resolveSessionSecret } from './session.ts';
+
+describe('session codec', () => {
+  it('round-trips an account id', () => {
+    const codec = createSessionCodec({ secret: 'test-secret' });
+    const token = codec.sign('acct-1');
+    expect(codec.verify(token)).toMatchObject({ accountId: 'acct-1' });
+  });
+
+  it('rejects a tampered payload', () => {
+    const codec = createSessionCodec({ secret: 'test-secret' });
+    const token = codec.sign('acct-1');
+    const [version, body, sig] = token.split('.');
+    // Swap the payload for a different account id, keep the old signature.
+    const forgedBody = Buffer.from(JSON.stringify({ sub: 'acct-2', iat: 1, exp: 9_999_999_999 }))
+      .toString('base64url');
+    expect(codec.verify(`${version}.${forgedBody}.${sig}`)).toBeNull();
+    void body;
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const a = createSessionCodec({ secret: 'secret-a' });
+    const b = createSessionCodec({ secret: 'secret-b' });
+    expect(b.verify(a.sign('acct-1'))).toBeNull();
+  });
+
+  it('rejects an expired token', () => {
+    let now = 1_000_000_000_000;
+    const codec = createSessionCodec({ secret: 's', ttlSeconds: 60, now: () => now });
+    const token = codec.sign('acct-1');
+    expect(codec.verify(token)).not.toBeNull();
+    now += 61_000; // past the 60s TTL
+    expect(codec.verify(token)).toBeNull();
+  });
+
+  it('rejects malformed / missing tokens without throwing', () => {
+    const codec = createSessionCodec({ secret: 's' });
+    expect(codec.verify(undefined)).toBeNull();
+    expect(codec.verify(null)).toBeNull();
+    expect(codec.verify('')).toBeNull();
+    expect(codec.verify('a.b')).toBeNull();
+    expect(codec.verify('v9.body.sig')).toBeNull();
+    expect(codec.verify('v1.@@@.sig')).toBeNull();
+  });
+
+  it('exposes the TTL for cookie max-age', () => {
+    expect(createSessionCodec({ secret: 's', ttlSeconds: 123 }).ttlSeconds).toBe(123);
+  });
+});
+
+describe('resolveSessionSecret', () => {
+  it('returns an explicit secret', () => {
+    expect(resolveSessionSecret('provided')).toBe('provided');
+  });
+
+  it('falls back to a random secret with a warning when unset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = resolveSessionSecret(undefined);
+    const b = resolveSessionSecret('');
+    expect(a).toBeTruthy();
+    expect(a).not.toEqual(b); // random each time
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/server/auth/session.ts
+++ b/server/auth/session.ts
@@ -1,0 +1,130 @@
+/**
+ * Signed session tokens (BACKLOG.md #20).
+ *
+ * A session is **stateless**: rather than keeping a server-side session table,
+ * the account id is packed into a compact token and signed with an HMAC keyed by
+ * `SESSION_SECRET` (the env var the deploy already provisions — see
+ * `.env.example` and docs/arc42.md §7). The server trusts a token only if the
+ * signature verifies and it hasn't expired, so nothing that reaches it from a
+ * cookie is believed without the key it can't forge.
+ *
+ *     v1.<payloadB64url>.<sigB64url>
+ *
+ * where the payload is `{ sub, iat, exp }` (account id, issued-at, expiry — epoch
+ * seconds) and the signature is `HMAC-SHA256(secret, "v1.<payloadB64url>")`.
+ * Verification is constant-time and never throws: a garbled, tampered, or expired
+ * token simply resolves to `null` and the request is treated as anonymous.
+ *
+ * Stateless tokens can't be individually revoked; rotating `SESSION_SECRET`
+ * invalidates every outstanding session at once, which is the intended blunt
+ * lever for a small self-hosted deployment. Durable, revocable sessions are a
+ * later concern.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Token version prefix, so the format can evolve without misreading old tokens. */
+const VERSION = 'v1';
+
+/** Default session lifetime: 30 days, in seconds. */
+export const DEFAULT_SESSION_TTL_S = 30 * 24 * 60 * 60;
+
+/** The decoded, verified contents of a session token. */
+export interface SessionClaims {
+  /** The authenticated account id. */
+  accountId: string;
+  /** Issued-at, epoch seconds. */
+  issuedAt: number;
+  /** Expiry, epoch seconds. */
+  expiresAt: number;
+}
+
+/** Mints and verifies session tokens for one signing secret + lifetime. */
+export interface SessionCodec {
+  /** Sign a token for `accountId`, valid for the configured TTL from now. */
+  sign(accountId: string): string;
+  /** Verify a token, returning its claims, or `null` if invalid/expired. */
+  verify(token: string | undefined | null): SessionClaims | null;
+  /** The cookie max-age (seconds) callers should set, matching the token TTL. */
+  readonly ttlSeconds: number;
+}
+
+interface CodecOptions {
+  /**
+   * HMAC signing key. Defaults to `SESSION_SECRET`; when that is unset a random
+   * per-process secret is generated (with a warning) so dev still works, at the
+   * cost of every session being invalidated on restart.
+   */
+  secret?: string;
+  /** Session lifetime in seconds. Defaults to {@link DEFAULT_SESSION_TTL_S}. */
+  ttlSeconds?: number;
+  /** Clock injection for tests; defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Resolve the HMAC secret. An explicit value wins; otherwise `SESSION_SECRET`;
+ * otherwise a random ephemeral secret is minted and a warning logged, since a
+ * missing secret must never silently disable signing.
+ */
+export function resolveSessionSecret(
+  raw: string | undefined = process.env.SESSION_SECRET,
+): string {
+  if (raw && raw.trim() !== '') return raw;
+  console.warn(
+    'SESSION_SECRET is not set — using a random per-process secret; ' +
+      'sessions will not survive a restart. Set SESSION_SECRET in production.',
+  );
+  return randomBytes(32).toString('base64url');
+}
+
+/** Constant-time string compare that tolerates unequal lengths. */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/** Build a {@link SessionCodec} over a signing secret and lifetime. */
+export function createSessionCodec({
+  secret = resolveSessionSecret(),
+  ttlSeconds = DEFAULT_SESSION_TTL_S,
+  now = Date.now,
+}: CodecOptions = {}): SessionCodec {
+  const sign = (payloadPart: string): string =>
+    createHmac('sha256', secret).update(payloadPart).digest('base64url');
+
+  return {
+    ttlSeconds,
+
+    sign(accountId) {
+      const issuedAt = Math.floor(now() / 1000);
+      const claims = { sub: accountId, iat: issuedAt, exp: issuedAt + ttlSeconds };
+      const body = Buffer.from(JSON.stringify(claims)).toString('base64url');
+      const payloadPart = `${VERSION}.${body}`;
+      return `${payloadPart}.${sign(payloadPart)}`;
+    },
+
+    verify(token) {
+      if (!token) return null;
+      const parts = token.split('.');
+      if (parts.length !== 3) return null;
+      const [version, body, signature] = parts as [string, string, string];
+      if (version !== VERSION) return null;
+      if (!safeEqual(signature, sign(`${version}.${body}`))) return null;
+
+      let claims: { sub?: unknown; iat?: unknown; exp?: unknown };
+      try {
+        claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+      } catch {
+        return null;
+      }
+      const { sub, iat, exp } = claims;
+      if (typeof sub !== 'string' || typeof iat !== 'number' || typeof exp !== 'number') {
+        return null;
+      }
+      if (Math.floor(now() / 1000) >= exp) return null;
+      return { accountId: sub, issuedAt: iat, expiresAt: exp };
+    },
+  };
+}

--- a/server/auth/store.test.ts
+++ b/server/auth/store.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { AuthError, createMemoryAccountStore, normalizeUsername } from './store.ts';
+
+describe('normalizeUsername', () => {
+  it('trims and lower-cases', () => {
+    expect(normalizeUsername('  Alice ')).toBe('alice');
+    expect(normalizeUsername('BOB')).toBe('bob');
+  });
+});
+
+describe('memory account store', () => {
+  it('creates an account and looks it up, never exposing the hash', async () => {
+    const store = createMemoryAccountStore();
+    const account = await store.createAccount({ name: 'Alice', username: 'Alice', password: 'pw' });
+    expect(account).toMatchObject({ name: 'Alice', username: 'alice', isRoot: false });
+    expect(account).not.toHaveProperty('passwordHash');
+    expect(account).not.toHaveProperty('password_hash');
+
+    expect(await store.getById(account.id)).toMatchObject({ id: account.id });
+    // Lookup is by normalized handle.
+    expect(await store.getByUsername('  ALICE ')).toMatchObject({ id: account.id });
+    expect(await store.getByUsername('nobody')).toBeNull();
+  });
+
+  it('rejects blank fields and duplicate usernames', async () => {
+    const store = createMemoryAccountStore();
+    await expect(store.createAccount({ name: '', username: 'u', password: 'p' })).rejects.toThrow(
+      AuthError,
+    );
+    await expect(store.createAccount({ name: 'n', username: '', password: 'p' })).rejects.toThrow(
+      /username/,
+    );
+    await expect(store.createAccount({ name: 'n', username: 'u', password: '' })).rejects.toThrow(
+      /password/,
+    );
+
+    await store.createAccount({ name: 'A', username: 'dup', password: 'p' });
+    await expect(
+      store.createAccount({ name: 'B', username: 'DUP', password: 'p' }),
+    ).rejects.toMatchObject({ code: 'username_taken' });
+  });
+
+  it('verifies credentials', async () => {
+    const store = createMemoryAccountStore();
+    await store.createAccount({ name: 'Alice', username: 'alice', password: 'hunter2' });
+    expect(await store.verifyCredentials('alice', 'hunter2')).toMatchObject({ username: 'alice' });
+    expect(await store.verifyCredentials('ALICE', 'hunter2')).toMatchObject({ username: 'alice' });
+    expect(await store.verifyCredentials('alice', 'wrong')).toBeNull();
+    expect(await store.verifyCredentials('ghost', 'whatever')).toBeNull();
+  });
+
+  it('reports whether a root exists', async () => {
+    const store = createMemoryAccountStore();
+    expect(await store.hasRoot()).toBe(false);
+    await store.createAccount({ name: 'A', username: 'a', password: 'p' });
+    expect(await store.hasRoot()).toBe(false);
+    await store.createAccount({ name: 'Root', username: 'root', password: 'p', isRoot: true });
+    expect(await store.hasRoot()).toBe(true);
+  });
+
+  describe('vouch / trust', () => {
+    it('flows trust transitively out from the root', async () => {
+      const store = createMemoryAccountStore();
+      const root = await store.createAccount({ name: 'Root', username: 'root', password: 'p', isRoot: true });
+      const a = await store.createAccount({ name: 'A', username: 'a', password: 'p' });
+      const b = await store.createAccount({ name: 'B', username: 'b', password: 'p' });
+
+      // Root is trusted by virtue of being root; others are not yet.
+      expect(await store.isTrusted(root.id)).toBe(true);
+      expect(await store.isTrusted(a.id)).toBe(false);
+
+      await store.vouch(root.id, a.id);
+      await store.vouch(a.id, b.id);
+      expect(await store.isTrusted(a.id)).toBe(true);
+      expect(await store.isTrusted(b.id)).toBe(true); // transitive
+    });
+
+    it('confers nothing from an untrusted voucher', async () => {
+      const store = createMemoryAccountStore();
+      await store.createAccount({ name: 'Root', username: 'root', password: 'p', isRoot: true });
+      const a = await store.createAccount({ name: 'A', username: 'a', password: 'p' });
+      const b = await store.createAccount({ name: 'B', username: 'b', password: 'p' });
+
+      // A (untrusted) vouches for B — edge recorded, but B stays untrusted until A
+      // is itself reachable from the root.
+      await store.vouch(a.id, b.id);
+      expect(await store.isTrusted(b.id)).toBe(false);
+    });
+
+    it('is idempotent and rejects self- and unknown-account vouches', async () => {
+      const store = createMemoryAccountStore();
+      const root = await store.createAccount({ name: 'Root', username: 'root', password: 'p', isRoot: true });
+      const a = await store.createAccount({ name: 'A', username: 'a', password: 'p' });
+
+      await store.vouch(root.id, a.id);
+      await store.vouch(root.id, a.id); // no throw, no double edge
+      expect(await store.isTrusted(a.id)).toBe(true);
+
+      await expect(store.vouch(root.id, root.id)).rejects.toMatchObject({ code: 'self_vouch' });
+      await expect(store.vouch(root.id, 'ghost')).rejects.toMatchObject({
+        code: 'account_not_found',
+      });
+    });
+
+    it('does not trust an unknown account id', async () => {
+      const store = createMemoryAccountStore();
+      await store.createAccount({ name: 'Root', username: 'root', password: 'p', isRoot: true });
+      expect(await store.isTrusted('ghost')).toBe(false);
+    });
+  });
+});

--- a/server/auth/store.ts
+++ b/server/auth/store.ts
@@ -1,0 +1,245 @@
+/**
+ * The account store (BACKLOG.md #20): account records, credential checks, and the
+ * vouch (web-of-trust) graph. It is the durable side of the auth subsystem —
+ * accounts and trust outlive any single game — so unlike the lobby/live stores
+ * the production implementation is PostgreSQL-backed ({@link createPostgresAccountStore}
+ * in `./postgres.ts`).
+ *
+ * The interface is storage-agnostic so tests (and a bare dev checkout without a
+ * database) can drive the whole auth surface against {@link createMemoryAccountStore},
+ * exactly as the lobby/live/subscription stores are injected into `createServer`.
+ *
+ * ## Trust
+ *
+ * An account is **trusted** when it is reachable from a *root* account by
+ * following `voucher → vouchee` edges: a root vouches for A, A vouches for B, and
+ * both A and B are trusted. A vouch by an untrusted account records an edge but
+ * confers nothing until the voucher itself becomes reachable from a root — so the
+ * seeded root is the sole trust anchor and the graph can't be bootstrapped from
+ * the outside.
+ */
+import { hashPassword, verifyPassword } from './password.ts';
+
+/** A public account record. Never carries the password hash. */
+export interface Account {
+  id: string;
+  name: string;
+  /** Normalized sign-in handle, or `null` for a credential-less/imported row. */
+  username: string | null;
+  isRoot: boolean;
+  createdAt: string;
+}
+
+/** Fields for creating an account. `password` is hashed before storage. */
+export interface NewAccount {
+  name: string;
+  username: string;
+  password: string;
+  /** Seed a root (trust anchor). Only the bootstrap path sets this. */
+  isRoot?: boolean;
+}
+
+/** Error codes surfaced to the client so it can show a specific message. */
+export type AuthErrorCode =
+  | 'name_required'
+  | 'username_required'
+  | 'password_required'
+  | 'username_taken'
+  | 'account_not_found'
+  | 'self_vouch';
+
+/** A recoverable auth-operation failure, translated to an HTTP error response. */
+export class AuthError extends Error {
+  readonly code: AuthErrorCode;
+
+  constructor(code: AuthErrorCode, message: string) {
+    super(message);
+    this.name = 'AuthError';
+    this.code = code;
+  }
+}
+
+/** The durable account + trust store. */
+export interface AccountStore {
+  /**
+   * Create an account, hashing its password. Throws {@link AuthError} on a blank
+   * field (`name_required`/`username_required`/`password_required`) or a
+   * duplicate handle (`username_taken`). The username is normalized first.
+   */
+  createAccount(input: NewAccount): Promise<Account>;
+  /** Look up by id, or `null` if unknown. */
+  getById(id: string): Promise<Account | null>;
+  /** Look up by (normalized) username, or `null` if unknown. */
+  getByUsername(username: string): Promise<Account | null>;
+  /**
+   * Verify a username + password pair, returning the account on success or `null`
+   * on an unknown user, a credential-less account, or a wrong password. The work
+   * is constant-ish either way — a real hash is compared even for an unknown user
+   * is not required here, but callers should not leak which half failed.
+   */
+  verifyCredentials(username: string, password: string): Promise<Account | null>;
+  /**
+   * Record that `voucherId` vouches for `voucheeId`. Idempotent (a repeat is a
+   * no-op). Throws {@link AuthError} `self_vouch` when the two are equal, or
+   * `account_not_found` when either id is unknown.
+   */
+  vouch(voucherId: string, voucheeId: string): Promise<void>;
+  /**
+   * Whether `accountId` is trusted: it is a root, or reachable from some root by
+   * following vouch edges. Unknown ids are not trusted.
+   */
+  isTrusted(accountId: string): Promise<boolean>;
+  /** Whether any root account exists (drives {@link bootstrapRoot}). */
+  hasRoot(): Promise<boolean>;
+}
+
+/** Longest accepted display name — mirrors the lobby's roster bound. */
+export const MAX_NAME_LENGTH = 24;
+/** Longest accepted username, to bound the handle and keep sign-in tidy. */
+export const MAX_USERNAME_LENGTH = 32;
+
+/**
+ * Normalize a username to its canonical, comparable form: trimmed and
+ * lower-cased, so `Alice`, `alice`, and ` alice ` are one handle. The stored and
+ * looked-up value is always this form.
+ */
+export function normalizeUsername(username: string): string {
+  return username.trim().toLowerCase();
+}
+
+/** Validate + normalize the fields of a new account, or throw {@link AuthError}. */
+function normalizeNewAccount(input: NewAccount): {
+  name: string;
+  username: string;
+  password: string;
+  isRoot: boolean;
+} {
+  const name = input.name?.trim() ?? '';
+  if (name === '') throw new AuthError('name_required', 'A display name is required');
+  const username = normalizeUsername(input.username ?? '');
+  if (username === '') throw new AuthError('username_required', 'A username is required');
+  if (!input.password) throw new AuthError('password_required', 'A password is required');
+  return {
+    name: name.slice(0, MAX_NAME_LENGTH),
+    username: username.slice(0, MAX_USERNAME_LENGTH),
+    password: input.password,
+    isRoot: input.isRoot ?? false,
+  };
+}
+
+// Shared by the memory store and (indirectly, via the same validation) the
+// Postgres store's create path, so both reject the same blank/oversized input.
+export { normalizeNewAccount };
+
+/** One stored account, with the hash the public {@link Account} never exposes. */
+interface StoredAccount extends Account {
+  passwordHash: string;
+}
+
+/** Strip the hash to hand back a public {@link Account}. */
+function toPublic(row: StoredAccount): Account {
+  return {
+    id: row.id,
+    name: row.name,
+    username: row.username,
+    isRoot: row.isRoot,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * An in-memory {@link AccountStore} for tests and bare dev checkouts. Trust is
+ * computed by a breadth-first walk of the vouch edges out from every root, so it
+ * always reflects the current graph with no cached-staleness to manage.
+ */
+export function createMemoryAccountStore(): AccountStore {
+  const byId = new Map<string, StoredAccount>();
+  const byUsername = new Map<string, StoredAccount>();
+  // voucher id -> set of vouchee ids.
+  const edges = new Map<string, Set<string>>();
+  let counter = 0;
+
+  const trusted = (rootSeed: StoredAccount[]): Set<string> => {
+    const reached = new Set<string>();
+    const queue: string[] = [];
+    for (const root of rootSeed) {
+      if (!reached.has(root.id)) {
+        reached.add(root.id);
+        queue.push(root.id);
+      }
+    }
+    while (queue.length > 0) {
+      const current = queue.shift() as string;
+      for (const vouchee of edges.get(current) ?? []) {
+        if (!reached.has(vouchee)) {
+          reached.add(vouchee);
+          queue.push(vouchee);
+        }
+      }
+    }
+    return reached;
+  };
+
+  return {
+    async createAccount(input) {
+      const { name, username, password, isRoot } = normalizeNewAccount(input);
+      if (byUsername.has(username)) {
+        throw new AuthError('username_taken', 'That username is taken');
+      }
+      const row: StoredAccount = {
+        id: `acct-${++counter}`,
+        name,
+        username,
+        isRoot,
+        createdAt: new Date().toISOString(),
+        passwordHash: await hashPassword(password),
+      };
+      byId.set(row.id, row);
+      byUsername.set(username, row);
+      return toPublic(row);
+    },
+
+    async getById(id) {
+      const row = byId.get(id);
+      return row ? toPublic(row) : null;
+    },
+
+    async getByUsername(username) {
+      const row = byUsername.get(normalizeUsername(username));
+      return row ? toPublic(row) : null;
+    },
+
+    async verifyCredentials(username, password) {
+      const row = byUsername.get(normalizeUsername(username));
+      if (!row || !row.passwordHash) return null;
+      const ok = await verifyPassword(password, row.passwordHash);
+      return ok ? toPublic(row) : null;
+    },
+
+    async vouch(voucherId, voucheeId) {
+      if (voucherId === voucheeId) {
+        throw new AuthError('self_vouch', 'An account cannot vouch for itself');
+      }
+      if (!byId.has(voucherId) || !byId.has(voucheeId)) {
+        throw new AuthError('account_not_found', 'No such account');
+      }
+      let set = edges.get(voucherId);
+      if (!set) {
+        set = new Set();
+        edges.set(voucherId, set);
+      }
+      set.add(voucheeId);
+    },
+
+    async isTrusted(accountId) {
+      if (!byId.has(accountId)) return false;
+      const roots = [...byId.values()].filter((a) => a.isRoot);
+      return trusted(roots).has(accountId);
+    },
+
+    async hasRoot() {
+      for (const row of byId.values()) if (row.isRoot) return true;
+      return false;
+    },
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,12 @@
 import { createServer } from './app.ts';
 import { migrate } from './db/migrate.ts';
+import { getPool } from './db/pool.ts';
+import {
+  bootstrapRootAndLog,
+  createMemoryAccountStore,
+  createPostgresAccountStore,
+  type AccountStore,
+} from './auth/index.ts';
 
 const PORT = process.env.PORT || 3000;
 
@@ -16,6 +23,25 @@ if (process.env.RUN_MIGRATIONS === 'true') {
   }
 }
 
-const { httpServer } = createServer();
+// Wire the account + trust store (BACKLOG.md #20). With a database configured we
+// use the PostgreSQL-backed store and seed the root account (idempotent, so it is
+// safe on every boot); without one, a bare dev checkout falls back to an
+// in-process store so sign-in still works locally (accounts just aren't durable).
+let accounts: AccountStore;
+if (process.env.DATABASE_URL) {
+  accounts = createPostgresAccountStore(getPool());
+  try {
+    await bootstrapRootAndLog(accounts);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error('failed to bootstrap root account:', reason);
+    process.exit(1);
+  }
+} else {
+  console.warn('DATABASE_URL is not set — using an in-memory account store (dev only).');
+  accounts = createMemoryAccountStore();
+}
+
+const { httpServer } = createServer({ accounts });
 
 httpServer.listen(PORT, () => console.log(`manhunt server listening on :${PORT}`));


### PR DESCRIPTION
Closes #20.

Implements the M3 auth foundation: authenticated sessions and a seeded root account that anchors a vouch-based web of trust.

## What's included

**Persistence (migration 0002)**
- Adds sign-in credentials to `accounts` (`username` unique, `password_hash`) and a `vouches` edge table (`voucher_id → vouchee_id`, self-vouch rejected, pair unique). `db/schema.sql` snapshot updated to match.

**`server/auth/` module**
- `password.ts` — scrypt hashing (Node built-in, no new dependency), self-describing digest carrying its cost params, constant-time verify that fails closed on a malformed hash.
- `session.ts` — stateless HMAC-signed session tokens keyed by `SESSION_SECRET`, with embedded expiry; `resolveSessionSecret` warns + uses a random per-process secret when unset (dev).
- `store.ts` — `AccountStore` interface + in-memory implementation; trust computed by a BFS over vouch edges out from the root(s).
- `postgres.ts` — PostgreSQL-backed `AccountStore` over the new tables; trust resolved with a recursive CTE; unique/FK violations translated to typed errors.
- `bootstrap.ts` — idempotent root seed from `ROOT_USERNAME`/`ROOT_PASSWORD` (generates + logs a strong password once when none is set).
- `routes.ts` — `/api/auth` router: `register`, `login`, `logout`, `me`, `vouch`. Identity always comes from the signed **httpOnly** cookie, never the request body — mirroring the socket layer's server-authoritative rule.

**Wiring**
- `createServer` gains injectable `accounts`/`sessions` options (in-memory defaults) and mounts the router before the static/SPA fallback.
- `index.ts` uses the Postgres store and seeds root when `DATABASE_URL` is set, falling back to an in-memory store for a bare dev checkout.

## Trust model

An account is *trusted* when reachable from a **root** by following `voucher → vouchee` edges. A vouch from an untrusted account records an edge but confers nothing until that account is itself reachable from the root, so the root is the sole trust anchor. (Distinct from the repo-governance `.github/VOUCHED.td` list.)

## Acceptance criteria

- ✅ **Authenticated sessions** — register/login mint a signed httpOnly session cookie; every authenticated route verifies it.
- ✅ **Root account exists and can vouch** — seeded idempotently on boot; `POST /api/auth/vouch` as root makes the vouchee trusted (covered by an end-to-end test).

## Testing

- New unit/integration tests for hashing, sessions, both stores, bootstrap, and the full HTTP flow (including a root vouch making a member trusted).
- `npm run lint`, `npm run typecheck`, and `npm run test:server` (353 tests) all pass locally.

## Docs

- README "Accounts, sessions & trust" section (endpoint table + trust model), arc42 §6.8 + glossary entries, and `.env.example` root-account vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApmLyoVjWBKRkuDBcsQ4Nr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account registration, login, logout, and authenticated profile endpoints.
  * Added secure session cookies and password protection.
  * Added root-account bootstrapping with optional generated credentials.
  * Added web-of-trust support, allowing trusted accounts to vouch for others.
  * Added PostgreSQL persistence with an in-memory fallback for development.

* **Documentation**
  * Documented authentication, sessions, configuration, and trust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->